### PR TITLE
refactor: remove hedging tag, use mongodb directly for heartbeats

### DIFF
--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -905,7 +905,7 @@ func (container *Container) MessageThreadRepository() (repository repositories.M
 // HeartbeatMonitorRepository creates a new instance of repositories.HeartbeatMonitorRepository
 func (container *Container) HeartbeatMonitorRepository() (repository repositories.HeartbeatMonitorRepository) {
 	switch os.Getenv("HEARTBEAT_DB_BACKEND") {
-	case "mongodb", "hedging":
+	case "mongodb":
 		container.logger.Debug("creating MongoDB repositories.HeartbeatMonitorRepository")
 		return repositories.NewMongoHeartbeatMonitorRepository(
 			container.Logger(),
@@ -1734,7 +1734,7 @@ func (container *Container) RegisterSwaggerRoutes() {
 // HeartbeatRepository registers a new instance of repositories.HeartbeatRepository
 func (container *Container) HeartbeatRepository() repositories.HeartbeatRepository {
 	switch os.Getenv("HEARTBEAT_DB_BACKEND") {
-	case "mongodb", "hedging":
+	case "mongodb":
 		container.logger.Debug("creating MongoDB repositories.HeartbeatRepository")
 		return repositories.NewMongoHeartbeatRepository(
 			container.Logger(),

--- a/tests/.env.test
+++ b/tests/.env.test
@@ -28,5 +28,5 @@ PUSHER_CLUSTER=
 GCS_BUCKET_NAME=
 UPTRACE_DSN=
 CLOUDFLARE_TURNSTILE_SECRET_KEY=
-HEARTBEAT_DB_BACKEND=hedging
+HEARTBEAT_DB_BACKEND=mongodb
 MONGODB_URI=mongodb://httpsms:testpassword@mongodb:27017/?authSource=admin&appName=httpsms


### PR DESCRIPTION
## Summary

Now that the migration is deployed and stable, remove the hedging case from the HEARTBEAT_DB_BACKEND switch. Only mongodb is recognized going forward.

## Changes

- api/pkg/di/container.go - Remove hedging from both HeartbeatMonitorRepository() and HeartbeatRepository() switch cases
- tests/.env.test - Update HEARTBEAT_DB_BACKEND=hedging to HEARTBEAT_DB_BACKEND=mongodb

## Deployment

Update the production environment variable from HEARTBEAT_DB_BACKEND=hedging to HEARTBEAT_DB_BACKEND=mongodb after merging.
