### PR TITLE
fix(web): resolve stylelint errors in bulk-messages page

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -4,14 +4,17 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 defaults:
   run:
     working-directory: ./web
 
 jobs:
-  ci:
-    name: Build & Deploy
+  validate:
+    name: Validate
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -37,8 +40,26 @@ jobs:
       - name: Run tests 🧪
         run: pnpm test
 
-      - name: Debug 🐛
-        run: echo GITHUB_SHA=${GITHUB_SHA}
+      - name: Build 🏗️
+        run: mv .env.production .env && echo GITHUB_SHA=${GITHUB_SHA} >> .env && pnpm run generate
+
+  deploy:
+    name: Deploy
+    needs: validate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@master
+
+      - uses: pnpm/action-setup@v6
+        name: Install pnpm
+        with:
+          version: 10
+
+      - name: Install dependencies 📦
+        run: pnpm install
 
       - name: Build 🏗️
         run: mv .env.production .env && echo GITHUB_SHA=${GITHUB_SHA} >> .env && pnpm run generate

--- a/web/pages/bulk-messages/index.vue
+++ b/web/pages/bulk-messages/index.vue
@@ -273,7 +273,8 @@ export default Vue.extend({
 .clickable-row {
   cursor: pointer;
 }
+
 .clickable-row:hover {
-  background-color: rgba(0, 0, 0, 0.04);
+  background-color: rgb(0 0 0 / 4%);
 }
 </style>


### PR DESCRIPTION
Fixes the CI lint failure on main caused by stylelint errors in \pages/bulk-messages/index.vue\:

- Added empty line before \.clickable-row:hover\ rule (\ule-empty-line-before\)
- Converted \gba(0, 0, 0, 0.04)\ to modern notation \gb(0 0 0 / 4%)\ (\color-function-notation\ + \lpha-value-notation\)