### PR TITLE
refactor: extract entitlement entity names to constants

### DIFF
--- a/api/pkg/entities/message_send_schedule.go
+++ b/api/pkg/entities/message_send_schedule.go
@@ -6,6 +6,9 @@ import (
 	"github.com/google/uuid"
 )
 
+// EntityNameMessageSendSchedule is the entitlement entity name for message send schedules.
+const EntityNameMessageSendSchedule = "MessageSendSchedule"
+
 // MessageSendScheduleWindow represents a single availability window for a day of the week.
 type MessageSendScheduleWindow struct {
 	DayOfWeek   int `json:"day_of_week" example:"1"`

--- a/api/pkg/entities/phone_api_key.go
+++ b/api/pkg/entities/phone_api_key.go
@@ -7,6 +7,9 @@ import (
 	"github.com/lib/pq"
 )
 
+// EntityNamePhoneAPIKey is the entitlement entity name for phone API keys.
+const EntityNamePhoneAPIKey = "PhoneAPIKey"
+
 // PhoneAPIKey represents the API key for a phone
 type PhoneAPIKey struct {
 	ID           uuid.UUID      `json:"id" gorm:"primaryKey;type:uuid;" example:"32343a19-da5e-4b1b-a767-3298a73703cb"`

--- a/api/pkg/handlers/message_send_schedule_handler.go
+++ b/api/pkg/handlers/message_send_schedule_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 
+	"github.com/NdoleStudio/httpsms/pkg/entities"
 	"github.com/NdoleStudio/httpsms/pkg/repositories"
 	"github.com/NdoleStudio/httpsms/pkg/requests"
 	"github.com/NdoleStudio/httpsms/pkg/services"
@@ -97,7 +98,7 @@ func (h *MessageSendScheduleHandler) Store(c *fiber.Ctx) error {
 
 	userID := h.userIDFomContext(c)
 
-	result, err := h.entitlementService.Check(ctx, userID, "MessageSendSchedule", func() (int, error) {
+	result, err := h.entitlementService.Check(ctx, userID, entities.EntityNameMessageSendSchedule, func() (int, error) {
 		return h.service.CountByUser(ctx, userID)
 	})
 	if err != nil {

--- a/api/pkg/handlers/phone_api_key_handler.go
+++ b/api/pkg/handlers/phone_api_key_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 
+	"github.com/NdoleStudio/httpsms/pkg/entities"
 	"github.com/NdoleStudio/httpsms/pkg/repositories"
 	"github.com/NdoleStudio/httpsms/pkg/requests"
 	"github.com/NdoleStudio/httpsms/pkg/services"
@@ -112,7 +113,7 @@ func (h *PhoneAPIKeyHandler) store(c *fiber.Ctx) error {
 
 	userID := h.userIDFomContext(c)
 
-	result, err := h.entitlementService.Check(ctx, userID, "PhoneAPIKey", func() (int, error) {
+	result, err := h.entitlementService.Check(ctx, userID, entities.EntityNamePhoneAPIKey, func() (int, error) {
 		return h.service.CountByUser(ctx, userID)
 	})
 	if err != nil {

--- a/api/pkg/services/entitlement_service.go
+++ b/api/pkg/services/entitlement_service.go
@@ -16,10 +16,10 @@ import (
 // entityLimits maps entity name → subscription plan → max count.
 // A limit of 0 means unlimited. If a plan is not listed, it defaults to unlimited (0).
 var entityLimits = map[string]map[entities.SubscriptionName]int{
-	"MessageSendSchedule": {
+	entities.EntityNameMessageSendSchedule: {
 		entities.SubscriptionNameFree: 1,
 	},
-	"PhoneAPIKey": {
+	entities.EntityNamePhoneAPIKey: {
 		entities.SubscriptionNameFree: 1,
 	},
 }


### PR DESCRIPTION
Replace magic strings with exported constants: services.EntityNameMessageSendSchedule and services.EntityNamePhoneAPIKey. This makes it easier to add new entitlement-limited entities and avoids typo risks.