### PR TITLE
Fix for the copy` command of .env in api 

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ FIREBASE_MEASUREMENT_ID=
 - Copy the `.env.docker` file in the `api` directory into `.env`
 
 ```bash
-cp api/.env.local.docker api/.env.local
+cp api/.env.docker api/.env
 ```
 
 - Update the environment variables in the `.env` file in the `api` directory with your firebase service account credentials and SMTP server details.


### PR DESCRIPTION
We don't have .env.local.docker in api and instead of putting things on .env.local , I suggest .env because in docker we using this only for api environment