### PR TITLE
Handle send message event in a local setup (dev. localhost)

### DIFF
--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -306,7 +306,12 @@ func (container *Container) EventsQueue() (queue services.PushQueue) {
 	container.logger.Debug("creating events services.PushQueue")
 
 	if isLocal() {
-		return nil
+		return services.NewInMemoryPushQueue(
+			container.Logger(),
+			container.Tracer(),
+			container.EventsQueueConfiguration(),
+			func() *services.EventDispatcher { return container.eventDispatcher },
+		)
 	}
 
 	return services.NewGooglePushQueue(

--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -305,6 +305,10 @@ func (container *Container) EventsQueueConfiguration() (config services.PushQueu
 func (container *Container) EventsQueue() (queue services.PushQueue) {
 	container.logger.Debug("creating events services.PushQueue")
 
+	if isLocal() {
+		return nil
+	}
+
 	return services.NewGooglePushQueue(
 		container.Logger(),
 		container.Tracer(),

--- a/api/pkg/services/event_dispatcher_service.go
+++ b/api/pkg/services/event_dispatcher_service.go
@@ -13,7 +13,6 @@ import (
 	"github.com/NdoleStudio/httpsms/pkg/telemetry"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/palantir/stacktrace"
-	"github.com/google/uuid"
 )
 
 // EventDispatcher dispatches a new event
@@ -73,30 +72,15 @@ func (dispatcher *EventDispatcher) DispatchWithTimeout(ctx context.Context, even
 		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
 	}
 
-	if dispatcher.queue == nil {
-		ctxLogger := dispatcher.tracer.CtxLogger(dispatcher.logger, span)
-		queueID := uuid.New()
-		go func() {
-			time.Sleep(timeout)
-			dispatcher.DispatchSync(ctx, event)
-		}()
-		ctxLogger.Info(fmt.Sprintf(
-			"item added to [%s] queue with id [%s] and schedule [%s]",
-			dispatcher.queueConfig.Name,
-			queueID,
-			time.Now().UTC().Add(timeout),
-		))
-	} else {
-		task, err := dispatcher.createCloudTask(event)
-		if err != nil {
-			msg := fmt.Sprintf("cannot create cloud task for event [%s] with id [%s]", event.Type(), event.ID())
-			return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
-		}
-	
-		if queueID, err = dispatcher.queue.Enqueue(ctx, task, timeout); err != nil {
-			msg := fmt.Sprintf("cannot enqueue event with ID [%s] and type [%s]", event.ID(), event.Type())
-			return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
-		}
+	task, err := dispatcher.createCloudTask(event)
+	if err != nil {
+		msg := fmt.Sprintf("cannot create cloud task for event [%s] with id [%s]", event.Type(), event.ID())
+		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	if queueID, err = dispatcher.queue.Enqueue(ctx, task, timeout); err != nil {
+		msg := fmt.Sprintf("cannot enqueue event with ID [%s] and type [%s]", event.ID(), event.Type())
+		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
 	}
 
 	return queueID, nil

--- a/api/pkg/services/in_memory_push_queue.go
+++ b/api/pkg/services/in_memory_push_queue.go
@@ -1,0 +1,57 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/uuid"
+)
+
+type inMemoryPushQueue struct {
+	getEventDispatcher func() *EventDispatcher
+	queueConfig        PushQueueConfig
+	logger             telemetry.Logger
+	tracer             telemetry.Tracer
+}
+
+// NewGooglePushQueue creates a new googlePushQueue
+func NewInMemoryPushQueue(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+	queueConfig PushQueueConfig,
+	getEventDispatcher func() *EventDispatcher,
+) PushQueue {
+	return &inMemoryPushQueue{
+		tracer:             tracer,
+		logger:             logger,
+		queueConfig:        queueConfig,
+		getEventDispatcher: getEventDispatcher,
+	}
+}
+
+// Enqueue a task to the queue
+func (queue *inMemoryPushQueue) Enqueue(ctx context.Context, task *PushQueueTask, timeout time.Duration) (queueID string, err error) {
+	ctx, span := queue.tracer.Start(ctx)
+	ctxLogger := queue.tracer.CtxLogger(queue.logger, span)
+	queueID = uuid.New().String()
+
+	go func() {
+		time.Sleep(timeout)
+		var event cloudevents.Event
+		json.Unmarshal(task.Body, &event)
+		queue.getEventDispatcher().DispatchSync(ctx, event)
+	}()
+
+	ctxLogger.Info(fmt.Sprintf(
+		"item added to [%s] queue with id [%s] and schedule [%s]",
+		queue.queueConfig.Name,
+		queueID,
+		time.Now().UTC().Add(timeout),
+	))
+
+	return queueID, nil
+}

--- a/api/pkg/services/in_memory_push_queue.go
+++ b/api/pkg/services/in_memory_push_queue.go
@@ -36,6 +36,8 @@ func NewInMemoryPushQueue(
 // Enqueue a task to the queue
 func (queue *inMemoryPushQueue) Enqueue(ctx context.Context, task *PushQueueTask, timeout time.Duration) (queueID string, err error) {
 	ctx, span := queue.tracer.Start(ctx)
+	defer span.End()
+
 	ctxLogger := queue.tracer.CtxLogger(queue.logger, span)
 	queueID = uuid.New().String()
 


### PR DESCRIPTION
When running in development environment, usually bound to the localhost, there is no way to use Cloud Task to trigger the internal api [/events](https://github.com/NdoleStudio/httpsms/blob/ca94a6a1e121f1ce27dbcae5be3c99492e54610f/api/pkg/handlers/events_handler.go#L46).
We can rely on an internal timeout to simulate the a task processing queue.