### PR TITLE
fix(web): restore original content on all statically generated pages

### DIFF
--- a/web/app/pages/blog/end-to-end-encryption-to-sms-messages.vue
+++ b/web/app/pages/blog/end-to-end-encryption-to-sms-messages.vue
@@ -1,72 +1,161 @@
 <script setup lang="ts">
+import { mdiLanguageGo, mdiLanguageJavascript } from "@mdi/js";
+import { ref } from "vue";
+
+const selectedTab = ref("javascript");
+
 definePageMeta({ layout: "website" });
 
 useHead({
-  title: "End-to-End Encryption to SMS Messages - httpSMS",
+  title:
+    "Secure your conversations with end-to-end encryption for SMS messages - httpSMS",
+  meta: [
+    {
+      property: "og:title",
+      content:
+        "Secure your conversations with end-to-end encryption for SMS messages",
+    },
+    {
+      property: "og:description",
+      content:
+        "We have added support for end-to-end encryption for SMS messages so that no one can see the content of the messages you send using httpSMS except you.",
+    },
+  ],
 });
 </script>
 
 <template>
-  <VContainer>
-    <VRow>
-      <VCol cols="12" md="8" offset-md="2">
-        <h1 class="text-display-small mb-2">
-          End-to-End Encryption to SMS Messages
+  <VContainer class="pt-8">
+    <VRow class="mt-16">
+      <VCol cols="12" md="9">
+        <h1 class="text-h3 text-md-h2 mt-1">
+          Secure your conversations by encrypting your SMS messages end-to-end
         </h1>
-        <BlogInfo date="January 21, 2024" read-time="10 min read" />
-        <VDivider class="my-6" />
+        <BlogInfo date="January 21, 2024" readTime="10 min read" />
 
-        <p class="text-body-large mb-6">
+        <p class="text-subtitle-1 mt-2">
           We have added support for end-to-end encryption for SMS messages so
           that no one can see the content of the messages you send using httpSMS
-          except you. You setup an encryption key which you use to encrypt your
-          messages before making an API request to httpSMS and you also use the
-          same key to decrypt the messages you receive from httpSMS via our
-          webhook events. We are using the AES 256 encryption algorithm to
-          encrypt and decrypt the messages.
+          except you.
         </p>
-
-        <h2 class="text-headline-medium mb-4">Setup your encryption key</h2>
-        <p class="text-body-large mb-6">
-          Download and install the httpSMS Android app on your phone and set
-          your encryption key under the App Settings page of the app.
+        <p>
+          You setup an encryption key which you use to encrypt your messages
+          before making an API request to httpSMS and you also use the same key
+          to decrypt the messages you receive from httpSMS via our
           <a
+            class="text-decoration-none"
+            href="https://docs.httpsms.com/webhooks/introduction"
+            >webhook events</a
+          >. We are using the
+          <a
+            class="text-decoration-none"
+            href="https://en.wikipedia.org/wiki/Advanced_Encryption_Standard"
+            >AES 256</a
+          >
+          encryption algorithm to encrypt and decrypt the messages.
+        </p>
+
+        <h3 class="text-h4 mt-8 mb-2">Setup your encryption key</h3>
+        <p>
+          <a
+            class="text-decoration-none"
             href="https://github.com/NdoleStudio/httpsms/releases/latest/download/HttpSms.apk"
-            target="_blank"
-            rel="noopener"
-            >Download the Android app</a
-          >.
+            >⬇️ Download and install</a
+          >
+          the httpSMS Android app on your phone and set you encryption key under
+          the <b>App Settings</b> page of the app.
+        </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms android app"
+          height="800"
+          src="/img/blog/end-to-end-encryption-to-sms-messages/encryption-key-android.png"
+        />
+
+        <h3 class="text-h4 mb-4 mt-16">Encrypt your SMS message</h3>
+        <p>
+          We use the AES-256 encryption algorithm to encrypt the SMS messages.
+          This algorithm requires a an encryption key which is 256 bits to work
+          around this, we will hash any encryption key you set on the mobile app
+          using the sha-256 algorithm so that it will always produce a key which
+          is 256 bits.
+        </p>
+        <p>
+          The AES algorithm also has an initialization vector (IV) parameter
+          which is used to ensure that the same value encrypted multiple times
+          will not produce the same encrypted value. The IV is 16 bits and it is
+          appended to the encrypted message before encoding it in base64.
+        </p>
+        <p>
+          When you use our client libraries it will automatically take care of
+          encrypting your message so you don't have to deal with creating the
+          initialization vector and encoding the payload yourself.
         </p>
 
-        <h2 class="text-headline-medium mb-4">Encrypt your SMS message</h2>
-        <p class="text-body-large mb-4">
-          We are using AES-256 to encrypt your SMS messages. The encryption key
-          is hashed with SHA-256 before use and the initialization vector (IV)
-          is generated for each message. The IV is appended to the encrypted
-          payload before the final value is base64 encoded.
-        </p>
-        <pre
-          class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
-        ><code class="language-javascript text-body-medium">import HttpSms from "httpsms"
+        <VTabs v-model="selectedTab" show-arrows>
+          <VTab value="javascript">
+            <VIcon color="#efd81d" class="mr-1" :icon="mdiLanguageJavascript" />
+            Javascript
+          </VTab>
+          <VTab value="go">
+            <VIcon color="#00aed8" class="mr-1" :icon="mdiLanguageGo" />
+            Go
+          </VTab>
+        </VTabs>
+        <VTabsWindow v-model="selectedTab">
+          <VTabsWindowItem value="javascript">
+            <pre
+              class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
+            ><code class="language-javascript text-body-medium">import HttpSms from "httpsms"
 
-const client = new HttpSms("" /* API Key from https://httpsms.com/settings */)
+const client = new HttpSms("" /* API Key from https://httpsms.com/settings */);
 
-const key = "Password123"
+const key = "Password123";
 
-const encryptedMessage = client.cipher.encrypt(key, "This is a sample text message")
+const encryptedMessage = client.cipher.encrypt(key, "This is a sample text message");
 
-// The encrypted message looks like this
+// The encrypted message looks like this, note that you will get a different encrypted message when you run this code on your computer
 // Qk3XGN5+Ax38Ig01m4AqaP6Y0b0wYpCXtx59sU23uVLWUU/c7axF7LozDg==</code></pre>
+          </VTabsWindowItem>
+          <VTabsWindowItem value="go">
+            <pre
+              class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
+            ><code class="language-go text-body-medium">import "github.com/NdoleStudio/httpsms-go"
 
-        <h2 class="text-headline-medium mb-4">Send an encrypted message</h2>
-        <p class="text-body-large mb-4">
-          Once you have encrypted the content, send it to the API with
-          <code>encrypted: true</code>. This flag tells the Android app to
-          decrypt the message before sending it to the recipient.
+client := htpsms.New(htpsms.WithAPIKey(""/* API Key from https://httpsms.com/settings */))
+
+key := "Password123" // use the same key on the Android app
+encryptedMessage := client.Cipher.Encrypt(key, "This is a test text message")
+
+// The encrypted message looks like this, note that you will get a different encrypted message when you run this code on your computer
+// Qk3XGN5+Ax38Ig01m4AqaP6Y0b0wYpCXtx59sU23uVLWUU/c7axF7LozDg==</code></pre>
+          </VTabsWindowItem>
+        </VTabsWindow>
+
+        <h3 class="text-h4 mt-6">Send an encrypted message</h3>
+        <p>
+          After generating the encrypted message payload, you can send it
+          directly using the httpSMS API. Make sure to set
+          <code>encrypted: true</code> in the JSON request payload so that
+          httpSMS knows that the message is encrypted and it will be decoded in
+          the Android app before sending to your recipient.
         </p>
-        <pre
-          class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
-        ><code class="language-javascript text-body-medium">import HttpSms from "httpsms"
+
+        <VTabs v-model="selectedTab" show-arrows>
+          <VTab value="javascript">
+            <VIcon color="#efd81d" class="mr-1" :icon="mdiLanguageJavascript" />
+            Javascript
+          </VTab>
+          <VTab value="go">
+            <VIcon color="#00aed8" class="mr-1" :icon="mdiLanguageGo" />
+            Go
+          </VTab>
+        </VTabs>
+        <VTabsWindow v-model="selectedTab">
+          <VTabsWindowItem value="javascript">
+            <pre
+              class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
+            ><code class="language-javascript text-body-medium">import HttpSms from "httpsms"
 
 client.messages.postSend({
     content:   encryptedMessage,
@@ -75,42 +164,133 @@ client.messages.postSend({
     to:        '+18005550100',
 })
 .then((message) =&gt; {
-    console.log(message.id) // log the ID of the sent message
+    console.log(message.id); // log the ID of the sent message
+});</code></pre>
+          </VTabsWindowItem>
+          <VTabsWindowItem value="go">
+            <pre
+              class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
+            ><code class="language-go text-body-medium">import "github.com/NdoleStudio/httpsms-go"
+
+client.Messages.Send(context.Background(), &amp;httpsms.MessageSendParams{
+    Content:   encryptedMessage,
+    From:      "+18005550199",
+    To:        "+18005550100",
+    Encrypted: true,
 })</code></pre>
+          </VTabsWindowItem>
+        </VTabsWindow>
 
-        <h2 class="text-headline-medium mb-4">
-          Receiving an encrypted message
-        </h2>
-        <p class="text-body-large mb-4">
-          When your Android phone receives an SMS message, the app encrypts the
-          message with the encryption key configured on the phone before
-          delivering it to your webhook endpoint.
+        <p class="mt-4">
+          When you make the API request, the message will be decrypted before
+          sending to the recipient. This is a screenshot of the SMS message
+          which is sent to the recipient.
         </p>
-        <pre
-          class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
-        ><code class="language-json text-body-medium">{
-  "event": "message.phone.received",
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms android app"
+          height="800"
+          src="/img/blog/end-to-end-encryption-to-sms-messages/send-sms-message.png"
+        />
+
+        <h3 class="text-h4 mb-4 mt-16">Receiving an encrypted message</h3>
+        <p>
+          When your android phone receives a new message, it will be encrypted
+          with the encryption Key on your Android phone before it is delivered
+          to your server's webhook endpoint. You can configure webhooks by
+          following
+          <NuxtLink
+            class="text-decoration-none"
+            to="/blog/forward-incoming-sms-from-phone-to-webhook"
+            >this guide.</NuxtLink
+          >
+        </p>
+
+        <VTabs v-model="selectedTab" show-arrows>
+          <VTab value="javascript">
+            <VIcon color="#efd81d" class="mr-1" :icon="mdiLanguageJavascript" />
+            Javascript
+          </VTab>
+          <VTab value="go">
+            <VIcon color="#00aed8" class="mr-1" :icon="mdiLanguageGo" />
+            Go
+          </VTab>
+        </VTabs>
+        <VTabsWindow v-model="selectedTab">
+          <VTabsWindowItem value="javascript">
+            <pre
+              class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
+            ><code class="language-javascript text-body-medium">import HttpSms from "httpsms"
+
+const client = new HttpSms("" /* API Key from https://httpsms.com/settings */);
+
+// The payload in the webhook HTTP request looks like this
+/*
+{
+  "specversion": "1.0",
+  "id": "8dca3b0a-446a-4a5d-8d2a-95314926c4ed",
+  "source": "/v1/messages/receive",
+  "type": "message.phone.received",
+  "datacontenttype": "application/json",
+  "time": "2024-01-21T12:27:29.1605708Z",
   "data": {
-    "content": "bdmZ7n6JVf/ST+SoNlSaOGUL1DcL5705ETw8GAB4llYBgE9HOOL+Pu/h+w==",
+    "message_id": "0681b838-4157-44bb-a4ea-721e40ee7ca7",
+    "user_id": "XtABz6zdeFMoBLoltz6SREDvRSh2",
+    "owner": "+37253920216",
     "encrypted": true,
-    "from": "+18005550100",
-    "id": "msg_123",
-    "to": "+18005550199"
+    "contact": "+37253920216",
+    "timestamp": "2024-01-21T12:27:17.949Z",
+    "content": "bdmZ7n6JVf/ST+SoNlSaOGUL1DcL5705ETw8GAB4llYBgE9HOOL+Pu/h+w==",
+    "sim": "SIM1"
   }
-}</code></pre>
-        <pre
-          class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
-        ><code class="language-javascript text-body-medium">import HttpSms from "httpsms"
+}
+*/
 
-const client = new HttpSms("" /* API Key from https://httpsms.com/settings */)
-
-const encryptedMessage = "bdmZ7n6JVf/ST+SoNlSaOGUL1DcL5705ETw8GAB4llYBgE9HOOL+Pu/h+w=="
-const encryptionkey = "Password123"
+const encryptedMessage = "bdmZ7n6JVf/ST+SoNlSaOGUL1DcL5705ETw8GAB4llYBgE9HOOL+Pu/h+w==" // get the encrypted message from the request payload
+const encryptionkey = "Password123" // use the same key on the Android app
 const decryptedMessage = client.cipher.decrypt(encryptionkey, encryptedMessage)
 
 // This is a test text message</code></pre>
+          </VTabsWindowItem>
+          <VTabsWindowItem value="go">
+            <pre
+              class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
+            ><code class="language-go text-body-medium">import "github.com/NdoleStudio/httpsms-go"
 
-        <p class="text-body-large mb-6">
+client := htpsms.New(htpsms.WithAPIKey(/* API Key from https://httpsms.com/settings */))
+
+// The payload in the webhook HTTP request looks like this
+/*
+{
+  "specversion": "1.0",
+  "id": "8dca3b0a-446a-4a5d-8d2a-95314926c4ed",
+  "source": "/v1/messages/receive",
+  "type": "message.phone.received",
+  "datacontenttype": "application/json",
+  "time": "2024-01-21T12:27:29.1605708Z",
+  "data": {
+    "message_id": "0681b838-4157-44bb-a4ea-721e40ee7ca7",
+    "user_id": "XtABz6zdeFMoBLoltz6SREDvRSh2",
+    "owner": "+37253920216",
+    "encrypted": true,
+    "contact": "+37253920216",
+    "timestamp": "2024-01-21T12:27:17.949Z",
+    "content": "bdmZ7n6JVf/ST+SoNlSaOGUL1DcL5705ETw8GAB4llYBgE9HOOL+Pu/h+w==",
+    "sim": "SIM1"
+  }
+}
+*/
+
+encryptedMessage = "bdmZ7n6JVf/ST+SoNlSaOGUL1DcL5705ETw8GAB4llYBgE9HOOL+Pu/h+w==" // get the encrypted message from the request payload
+encryptionkey := "Password123" // use the same key on the Android app
+decryptedMessage := client.Cipher.Decrypt(encryptionkey, encryptedMessage)
+
+// This is a test text message</code></pre>
+          </VTabsWindowItem>
+        </VTabsWindow>
+
+        <h3 class="text-h4 mt-12">Conclusion</h3>
+        <p>
           Congratulations, you have successfully configured your Android phone
           to send and receive SMS messages with end-to-end encryption. Don't
           hesitate to contact us if you face any problems while following this
@@ -118,6 +298,10 @@ const decryptedMessage = client.cipher.decrypt(encryptionkey, encryptedMessage)
         </p>
 
         <BlogAuthorBio />
+        <VDivider class="mx-16" />
+        <div class="text-center mt-8 mb-4">
+          <BackButton />
+        </div>
       </VCol>
     </VRow>
   </VContainer>

--- a/web/app/pages/blog/end-to-end-encryption-to-sms-messages.vue
+++ b/web/app/pages/blog/end-to-end-encryption-to-sms-messages.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { useDisplay } from "vuetify";
+
+const { mdAndUp } = useDisplay();
+
 import { mdiLanguageGo, mdiLanguageJavascript } from "@mdi/js";
 import { ref } from "vue";
 
@@ -28,12 +32,16 @@ useHead({
   <VContainer class="pt-8">
     <VRow class="mt-16">
       <VCol cols="12" md="9">
-        <h1 class="text-h3 text-md-h2 mt-1">
+        <h1
+          :class="
+            mdAndUp ? 'text-display-medium mt-1' : 'text-display-small mt-1'
+          "
+        >
           Secure your conversations by encrypting your SMS messages end-to-end
         </h1>
         <BlogInfo date="January 21, 2024" readTime="10 min read" />
 
-        <p class="text-subtitle-1 mt-2">
+        <p class="text-body-large mt-2">
           We have added support for end-to-end encryption for SMS messages so
           that no one can see the content of the messages you send using httpSMS
           except you.
@@ -55,7 +63,7 @@ useHead({
           encryption algorithm to encrypt and decrypt the messages.
         </p>
 
-        <h3 class="text-h4 mt-8 mb-2">Setup your encryption key</h3>
+        <h3 class="text-headline-large mt-8 mb-2">Setup your encryption key</h3>
         <p>
           <a
             class="text-decoration-none"
@@ -72,7 +80,7 @@ useHead({
           src="/img/blog/end-to-end-encryption-to-sms-messages/encryption-key-android.png"
         />
 
-        <h3 class="text-h4 mb-4 mt-16">Encrypt your SMS message</h3>
+        <h3 class="text-headline-large mb-4 mt-16">Encrypt your SMS message</h3>
         <p>
           We use the AES-256 encryption algorithm to encrypt the SMS messages.
           This algorithm requires a an encryption key which is 256 bits to work
@@ -132,7 +140,7 @@ encryptedMessage := client.Cipher.Encrypt(key, "This is a test text message")
           </VTabsWindowItem>
         </VTabsWindow>
 
-        <h3 class="text-h4 mt-6">Send an encrypted message</h3>
+        <h3 class="text-headline-large mt-6">Send an encrypted message</h3>
         <p>
           After generating the encrypted message payload, you can send it
           directly using the httpSMS API. Make sure to set
@@ -193,7 +201,9 @@ client.Messages.Send(context.Background(), &amp;httpsms.MessageSendParams{
           src="/img/blog/end-to-end-encryption-to-sms-messages/send-sms-message.png"
         />
 
-        <h3 class="text-h4 mb-4 mt-16">Receiving an encrypted message</h3>
+        <h3 class="text-headline-large mb-4 mt-16">
+          Receiving an encrypted message
+        </h3>
         <p>
           When your android phone receives a new message, it will be encrypted
           with the encryption Key on your Android phone before it is delivered
@@ -289,7 +299,7 @@ decryptedMessage := client.Cipher.Decrypt(encryptionkey, encryptedMessage)
           </VTabsWindowItem>
         </VTabsWindow>
 
-        <h3 class="text-h4 mt-12">Conclusion</h3>
+        <h3 class="text-headline-large mt-12">Conclusion</h3>
         <p>
           Congratulations, you have successfully configured your Android phone
           to send and receive SMS messages with end-to-end encryption. Don't

--- a/web/app/pages/blog/end-to-end-encryption-to-sms-messages.vue
+++ b/web/app/pages/blog/end-to-end-encryption-to-sms-messages.vue
@@ -6,7 +6,9 @@ const { mdAndUp } = useDisplay();
 import { mdiLanguageGo, mdiLanguageJavascript } from "@mdi/js";
 import { ref } from "vue";
 
-const selectedTab = ref("javascript");
+const encryptTab = ref("javascript");
+const sendTab = ref("javascript");
+const receiveTab = ref("javascript");
 
 definePageMeta({ layout: "website" });
 
@@ -100,7 +102,7 @@ useHead({
           initialization vector and encoding the payload yourself.
         </p>
 
-        <VTabs v-model="selectedTab" show-arrows>
+        <VTabs v-model="encryptTab" show-arrows>
           <VTab value="javascript">
             <VIcon color="#efd81d" class="mr-1" :icon="mdiLanguageJavascript" />
             Javascript
@@ -110,7 +112,7 @@ useHead({
             Go
           </VTab>
         </VTabs>
-        <VTabsWindow v-model="selectedTab">
+        <VTabsWindow v-model="encryptTab">
           <VTabsWindowItem value="javascript">
             <pre
               class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
@@ -149,7 +151,7 @@ encryptedMessage := client.Cipher.Encrypt(key, "This is a test text message")
           the Android app before sending to your recipient.
         </p>
 
-        <VTabs v-model="selectedTab" show-arrows>
+        <VTabs v-model="sendTab" show-arrows>
           <VTab value="javascript">
             <VIcon color="#efd81d" class="mr-1" :icon="mdiLanguageJavascript" />
             Javascript
@@ -159,7 +161,7 @@ encryptedMessage := client.Cipher.Encrypt(key, "This is a test text message")
             Go
           </VTab>
         </VTabs>
-        <VTabsWindow v-model="selectedTab">
+        <VTabsWindow v-model="sendTab">
           <VTabsWindowItem value="javascript">
             <pre
               class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
@@ -216,7 +218,7 @@ client.Messages.Send(context.Background(), &amp;httpsms.MessageSendParams{
           >
         </p>
 
-        <VTabs v-model="selectedTab" show-arrows>
+        <VTabs v-model="receiveTab" show-arrows>
           <VTab value="javascript">
             <VIcon color="#efd81d" class="mr-1" :icon="mdiLanguageJavascript" />
             Javascript
@@ -226,7 +228,7 @@ client.Messages.Send(context.Background(), &amp;httpsms.MessageSendParams{
             Go
           </VTab>
         </VTabs>
-        <VTabsWindow v-model="selectedTab">
+        <VTabsWindow v-model="receiveTab">
           <VTabsWindowItem value="javascript">
             <pre
               class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"

--- a/web/app/pages/blog/forward-incoming-sms-from-phone-to-webhook.vue
+++ b/web/app/pages/blog/forward-incoming-sms-from-phone-to-webhook.vue
@@ -2,72 +2,130 @@
 definePageMeta({ layout: "website" });
 
 useHead({
-  title: "Forward Incoming SMS from Phone to Webhook - httpSMS",
+  title:
+    "How to forward a text message (SMS) from an android phone into your webhook - httpSMS",
+  meta: [
+    {
+      property: "og:title",
+      content:
+        "How to forward a text message (SMS) from an android phone into your webhook",
+    },
+    {
+      property: "og:description",
+      content:
+        "You can now program your android phone to forward messages received on your phone to your server and trigger powerful automations with tools like Zapier and IFTTT.",
+    },
+    {
+      property: "og:image",
+      content:
+        "https://httpsms.com/img/blog/forward-incoming-sms-from-phone-to-webhook/header.png",
+    },
+    {
+      name: "twitter:card",
+      content: "summary_large_image",
+    },
+    {
+      property: "og:url",
+      content:
+        "https://httpsms.com/blog/forward-incoming-sms-from-phone-to-webhook/",
+    },
+  ],
 });
 </script>
 
 <template>
-  <VContainer>
-    <VRow>
-      <VCol cols="12" md="8" offset-md="2">
-        <h1 class="text-display-small mb-2">
-          Forward Incoming SMS from Phone to Webhook
-        </h1>
-        <BlogInfo date="April 08, 2023" read-time="5 min read" />
-        <VDivider class="my-6" />
+  <VContainer class="pt-8">
+    <VRow class="mt-16">
+      <VCol cols="12" md="9">
+        <VImg
+          style="border-radius: 4px"
+          alt="blog post header image"
+          src="/img/blog/forward-incoming-sms-from-phone-to-webhook/header.png"
+        />
 
-        <p class="text-body-large mb-6">
+        <h1 class="text-h3 text-md-h2 mt-1">
+          How to forward a text message (SMS) from an android phone into your
+          webhook
+        </h1>
+        <BlogInfo date="April 08, 2023" readTime="5 min read" />
+
+        <p class="text-subtitle-1 mt-2">
           You can now program your android phone to forward messages received on
           your phone to your server and trigger powerful automations with tools
           like Zapier and IFTTT. I created an open source application called
-          httpSMS that helps you to set this up with ease.
+          <NuxtLink class="text-decoration-none" to="/">httpSMS</NuxtLink>
+          that helps you to set this up with ease
         </p>
 
-        <h2 class="text-headline-medium mb-4">Step 1: Get your API_KEY</h2>
-        <p class="text-body-large mb-6">
-          Create an account on the httpSMS web app and copy your API key from
-          the
-          <a href="https://httpsms.com/settings" target="_blank" rel="noopener"
-            >settings page</a
-          >.
+        <h3 class="text-h4 mt-2">Step 1: Get your API_KEY</h3>
+        <p>
+          Create an account on the httpSMS web application and copy your API key
+          from the settings page.
+          <NuxtLink class="text-decoration-none" to="/settings"
+            >https://httpsms.com/settings</NuxtLink
+          >
         </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms.com settings page"
+          src="/img/blog/forward-incoming-sms-from-phone-to-webhook/settings.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">
-          Step 2: Install the httpSMS android app
-        </h2>
-        <p class="text-body-large mb-6">
-          Download the Android app from
+        <h3 class="text-h4 mt-12">Step 2: Install the httpSMS android app</h3>
+        <p>
           <a
+            class="text-decoration-none"
             href="https://github.com/NdoleStudio/httpsms/releases/latest/download/HttpSms.apk"
-            target="_blank"
-            rel="noopener"
-            >https://github.com/NdoleStudio/httpsms/releases/latest/download/HttpSms.apk</a
+            >⬇️ Download and install</a
           >
-          and sign in using your API KEY.
+          the httpSMS android app on your phone and sign in using your API KEY
+          which you copied above. This app listens for SMS messages received on
+          your android phone.
         </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms android app"
+          height="800"
+          src="/img/blog/forward-incoming-sms-from-phone-to-webhook/android-app.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">Step 3: Set up a webhook</h2>
-        <p class="text-body-large mb-6">
-          Once installed, the app listens for SMS messages received on your
-          phone. Configure your webhook URL under the
-          <a href="https://httpsms.com/settings" target="_blank" rel="noopener"
-            >settings page</a
+        <h3 class="text-h4 mt-12">Step 3: Set up a webhook</h3>
+        <p>
+          Once the application has been installed, it will be listening for SMS
+          messages received on the android phone. You can configure the
+          application to sent this SMS message to your server URL using a
+          webhook. You can configure this URL under the settings page in the
+          httpSMS application
+          <NuxtLink class="text-decoration-none" to="/settings"
+            >https://httpsms.com/settings</NuxtLink
           >
-          so the messages can be delivered to your server.
         </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpSMS webhook configuration"
+          src="/img/blog/forward-incoming-sms-from-phone-to-webhook/webhook.png"
+        />
 
-        <p class="text-body-large mb-6">
+        <h3 class="text-h4 mt-12">Conclusion</h3>
+        <p>
           Congratulations, you have successfully set up SMS forwarding from your
           Android phone to a webhook! This powerful automation tool can help you
-          streamline your business workflow and save you time and effort. You
-          can also trigger the httpSMS application to send an SMS a simple API.
-          You can find more information on the documentation page at
-          <a href="https://docs.httpsms.com" target="_blank" rel="noopener"
-            >https://docs.httpsms.com</a
-          >. Until the next time ✌️
+          streamline your business workflow and save you time and effort.
         </p>
+        <p>
+          You can also trigger the httpSMS application to send an SMS a simple
+          API. You can find more information on the documentation page at
+          <a class="text-decoration-none" href="https://docs.httpsms.com"
+            >https://docs.httpsms.com</a
+          >
+        </p>
+        <p>Until the next time✌️</p>
 
         <BlogAuthorBio />
+        <VDivider class="mx-16" />
+        <div class="text-center mt-8 mb-4">
+          <BackButton />
+        </div>
       </VCol>
     </VRow>
   </VContainer>

--- a/web/app/pages/blog/forward-incoming-sms-from-phone-to-webhook.vue
+++ b/web/app/pages/blog/forward-incoming-sms-from-phone-to-webhook.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { useDisplay } from "vuetify";
+
+const { mdAndUp } = useDisplay();
+
 definePageMeta({ layout: "website" });
 
 useHead({
@@ -43,13 +47,17 @@ useHead({
           src="/img/blog/forward-incoming-sms-from-phone-to-webhook/header.png"
         />
 
-        <h1 class="text-h3 text-md-h2 mt-1">
+        <h1
+          :class="
+            mdAndUp ? 'text-display-medium mt-1' : 'text-display-small mt-1'
+          "
+        >
           How to forward a text message (SMS) from an android phone into your
           webhook
         </h1>
         <BlogInfo date="April 08, 2023" readTime="5 min read" />
 
-        <p class="text-subtitle-1 mt-2">
+        <p class="text-body-large mt-2">
           You can now program your android phone to forward messages received on
           your phone to your server and trigger powerful automations with tools
           like Zapier and IFTTT. I created an open source application called
@@ -57,7 +65,7 @@ useHead({
           that helps you to set this up with ease
         </p>
 
-        <h3 class="text-h4 mt-2">Step 1: Get your API_KEY</h3>
+        <h3 class="text-headline-large mt-2">Step 1: Get your API_KEY</h3>
         <p>
           Create an account on the httpSMS web application and copy your API key
           from the settings page.
@@ -71,7 +79,9 @@ useHead({
           src="/img/blog/forward-incoming-sms-from-phone-to-webhook/settings.png"
         />
 
-        <h3 class="text-h4 mt-12">Step 2: Install the httpSMS android app</h3>
+        <h3 class="text-headline-large mt-12">
+          Step 2: Install the httpSMS android app
+        </h3>
         <p>
           <a
             class="text-decoration-none"
@@ -89,7 +99,7 @@ useHead({
           src="/img/blog/forward-incoming-sms-from-phone-to-webhook/android-app.png"
         />
 
-        <h3 class="text-h4 mt-12">Step 3: Set up a webhook</h3>
+        <h3 class="text-headline-large mt-12">Step 3: Set up a webhook</h3>
         <p>
           Once the application has been installed, it will be listening for SMS
           messages received on the android phone. You can configure the
@@ -106,7 +116,7 @@ useHead({
           src="/img/blog/forward-incoming-sms-from-phone-to-webhook/webhook.png"
         />
 
-        <h3 class="text-h4 mt-12">Conclusion</h3>
+        <h3 class="text-headline-large mt-12">Conclusion</h3>
         <p>
           Congratulations, you have successfully set up SMS forwarding from your
           Android phone to a webhook! This powerful automation tool can help you

--- a/web/app/pages/blog/grant-send-and-read-sms-permissions-on-android.vue
+++ b/web/app/pages/blog/grant-send-and-read-sms-permissions-on-android.vue
@@ -1,55 +1,107 @@
 <script setup lang="ts">
+import { mdiDotsVertical } from "@mdi/js";
+import { useDisplay } from "vuetify";
+
+const { mdAndUp } = useDisplay();
+
 definePageMeta({ layout: "website" });
 
 useHead({
-  title: "Grant Send and Read SMS Permissions on Android - httpSMS",
+  title:
+    "How to grant SEND_SMS and RECEIVE_SMS permissions on Android 14+ - httpSMS",
+  meta: [
+    {
+      property: "og:title",
+      content:
+        "How to grant SEND_SMS and RECEIVE_SMS permissions on Android 14+",
+    },
+    {
+      property: "og:description",
+      content:
+        "We have added support for end-to-end encryption for SMS messages so that no one can see the content of the messages you send using httpSMS except you.",
+    },
+  ],
 });
 </script>
 
 <template>
-  <VContainer>
-    <VRow>
-      <VCol cols="12" md="8" offset-md="2">
-        <h1 class="text-display-small mb-2">
-          Grant Send and Read SMS Permissions on Android
+  <VContainer class="pt-8">
+    <VRow class="mt-16">
+      <VCol cols="12" md="9">
+        <h1 class="text-h3 text-md-h2 mt-1">
+          How to grant SMS permissions on Android 15+
         </h1>
         <BlogInfo date="February 18, 2025" read-time="5 min read" />
-        <VDivider class="my-6" />
 
-        <p class="text-body-large mb-6">
-          In Android 15 (Vanilla Ice Cream), the android.permission.SEND_SMS and
-          android.permission.RECEIVE_SMS permissions are now hard restricted and
-          cannot be granted via the runtime permissions interface.
+        <p class="text-subtitle-1 mt-2">
+          In Android 15 (Vanilla Ice Cream), the
+          <code>android.permission.SEND_SMS</code> and
+          <code>android.permission.RECEIVE_SMS</code> permissions are now hard
+          restricted and cannot be granted
+          <a
+            class="text-decoration-none"
+            href="https://developer.android.com/training/permissions/requesting"
+            >via the runtime permissions interface</a
+          >.
         </p>
 
-        <h2 class="text-headline-medium mb-4">Step 1: Open App Info</h2>
-        <p class="text-body-large mb-6">
+        <VAlert type="warning" variant="outlined" class="my-4">
+          Granting the <code>SEND_SMS</code> and
+          <code>RECEIVE_SMS</code> permissions will allow an Android app to be
+          able to read and send SMS messages on your phone. Make sure you trust
+          the application before allowing these permissions.
+        </VAlert>
+
+        <h3 class="text-h4 mt-8 mb-2">Step1: Open App Info</h3>
+        <p>
           Long press the icon of the android app which you want to grant the
-          permission and select 'App info'
+          permission and select <b>"App info"</b>
         </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms android app"
+          height="800"
+          src="/img/blog/grant-send-and-read-sms-permissions-on-android/app-info.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">
-          Step 2: Allow Restricted Permissions
-        </h2>
-        <p class="text-body-large mb-6">
-          On the App Info page, click on the menu button and select the 'Allow
-          restricted settings' option
+        <h3 class="text-h4 mb-4 mt-16">Step 2: Allow Restricted Permissions</h3>
+        <p>
+          On the App Info page, click on the menu button
+          <VIcon :icon="mdiDotsVertical" /> and select the
+          <b>"Allow restricted settings"</b> option
         </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms android app"
+          height="800"
+          src="/img/blog/grant-send-and-read-sms-permissions-on-android/allow-restricted-settings.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">Step 3: Allow SMS Permissions</h2>
-        <p class="text-body-large mb-6">
+        <h3 class="text-h4 mb-4 mt-16">Step 3: Allow SMS Permissions</h3>
+        <p>
           Once you have allowed the restricted settings from step 2 above, You
-          can navigate to Permissions ➡️ SMS and tap the Allow button to grant
-          SMS permissions to the android app.
+          can navigate to <b>Permissions ➡️ SMS</b> and tap the Allow button to
+          grant SMS permissions to the android app.
         </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms android app"
+          height="800"
+          src="/img/blog/grant-send-and-read-sms-permissions-on-android/allow.png"
+        />
 
-        <p class="text-body-large mb-6">
+        <h3 class="text-h4 mt-12">Conclusion</h3>
+        <p>
           Congratulations, you have successfully configured SMS permissions on
           your Android app. Don't hesitate to contact us if you face any
           problems while following this guide.
         </p>
 
         <BlogAuthorBio />
+        <VDivider class="mx-16" />
+        <div class="text-center mt-8 mb-4">
+          <BackButton />
+        </div>
       </VCol>
     </VRow>
   </VContainer>

--- a/web/app/pages/blog/grant-send-and-read-sms-permissions-on-android.vue
+++ b/web/app/pages/blog/grant-send-and-read-sms-permissions-on-android.vue
@@ -18,7 +18,7 @@ useHead({
     {
       property: "og:description",
       content:
-        "We have added support for end-to-end encryption for SMS messages so that no one can see the content of the messages you send using httpSMS except you.",
+        "In Android 15 (Vanilla Ice Cream), the SEND_SMS and RECEIVE_SMS permissions are now hard restricted. Learn how to grant these permissions step by step.",
     },
   ],
 });
@@ -35,7 +35,7 @@ useHead({
         >
           How to grant SMS permissions on Android 15+
         </h1>
-        <BlogInfo date="February 18, 2025" read-time="5 min read" />
+        <BlogInfo date="February 18, 2025" readTime="5 min read" />
 
         <p class="text-body-large mt-2">
           In Android 15 (Vanilla Ice Cream), the

--- a/web/app/pages/blog/grant-send-and-read-sms-permissions-on-android.vue
+++ b/web/app/pages/blog/grant-send-and-read-sms-permissions-on-android.vue
@@ -28,12 +28,16 @@ useHead({
   <VContainer class="pt-8">
     <VRow class="mt-16">
       <VCol cols="12" md="9">
-        <h1 class="text-h3 text-md-h2 mt-1">
+        <h1
+          :class="
+            mdAndUp ? 'text-display-medium mt-1' : 'text-display-small mt-1'
+          "
+        >
           How to grant SMS permissions on Android 15+
         </h1>
         <BlogInfo date="February 18, 2025" read-time="5 min read" />
 
-        <p class="text-subtitle-1 mt-2">
+        <p class="text-body-large mt-2">
           In Android 15 (Vanilla Ice Cream), the
           <code>android.permission.SEND_SMS</code> and
           <code>android.permission.RECEIVE_SMS</code> permissions are now hard
@@ -52,7 +56,7 @@ useHead({
           the application before allowing these permissions.
         </VAlert>
 
-        <h3 class="text-h4 mt-8 mb-2">Step1: Open App Info</h3>
+        <h3 class="text-headline-large mt-8 mb-2">Step1: Open App Info</h3>
         <p>
           Long press the icon of the android app which you want to grant the
           permission and select <b>"App info"</b>
@@ -64,7 +68,9 @@ useHead({
           src="/img/blog/grant-send-and-read-sms-permissions-on-android/app-info.png"
         />
 
-        <h3 class="text-h4 mb-4 mt-16">Step 2: Allow Restricted Permissions</h3>
+        <h3 class="text-headline-large mb-4 mt-16">
+          Step 2: Allow Restricted Permissions
+        </h3>
         <p>
           On the App Info page, click on the menu button
           <VIcon :icon="mdiDotsVertical" /> and select the
@@ -77,7 +83,9 @@ useHead({
           src="/img/blog/grant-send-and-read-sms-permissions-on-android/allow-restricted-settings.png"
         />
 
-        <h3 class="text-h4 mb-4 mt-16">Step 3: Allow SMS Permissions</h3>
+        <h3 class="text-headline-large mb-4 mt-16">
+          Step 3: Allow SMS Permissions
+        </h3>
         <p>
           Once you have allowed the restricted settings from step 2 above, You
           can navigate to <b>Permissions ➡️ SMS</b> and tap the Allow button to
@@ -90,7 +98,7 @@ useHead({
           src="/img/blog/grant-send-and-read-sms-permissions-on-android/allow.png"
         />
 
-        <h3 class="text-h4 mt-12">Conclusion</h3>
+        <h3 class="text-headline-large mt-12">Conclusion</h3>
         <p>
           Congratulations, you have successfully configured SMS permissions on
           your Android app. Don't hesitate to contact us if you face any

--- a/web/app/pages/blog/how-to-send-sms-messages-from-excel.vue
+++ b/web/app/pages/blog/how-to-send-sms-messages-from-excel.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { useDisplay } from "vuetify";
+
+const { mdAndUp } = useDisplay();
+
 import { mdiCommentTextMultipleOutline } from "@mdi/js";
 
 definePageMeta({ layout: "website" });
@@ -32,25 +36,29 @@ useHead({
   <VContainer class="pt-8">
     <VRow class="mt-16">
       <VCol cols="12" md="9">
-        <h1 class="text-h3 text-md-h2 mt-1">
+        <h1
+          :class="
+            mdAndUp ? 'text-display-medium mt-1' : 'text-display-small mt-1'
+          "
+        >
           How to send SMS messages to multiple phone numbers from Excel
         </h1>
         <BlogInfo date="October 29, 2023" readTime="5 min read" />
 
-        <p class="text-subtitle-1 mt-2">
+        <p class="text-body-large mt-2">
           Send personalized SMS messages to multiple phone numbers for less than
           <b>$0.002 </b> per SMS message. You can also configure every SMS
           message in your Excel spreadsheet so they are unique for each
           recipient phone number.
         </p>
 
-        <h3 class="text-h4 mt-8 mb-2">Prerequisites</h3>
+        <h3 class="text-headline-large mt-8 mb-2">Prerequisites</h3>
         <ul>
           <li>Basic understanding of Microsoft Excel or Google Sheets.</li>
           <li>An Android phone.</li>
         </ul>
 
-        <h3 class="text-h4 mt-8 mb-2">Step 1: Get your API Key</h3>
+        <h3 class="text-headline-large mt-8 mb-2">Step 1: Get your API Key</h3>
         <p>
           Create an account on
           <NuxtLink class="text-decoration-none" to="/">httpsms.com</NuxtLink>
@@ -65,7 +73,7 @@ useHead({
           src="/img/blog/forward-incoming-sms-from-phone-to-webhook/settings.png"
         />
 
-        <h3 class="text-h4 mb-4 mt-16">
+        <h3 class="text-headline-large mb-4 mt-16">
           Step 2: Install the httpSMS android app
         </h3>
         <p>
@@ -89,7 +97,7 @@ useHead({
           src="/img/blog/forward-incoming-sms-from-phone-to-webhook/android-app.png"
         />
 
-        <h3 class="text-h4 mt-12">Step 3: Edit your Excel file</h3>
+        <h3 class="text-headline-large mt-12">Step 3: Edit your Excel file</h3>
         <p>
           Download the
           <a
@@ -116,7 +124,7 @@ useHead({
           src="/img/blog/send-bulk-sms-from-csv-file-with-no-code/httpms-spreedsheet.png"
         />
 
-        <h3 class="text-h4 mt-12">Step 3: Send the SMS Messages</h3>
+        <h3 class="text-headline-large mt-12">Step 3: Send the SMS Messages</h3>
         <p>
           Visit the
           <NuxtLink class="text-decoration-none" to="/bulk-messages">

--- a/web/app/pages/blog/how-to-send-sms-messages-from-excel.vue
+++ b/web/app/pages/blog/how-to-send-sms-messages-from-excel.vue
@@ -1,93 +1,158 @@
 <script setup lang="ts">
+import { mdiCommentTextMultipleOutline } from "@mdi/js";
+
 definePageMeta({ layout: "website" });
 
 useHead({
-  title: "How to Send SMS Messages from Excel - httpSMS",
+  title:
+    "How to send SMS messages to multiple phone numbers from Excel  - httpSMS",
+  meta: [
+    {
+      property: "og:title",
+      content: "How to send SMS messages to multiple phone numbers from Excel",
+    },
+    {
+      property: "og:description",
+      content:
+        "Configure your Android phone as an SMS gateway to automate sending text messages with the Python programing language.",
+    },
+    {
+      name: "twitter:card",
+      content: "summary_large_image",
+    },
+    {
+      property: "og:url",
+      content: "https://httpsms.com/blog/how-to-send-sms-messages-from-excel/",
+    },
+  ],
 });
 </script>
 
 <template>
-  <VContainer>
-    <VRow>
-      <VCol cols="12" md="8" offset-md="2">
-        <h1 class="text-display-small mb-2">
-          How to Send SMS Messages from Excel
+  <VContainer class="pt-8">
+    <VRow class="mt-16">
+      <VCol cols="12" md="9">
+        <h1 class="text-h3 text-md-h2 mt-1">
+          How to send SMS messages to multiple phone numbers from Excel
         </h1>
-        <BlogInfo date="October 29, 2023" read-time="5 min read" />
-        <VDivider class="my-6" />
+        <BlogInfo date="October 29, 2023" readTime="5 min read" />
 
-        <p class="text-body-large mb-6">
+        <p class="text-subtitle-1 mt-2">
           Send personalized SMS messages to multiple phone numbers for less than
-          $0.002 per SMS message. You can also configure every SMS message in
-          your Excel spreadsheet so they are unique for each recipient phone
-          number.
+          <b>$0.002 </b> per SMS message. You can also configure every SMS
+          message in your Excel spreadsheet so they are unique for each
+          recipient phone number.
         </p>
 
-        <h2 class="text-headline-medium mb-4">Prerequisites</h2>
-        <ul class="text-body-large pl-6 mb-6">
-          <li>Basic understanding of Microsoft Excel or Google Sheets</li>
-          <li>An Android phone</li>
+        <h3 class="text-h4 mt-8 mb-2">Prerequisites</h3>
+        <ul>
+          <li>Basic understanding of Microsoft Excel or Google Sheets.</li>
+          <li>An Android phone.</li>
         </ul>
 
-        <h2 class="text-headline-medium mb-4">Step 1: Get your API Key</h2>
-        <p class="text-body-large mb-6">
+        <h3 class="text-h4 mt-8 mb-2">Step 1: Get your API Key</h3>
+        <p>
           Create an account on
-          <a href="https://httpsms.com" target="_blank" rel="noopener"
-            >httpsms.com</a
+          <NuxtLink class="text-decoration-none" to="/">httpsms.com</NuxtLink>
+          and copy your API key from the settings page
+          <NuxtLink class="text-decoration-none" to="/settings"
+            >https://httpsms.com/settings</NuxtLink
           >
-          and copy your API key from the
-          <a href="https://httpsms.com/settings" target="_blank" rel="noopener"
-            >settings page</a
-          >.
         </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms.com settings page"
+          src="/img/blog/forward-incoming-sms-from-phone-to-webhook/settings.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">
+        <h3 class="text-h4 mb-4 mt-16">
           Step 2: Install the httpSMS android app
-        </h2>
-        <p class="text-body-large mb-6">
-          Download the Android app from
+        </h3>
+        <p>
           <a
+            class="text-decoration-none"
             href="https://github.com/NdoleStudio/httpsms/releases/latest/download/HttpSms.apk"
-            target="_blank"
-            rel="noopener"
-            >https://github.com/NdoleStudio/httpsms/releases/latest/download/HttpSms.apk</a
+            >⬇️ Download and install</a
           >
-          and sign in using your API KEY.
+          the httpSMS android app on your phone and sign in using your API KEY
+          which you copied above. This app listens for SMS messages received on
+          your android phone.
         </p>
+        <VAlert type="info" variant="outlined">
+          Make sure to enter your phone number in the international format e.g
+          +18005550199 when authenticating with the httpSMS Android app.
+        </VAlert>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms android app"
+          height="800"
+          src="/img/blog/forward-incoming-sms-from-phone-to-webhook/android-app.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">Step 3: Edit your Excel file</h2>
-        <p class="text-body-large mb-6">
-          Download the httpSMS Excel file template from
+        <h3 class="text-h4 mt-12">Step 3: Edit your Excel file</h3>
+        <p>
+          Download the
           <a
-            href="https://httpsms.com/templates/httpsms-bulk.xlsx"
-            target="_blank"
-            rel="noopener"
-            >https://httpsms.com/templates/httpsms-bulk.xlsx</a
+            class="text-decoration-none"
+            href="/templates/httpsms-bulk.xlsx"
+            download
+            >httpSMS Excel file template</a
           >
-          and edit it with Microsoft Excel, Google Sheets, or any spreadsheet
-          software. Fill in the <strong>FromPhoneNumber</strong>,
-          <strong>ToPhoneNumber</strong>, and <strong>Content</strong> columns.
+          and edit it with your favorite spreadsheet software e.g Excel, Google
+          Sheets, Open Office etc. Fill in the phone number which you registered
+          in httpSMS in the <code>FromPhoneNumber</code> column and fill in the
+          number of the recipient of the SMS in the
+          <code>ToPhoneNumber</code> column. Also add the SMS which you want to
+          send in the message in the <code>Content</code> column.
         </p>
+        <VAlert type="info" variant="outlined" class="mt-2 mb-4">
+          Make sure to use the correct <code>FromPhoneNumber</code> from step 2
+          above in your Excel file
+        </VAlert>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms spreadsheet"
+          height="800"
+          src="/img/blog/send-bulk-sms-from-csv-file-with-no-code/httpms-spreedsheet.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">Send your SMS messages</h2>
-        <p class="text-body-large mb-6">
+        <h3 class="text-h4 mt-12">Step 3: Send the SMS Messages</h3>
+        <p>
           Visit the
-          <a
-            href="https://httpsms.com/bulk-messages"
-            target="_blank"
-            rel="noopener"
-            >Bulk Messages page</a
-          >
-          and upload your Excel file.
+          <NuxtLink class="text-decoration-none" to="/bulk-messages">
+            <VIcon
+              color="primary"
+              size="small"
+              class="mr-1"
+              :icon="mdiCommentTextMultipleOutline"
+            />
+            Bulk Messages
+          </NuxtLink>
+          page on httpSMS and upload your Excel file and send the your SMS
+          messages.
         </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="bulk csv upload"
+          height="800"
+          src="/img/blog/send-bulk-sms-from-csv-file-with-no-code/bulk-csv-upload.png"
+        />
 
-        <p class="text-body-large mb-6">
-          Don't hesitate to contact us if you face any issues sending bulk SMS
-          messages from your Excel files by following this tutorial. Until the
-          next time ✌️
+        <p class="mt-12">
+          Don't hesitate to
+          <a class="text-decoration-none" href="mailto:arnold@httpsms.com"
+            >contact us</a
+          >
+          if you face any issues sending bulk SMS messages from your Excel files
+          by following this tutorial.
         </p>
+        <p>Until the next time✌️</p>
 
         <BlogAuthorBio />
+        <VDivider class="mx-16" />
+        <div class="text-center mt-8 mb-4">
+          <BackButton />
+        </div>
       </VCol>
     </VRow>
   </VContainer>

--- a/web/app/pages/blog/how-to-send-sms-messages-from-excel.vue
+++ b/web/app/pages/blog/how-to-send-sms-messages-from-excel.vue
@@ -18,7 +18,7 @@ useHead({
     {
       property: "og:description",
       content:
-        "Configure your Android phone as an SMS gateway to automate sending text messages with the Python programing language.",
+        "Send personalized SMS messages to multiple phone numbers for less than $0.002 per SMS message using your Android phone as the SMS gateway.",
     },
     {
       name: "twitter:card",
@@ -124,7 +124,7 @@ useHead({
           src="/img/blog/send-bulk-sms-from-csv-file-with-no-code/httpms-spreedsheet.png"
         />
 
-        <h3 class="text-headline-large mt-12">Step 3: Send the SMS Messages</h3>
+        <h3 class="text-headline-large mt-12">Step 4: Send the SMS Messages</h3>
         <p>
           Visit the
           <NuxtLink class="text-decoration-none" to="/bulk-messages">

--- a/web/app/pages/blog/index.vue
+++ b/web/app/pages/blog/index.vue
@@ -4,7 +4,7 @@ definePageMeta({
 });
 
 useHead({
-  title: "Blog - httpSMS",
+  title: "Blog Posts - httpSMS",
 });
 
 type Article = {
@@ -20,9 +20,9 @@ type Article = {
 const articles: Article[] = [
   {
     slug: "grant-send-and-read-sms-permissions-on-android",
-    title: "Grant Send and Read SMS Permissions on Android",
+    title: "How to grant SMS permissions on Android 15+",
     description:
-      "In Android 15, the SEND_SMS and RECEIVE_SMS permissions are now hard restricted. Learn how to grant these permissions.",
+      "Take control of your privacy by encrypting your SMS messages end-to-end. Safeguard your messages from prying eyes, ensuring absolute confidentiality.",
     date: "February 18, 2025",
     readTime: "5 min read",
     author: "Acho Arnold",
@@ -30,9 +30,10 @@ const articles: Article[] = [
   },
   {
     slug: "end-to-end-encryption-to-sms-messages",
-    title: "End-to-End Encryption to SMS Messages",
+    title:
+      "Secure your conversations with end-to-end encryption for SMS messages",
     description:
-      "We have added support for end-to-end encryption for SMS messages so that no one can see the content of the messages you send using httpSMS except you.",
+      "Take control of your privacy by encrypting your SMS messages end-to-end. Safeguard your messages from prying eyes, ensuring absolute confidentiality.",
     date: "January 21, 2024",
     readTime: "10 min read",
     author: "Acho Arnold",
@@ -40,19 +41,19 @@ const articles: Article[] = [
   },
   {
     slug: "send-sms-when-new-row-is-added-to-google-sheets-using-zapier",
-    title: "Send SMS When New Row is Added to Google Sheets Using Zapier",
+    title: "Send an SMS when a new row is added to Google Sheets using Zapier",
     description:
-      "Automate sending personalized SMS messages each time a new row is added to your Google Sheets document using Zapier.",
-    date: "October 29, 2023",
-    readTime: "5 min read",
+      "Automate sending personalized SMS messages each time a new row is added to your Google Sheets document using Zapier without writing code.",
+    date: "November 29, 2023",
+    readTime: "7 min read",
     author: "Acho Arnold",
-    sortDate: "2023-10-29",
+    sortDate: "2023-11-29",
   },
   {
     slug: "how-to-send-sms-messages-from-excel",
-    title: "How to Send SMS Messages from Excel",
+    title: "How to send SMS messages to multiple phone numbers from Excel",
     description:
-      "Send personalized SMS messages to multiple phone numbers for less than $0.002 per SMS message.",
+      "Send multiple SMS messages to your customers from a an Excel file using your Android phone as the SMS gateway.",
     date: "October 29, 2023",
     readTime: "5 min read",
     author: "Acho Arnold",
@@ -60,9 +61,9 @@ const articles: Article[] = [
   },
   {
     slug: "send-bulk-sms-from-csv-file-with-no-code",
-    title: "Send Bulk SMS from CSV File with No Code",
+    title: "Send bulk SMS messages from a CSV file with no code",
     description:
-      "Send personalized SMS messages to your users in bulk using your Android phone without writing any code.",
+      "Send SMS messages to multiple recipients in your CSV file without writing a single piece of code.",
     date: "October 29, 2023",
     readTime: "7 min read",
     author: "Acho Arnold",
@@ -70,9 +71,9 @@ const articles: Article[] = [
   },
   {
     slug: "send-sms-from-android-phone-with-python",
-    title: "Send SMS from Android Phone with Python",
+    title: "Send an SMS from your Android phone with Python",
     description:
-      "Learn how to setup your Android phone to send SMS messages using Python and the httpSMS API.",
+      "This article will show you how to configure your Android phone as an SMS gateway to automate sending text messages with the Python programing language.",
     date: "June 03, 2023",
     readTime: "6 min read",
     author: "Acho Arnold",
@@ -80,9 +81,10 @@ const articles: Article[] = [
   },
   {
     slug: "forward-incoming-sms-from-phone-to-webhook",
-    title: "Forward Incoming SMS from Phone to Webhook",
+    title:
+      "Forward a text message (SMS) from an Android phone into your webhook",
     description:
-      "Program your android phone to forward messages received on your phone to your server and trigger powerful automations.",
+      "Program your android phone to forward messages received on your phone to your server and trigger powerful automations with tools like zapper and IFTTFT.",
     date: "April 08, 2023",
     readTime: "5 min read",
     author: "Acho Arnold",
@@ -101,8 +103,7 @@ const sortedArticles = computed(() =>
       <VCol cols="12" md="8" offset-md="2">
         <h1 class="text-display-small mb-4">Blog</h1>
         <p class="text-body-large mb-8">
-          Guides, tutorials, and product updates to help you get the most out of
-          httpSMS.
+          Learn more about httpSMS through our blog!
         </p>
 
         <div class="d-flex flex-column ga-4">

--- a/web/app/pages/blog/index.vue
+++ b/web/app/pages/blog/index.vue
@@ -22,7 +22,7 @@ const articles: Article[] = [
     slug: "grant-send-and-read-sms-permissions-on-android",
     title: "How to grant SMS permissions on Android 15+",
     description:
-      "Take control of your privacy by encrypting your SMS messages end-to-end. Safeguard your messages from prying eyes, ensuring absolute confidentiality.",
+      "In Android 15 (Vanilla Ice Cream), the SEND_SMS and RECEIVE_SMS permissions are now hard restricted. Learn how to grant these permissions step by step.",
     date: "February 18, 2025",
     readTime: "5 min read",
     author: "Acho Arnold",
@@ -84,7 +84,7 @@ const articles: Article[] = [
     title:
       "Forward a text message (SMS) from an Android phone into your webhook",
     description:
-      "Program your android phone to forward messages received on your phone to your server and trigger powerful automations with tools like zapper and IFTTFT.",
+      "Program your android phone to forward messages received on your phone to your server and trigger powerful automations with tools like Zapier and IFTTT.",
     date: "April 08, 2023",
     readTime: "5 min read",
     author: "Acho Arnold",

--- a/web/app/pages/blog/send-bulk-sms-from-csv-file-with-no-code.vue
+++ b/web/app/pages/blog/send-bulk-sms-from-csv-file-with-no-code.vue
@@ -135,7 +135,7 @@ useHead({
           src="/img/blog/send-bulk-sms-from-csv-file-with-no-code/httpms-spreedsheet.png"
         />
 
-        <h3 class="text-headline-large mt-12">Step 3: Send the SMS Messages</h3>
+        <h3 class="text-headline-large mt-12">Step 4: Send the SMS Messages</h3>
         <p>
           Visit the
           <NuxtLink class="text-decoration-none" to="/bulk-messages">

--- a/web/app/pages/blog/send-bulk-sms-from-csv-file-with-no-code.vue
+++ b/web/app/pages/blog/send-bulk-sms-from-csv-file-with-no-code.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { useDisplay } from "vuetify";
+
+const { mdAndUp } = useDisplay();
+
 import { mdiCommentTextMultipleOutline } from "@mdi/js";
 
 definePageMeta({ layout: "website" });
@@ -32,19 +36,23 @@ useHead({
   <VContainer class="pt-8">
     <VRow class="mt-16">
       <VCol cols="12" md="9">
-        <h1 class="text-h3 text-md-h2 mt-1">
+        <h1
+          :class="
+            mdAndUp ? 'text-display-medium mt-1' : 'text-display-small mt-1'
+          "
+        >
           Send multiple SMS messages from a CSV file with no code
         </h1>
         <BlogInfo date="October 29, 2023" readTime="7 min read" />
 
-        <p class="text-subtitle-1 mt-2">
+        <p class="text-body-large mt-2">
           Send personalized SMS messages to your users in bulk using your
           Android phone. The good news is, you don't have to write a single
           piece of code, just upload your CSV file and we will take care of the
           rest.
         </p>
 
-        <h3 class="text-h4 mt-8 mb-2">What is a CSV file</h3>
+        <h3 class="text-headline-large mt-8 mb-2">What is a CSV file</h3>
         <p>
           CSV is an abbreviation for comma-separated values. A CSV file allows
           data to be saved in a table structured format using a comma
@@ -54,13 +62,13 @@ useHead({
           Google Sheets.
         </p>
 
-        <h3 class="text-h4 mt-8 mb-2">Prerequisites</h3>
+        <h3 class="text-headline-large mt-8 mb-2">Prerequisites</h3>
         <ul>
           <li>Basic understanding of CSV files.</li>
           <li>An Android phone.</li>
         </ul>
 
-        <h3 class="text-h4 mt-8 mb-2">Step 1: Get your API Key</h3>
+        <h3 class="text-headline-large mt-8 mb-2">Step 1: Get your API Key</h3>
         <p>
           Create an account on
           <NuxtLink class="text-decoration-none" to="/">httpsms.com</NuxtLink>
@@ -75,7 +83,7 @@ useHead({
           src="/img/blog/forward-incoming-sms-from-phone-to-webhook/settings.png"
         />
 
-        <h3 class="text-h4 mb-4 mt-16">
+        <h3 class="text-headline-large mb-4 mt-16">
           Step 2: Install the httpSMS android app
         </h3>
         <p>
@@ -99,7 +107,7 @@ useHead({
           src="/img/blog/forward-incoming-sms-from-phone-to-webhook/android-app.png"
         />
 
-        <h3 class="text-h4 mt-12">Step 3: Edit your CSV file</h3>
+        <h3 class="text-headline-large mt-12">Step 3: Edit your CSV file</h3>
         <p>
           Download the
           <a
@@ -127,7 +135,7 @@ useHead({
           src="/img/blog/send-bulk-sms-from-csv-file-with-no-code/httpms-spreedsheet.png"
         />
 
-        <h3 class="text-h4 mt-12">Step 3: Send the SMS Messages</h3>
+        <h3 class="text-headline-large mt-12">Step 3: Send the SMS Messages</h3>
         <p>
           Visit the
           <NuxtLink class="text-decoration-none" to="/bulk-messages">

--- a/web/app/pages/blog/send-bulk-sms-from-csv-file-with-no-code.vue
+++ b/web/app/pages/blog/send-bulk-sms-from-csv-file-with-no-code.vue
@@ -1,101 +1,169 @@
 <script setup lang="ts">
+import { mdiCommentTextMultipleOutline } from "@mdi/js";
+
 definePageMeta({ layout: "website" });
 
 useHead({
-  title: "Send Bulk SMS from CSV File with No Code - httpSMS",
+  title: "Send bulk SMS messages from a CSV file with no code  - httpSMS",
+  meta: [
+    {
+      property: "og:title",
+      content: "Send bulk SMS messages from a CSV file with no code",
+    },
+    {
+      property: "og:description",
+      content:
+        "Send personalized SMS messages from your CSV file instantly using your Android phone as the SMS gateway.",
+    },
+    {
+      name: "twitter:card",
+      content: "summary_large_image",
+    },
+    {
+      property: "og:url",
+      content:
+        "https://httpsms.com/blog/send-bulk-sms-from-csv-file-with-no-code/",
+    },
+  ],
 });
 </script>
 
 <template>
-  <VContainer>
-    <VRow>
-      <VCol cols="12" md="8" offset-md="2">
-        <h1 class="text-display-small mb-2">
-          Send Bulk SMS from CSV File with No Code
+  <VContainer class="pt-8">
+    <VRow class="mt-16">
+      <VCol cols="12" md="9">
+        <h1 class="text-h3 text-md-h2 mt-1">
+          Send multiple SMS messages from a CSV file with no code
         </h1>
-        <BlogInfo date="October 29, 2023" read-time="7 min read" />
-        <VDivider class="my-6" />
+        <BlogInfo date="October 29, 2023" readTime="7 min read" />
 
-        <p class="text-body-large mb-6">
+        <p class="text-subtitle-1 mt-2">
           Send personalized SMS messages to your users in bulk using your
           Android phone. The good news is, you don't have to write a single
           piece of code, just upload your CSV file and we will take care of the
           rest.
         </p>
 
-        <h2 class="text-headline-medium mb-4">What is a CSV file?</h2>
-        <p class="text-body-large mb-6">
-          CSV stands for Comma-Separated Values. It is a simple file format
-          where each row is on a new line and each column is separated by a
-          comma. CSV files can be opened and edited in tools like Microsoft
-          Excel, OpenOffice, Google Sheets, or even a plain text editor.
+        <h3 class="text-h4 mt-8 mb-2">What is a CSV file</h3>
+        <p>
+          CSV is an abbreviation for comma-separated values. A CSV file allows
+          data to be saved in a table structured format using a comma
+          <code>,</code> to separate the various cells of a table and a new line
+          to separate the various rows in the table. CSV files can be used with
+          any spreadsheet program, such as Microsoft Excel, Open Office Calc, or
+          Google Sheets.
         </p>
 
-        <h2 class="text-headline-medium mb-4">Prerequisites</h2>
-        <ul class="text-body-large pl-6 mb-6">
-          <li>Basic understanding of CSV files</li>
-          <li>An Android phone</li>
+        <h3 class="text-h4 mt-8 mb-2">Prerequisites</h3>
+        <ul>
+          <li>Basic understanding of CSV files.</li>
+          <li>An Android phone.</li>
         </ul>
 
-        <h2 class="text-headline-medium mb-4">Step 1: Get your API Key</h2>
-        <p class="text-body-large mb-6">
+        <h3 class="text-h4 mt-8 mb-2">Step 1: Get your API Key</h3>
+        <p>
           Create an account on
-          <a href="https://httpsms.com" target="_blank" rel="noopener"
-            >httpsms.com</a
+          <NuxtLink class="text-decoration-none" to="/">httpsms.com</NuxtLink>
+          and copy your API key from the settings page
+          <NuxtLink class="text-decoration-none" to="/settings"
+            >https://httpsms.com/settings</NuxtLink
           >
-          and copy your API key from the
-          <a href="https://httpsms.com/settings" target="_blank" rel="noopener"
-            >settings page</a
-          >.
         </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms.com settings page"
+          src="/img/blog/forward-incoming-sms-from-phone-to-webhook/settings.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">
+        <h3 class="text-h4 mb-4 mt-16">
           Step 2: Install the httpSMS android app
-        </h2>
-        <p class="text-body-large mb-6">
-          Download the Android app from
+        </h3>
+        <p>
           <a
+            class="text-decoration-none"
             href="https://github.com/NdoleStudio/httpsms/releases/latest/download/HttpSms.apk"
-            target="_blank"
-            rel="noopener"
-            >https://github.com/NdoleStudio/httpsms/releases/latest/download/HttpSms.apk</a
+            >⬇️ Download and install</a
           >
-          and sign in using your API KEY.
+          the httpSMS android app on your phone and sign in using your API KEY
+          which you copied above. This app listens for SMS messages received on
+          your android phone.
         </p>
+        <VAlert type="info" variant="outlined">
+          Make sure to enter your phone number in the international format e.g
+          +18005550199 when authenticating with the httpSMS Android app.
+        </VAlert>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms android app"
+          height="800"
+          src="/img/blog/forward-incoming-sms-from-phone-to-webhook/android-app.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">Step 3: Edit your CSV file</h2>
-        <p class="text-body-large mb-6">
-          Download the httpSMS CSV template from
+        <h3 class="text-h4 mt-12">Step 3: Edit your CSV file</h3>
+        <p>
+          Download the
           <a
-            href="https://httpsms.com/templates/httpsms-bulk.csv"
-            target="_blank"
-            rel="noopener"
-            >https://httpsms.com/templates/httpsms-bulk.csv</a
+            class="text-decoration-none"
+            href="/templates/httpsms-bulk.csv"
+            download
+            >httpSMS CSV file template</a
           >
-          and edit it with spreadsheet software or a text editor. Fill in the
-          <strong>FromPhoneNumber</strong>, <strong>ToPhoneNumber</strong>, and
-          <strong>Content</strong> columns.
+          and edit it with your favorite spreadsheet software e.g Excel, Google
+          Sheets or even a text editor like notepad. Fill in the phone number
+          which you registered in httpSMS in the
+          <code>FromPhoneNumber</code> column and fill in the number of the
+          recipient of the SMS in the <code>ToPhoneNumber</code> column. Also
+          add the SMS which you want to send in the message in the
+          <code>Content</code> column.
         </p>
+        <VAlert type="info" variant="outlined" class="mt-2 mb-4">
+          Make sure to use the correct <code>FromPhoneNumber</code> from step 2
+          above in your CSV file
+        </VAlert>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms spreadsheet"
+          height="800"
+          src="/img/blog/send-bulk-sms-from-csv-file-with-no-code/httpms-spreedsheet.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">Send your SMS messages</h2>
-        <p class="text-body-large mb-6">
+        <h3 class="text-h4 mt-12">Step 3: Send the SMS Messages</h3>
+        <p>
           Visit the
-          <a
-            href="https://httpsms.com/bulk-messages"
-            target="_blank"
-            rel="noopener"
-            >Bulk Messages page</a
-          >
-          and upload your CSV file.
+          <NuxtLink class="text-decoration-none" to="/bulk-messages">
+            <VIcon
+              color="primary"
+              size="small"
+              class="mr-1"
+              :icon="mdiCommentTextMultipleOutline"
+            />
+            Bulk Messages
+          </NuxtLink>
+          page on httpSMS and upload your CSV file and send the your SMS
+          messages.
         </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="bulk csv upload"
+          height="800"
+          src="/img/blog/send-bulk-sms-from-csv-file-with-no-code/bulk-csv-upload.png"
+        />
 
-        <p class="text-body-large mb-6">
-          Don't hesitate to contact us if you face any issues sending bulk SMS
-          messages from your CSV files by following this tutorial. Until the
-          next time ✌️
+        <p class="mt-12">
+          Don't hesitate to
+          <a class="text-decoration-none" href="mailto:arnold@httpsms.com"
+            >contact us</a
+          >
+          if you face any issues sending bulk SMS messages from your CSV files
+          by following this tutorial.
         </p>
+        <p>Until the next time✌️</p>
 
         <BlogAuthorBio />
+        <VDivider class="mx-16" />
+        <div class="text-center mt-8 mb-4">
+          <BackButton />
+        </div>
       </VCol>
     </VRow>
   </VContainer>

--- a/web/app/pages/blog/send-sms-from-android-phone-with-python.vue
+++ b/web/app/pages/blog/send-sms-from-android-phone-with-python.vue
@@ -2,26 +2,58 @@
 definePageMeta({ layout: "website" });
 
 useHead({
-  title: "Send SMS from Android Phone with Python - httpSMS",
+  title: "Send an SMS from your Android phone with Python - httpSMS",
+  meta: [
+    {
+      property: "og:title",
+      content: "Send an SMS from your Android phone with Python",
+    },
+    {
+      property: "og:description",
+      content:
+        "Configure your Android phone as an SMS gateway to automate sending text messages with the Python programing language.",
+    },
+    {
+      property: "og:image",
+      content:
+        "https://httpsms.com/img/blog/send-sms-from-android-phone-with-python/header.png",
+    },
+    {
+      name: "twitter:card",
+      content: "summary_large_image",
+    },
+    {
+      property: "og:url",
+      content:
+        "https://httpsms.com/blog/send-sms-from-android-phone-with-python/",
+    },
+  ],
 });
 </script>
 
 <template>
-  <VContainer>
-    <VRow>
-      <VCol cols="12" md="8" offset-md="2">
-        <h1 class="text-display-small mb-2">
-          Send SMS from Android Phone with Python
-        </h1>
-        <BlogInfo date="June 03, 2023" read-time="6 min read" />
-        <VDivider class="my-6" />
+  <VContainer class="pt-8">
+    <VRow class="mt-16">
+      <VCol cols="12" md="9">
+        <VImg
+          style="border-radius: 4px"
+          alt="blog post header image"
+          src="/img/blog/send-sms-from-android-phone-with-python/header.png"
+        />
 
-        <p class="text-body-large mb-6">
+        <h1 class="text-h3 text-md-h2 mt-1">
+          Send an SMS from your Android phone with Python
+        </h1>
+        <BlogInfo date="June 03, 2023" readTime="6 min read" />
+
+        <p class="text-subtitle-1 mt-2">
           In an era dominated by social media, instant messaging apps, and
           ever-evolving communication technologies, it's easy to overlook the
           humble yet remarkably resilient Short Message Service (SMS). Since its
           inception in the 1990s, SMS has stood the test of time, remaining one
           of the most widely used and reliable means of mobile communication.
+        </p>
+        <p>
           Whether you're a business owner looking to optimize your communication
           strategy, a developer seeking to integrate SMS functionality into your
           applications, or simply intrigued by the enduring charm of SMS, this
@@ -29,40 +61,70 @@ useHead({
           messages.
         </p>
 
-        <h2 class="text-headline-medium mb-4">Prerequisites</h2>
-        <ul class="text-body-large pl-6 mb-6">
-          <li>Basic understanding of Python</li>
-          <li>An Android phone</li>
-          <li>Python installed on your computer</li>
+        <h3 class="text-h4 mt-8 mb-2">Prerequisites</h3>
+        <ul>
+          <li>Basic understanding of Python.</li>
+          <li>An Android phone.</li>
+          <li>
+            <a class="text-decoration-none" href="https://www.python.org/"
+              >Python</a
+            >
+            installed on your computer.
+          </li>
         </ul>
 
-        <h2 class="text-headline-medium mb-4">Step 1: Get your API Key</h2>
-        <p class="text-body-large mb-6">
+        <h3 class="text-h4 mt-8 mb-2">Step 1: Get your API Key</h3>
+        <p>
           Create an account on
-          <a href="https://httpsms.com" target="_blank" rel="noopener"
-            >httpsms.com</a
+          <NuxtLink class="text-decoration-none" to="/">httpsms.com</NuxtLink>
+          and copy your API key from the settings page
+          <NuxtLink class="text-decoration-none" to="/settings"
+            >https://httpsms.com/settings</NuxtLink
           >
-          and copy your API key from the
-          <a href="https://httpsms.com/settings" target="_blank" rel="noopener"
-            >settings page</a
-          >.
         </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms.com settings page"
+          src="/img/blog/forward-incoming-sms-from-phone-to-webhook/settings.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">
+        <h3 class="text-h4 mb-4 mt-16">
           Step 2: Install the httpSMS android app
-        </h2>
-        <p class="text-body-large mb-6">
-          Download the Android app from
+        </h3>
+        <p>
           <a
+            class="text-decoration-none"
             href="https://github.com/NdoleStudio/httpsms/releases/latest/download/HttpSms.apk"
-            target="_blank"
-            rel="noopener"
-            >https://github.com/NdoleStudio/httpsms/releases/latest/download/HttpSms.apk</a
+            >⬇️ Download and install</a
           >
-          and sign in using your API KEY.
+          the httpSMS android app on your phone and sign in using your API KEY
+          which you copied above. This app listens for SMS messages received on
+          your android phone.
         </p>
+        <VAlert type="info" variant="outlined">
+          Make sure to enter your phone number in the international format e.g
+          +18005550199 when authenticating with the httpSMS Android app.
+        </VAlert>
+        <VImg
+          style="border-radius: 4px"
+          alt="httpsms android app"
+          height="800"
+          src="/img/blog/forward-incoming-sms-from-phone-to-webhook/android-app.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">Step 3: Writing the code</h2>
+        <h3 class="text-h4 mt-12">Step 3: Writing the code</h3>
+        <p>
+          Now that you have setup your android phone correctly on httpSMS, you
+          can write the python code below in a new file named
+          <code>send_sms.py</code>. This code will send and SMS and after
+          running the script via your Android phone to the recipient phone
+          number specified in the <code>payload</code>.
+        </p>
+        <VAlert type="info" variant="outlined" class="mt-2 mb-4">
+          Make sure to use the correct <code>api_key</code> from step 1 and also
+          use the correct <code>to</code> and <code>from</code> phone numbers in
+          the <code>payload</code> variable.
+        </VAlert>
         <pre
           class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
         ><code class="language-python text-body-medium">import requests
@@ -87,22 +149,41 @@ payload = {
 response = requests.post(url, headers=headers, data=json.dumps(payload))
 
 print(json.dumps(response.json(), indent=4))</code></pre>
-        <p class="text-body-large mb-6">
-          Run the script with <code>python send_sms.py</code>.
+        <p>
+          Run the code above with the command
+          <code>python send_sms.py</code> and check the phone specified in the
+          <code>to</code> field of the <code>payload</code> to verify that the
+          message has been received successfully.
         </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="sms sent"
+          height="800"
+          src="/img/blog/send-sms-from-android-phone-with-python/sms-sent.png"
+        />
 
-        <p class="text-body-large mb-6">
+        <h3 class="text-h4 mt-12">Conclusion</h3>
+        <p>
           Congratulations, you have successfully configured your android phone
           to send SMS messages via python. You can now reuse this code to send
-          SMS messages from your python applications. If you are also interested
-          in forwarding incoming SMS from your android phone to your server,
-          checkout our SMS forwarding guide
-          <NuxtLink to="/blog/forward-incoming-sms-from-phone-to-webhook"
-            >here</NuxtLink
-          >. Until the next time ✌️
+          SMS messages from your python applications.
         </p>
+        <p>
+          If you are also interested in forwarding incoming SMS from your
+          android phone to your server, checkout our
+          <NuxtLink
+            class="text-decoration-none"
+            to="/blog/forward-incoming-sms-from-phone-to-webhook"
+            >SMS forwarding guide.</NuxtLink
+          >
+        </p>
+        <p>Until the next time✌️</p>
 
         <BlogAuthorBio />
+        <VDivider class="mx-16" />
+        <div class="text-center mt-8 mb-4">
+          <BackButton />
+        </div>
       </VCol>
     </VRow>
   </VContainer>

--- a/web/app/pages/blog/send-sms-from-android-phone-with-python.vue
+++ b/web/app/pages/blog/send-sms-from-android-phone-with-python.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { useDisplay } from "vuetify";
+
+const { mdAndUp } = useDisplay();
+
 definePageMeta({ layout: "website" });
 
 useHead({
@@ -41,12 +45,16 @@ useHead({
           src="/img/blog/send-sms-from-android-phone-with-python/header.png"
         />
 
-        <h1 class="text-h3 text-md-h2 mt-1">
+        <h1
+          :class="
+            mdAndUp ? 'text-display-medium mt-1' : 'text-display-small mt-1'
+          "
+        >
           Send an SMS from your Android phone with Python
         </h1>
         <BlogInfo date="June 03, 2023" readTime="6 min read" />
 
-        <p class="text-subtitle-1 mt-2">
+        <p class="text-body-large mt-2">
           In an era dominated by social media, instant messaging apps, and
           ever-evolving communication technologies, it's easy to overlook the
           humble yet remarkably resilient Short Message Service (SMS). Since its
@@ -61,7 +69,7 @@ useHead({
           messages.
         </p>
 
-        <h3 class="text-h4 mt-8 mb-2">Prerequisites</h3>
+        <h3 class="text-headline-large mt-8 mb-2">Prerequisites</h3>
         <ul>
           <li>Basic understanding of Python.</li>
           <li>An Android phone.</li>
@@ -73,7 +81,7 @@ useHead({
           </li>
         </ul>
 
-        <h3 class="text-h4 mt-8 mb-2">Step 1: Get your API Key</h3>
+        <h3 class="text-headline-large mt-8 mb-2">Step 1: Get your API Key</h3>
         <p>
           Create an account on
           <NuxtLink class="text-decoration-none" to="/">httpsms.com</NuxtLink>
@@ -88,7 +96,7 @@ useHead({
           src="/img/blog/forward-incoming-sms-from-phone-to-webhook/settings.png"
         />
 
-        <h3 class="text-h4 mb-4 mt-16">
+        <h3 class="text-headline-large mb-4 mt-16">
           Step 2: Install the httpSMS android app
         </h3>
         <p>
@@ -112,7 +120,7 @@ useHead({
           src="/img/blog/forward-incoming-sms-from-phone-to-webhook/android-app.png"
         />
 
-        <h3 class="text-h4 mt-12">Step 3: Writing the code</h3>
+        <h3 class="text-headline-large mt-12">Step 3: Writing the code</h3>
         <p>
           Now that you have setup your android phone correctly on httpSMS, you
           can write the python code below in a new file named
@@ -162,7 +170,7 @@ print(json.dumps(response.json(), indent=4))</code></pre>
           src="/img/blog/send-sms-from-android-phone-with-python/sms-sent.png"
         />
 
-        <h3 class="text-h4 mt-12">Conclusion</h3>
+        <h3 class="text-headline-large mt-12">Conclusion</h3>
         <p>
           Congratulations, you have successfully configured your android phone
           to send SMS messages via python. You can now reuse this code to send

--- a/web/app/pages/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier.vue
+++ b/web/app/pages/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier.vue
@@ -3,89 +3,169 @@ definePageMeta({ layout: "website" });
 
 useHead({
   title:
-    "Send SMS When New Row is Added to Google Sheets Using Zapier - httpSMS",
+    "Send an SMS message when a new row is added to Google Sheets using Zapier - httpSMS",
+  meta: [
+    {
+      property: "og:title",
+      content:
+        "Send an SMS message when a new row is added to Google Sheets using Zapier",
+    },
+    {
+      property: "og:description",
+      content:
+        "Automate sending personalized SMS messages each time a new row is added to your Google Sheets document using Zapier. You don't need to write any code to make this happen and you can personalize the SMS messages which are sent out.",
+    },
+    {
+      name: "twitter:card",
+      content: "summary_large_image",
+    },
+    {
+      property: "og:url",
+      content:
+        "https://httpsms.com/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier/",
+    },
+  ],
 });
 </script>
 
 <template>
-  <VContainer>
-    <VRow>
-      <VCol cols="12" md="8" offset-md="2">
-        <h1 class="text-display-small mb-2">
-          Send SMS When New Row is Added to Google Sheets Using Zapier
+  <VContainer class="pt-8">
+    <VRow class="mt-16">
+      <VCol cols="12" md="9">
+        <h1 class="text-h3 text-md-h2 mt-1">
+          Send an SMS message when a new row is added to Google Sheets using
+          Zapier
         </h1>
-        <BlogInfo date="October 29, 2023" read-time="5 min read" />
-        <VDivider class="my-6" />
+        <BlogInfo date="October 29, 2023" readTime="5 min read" />
 
-        <p class="text-body-large mb-6">
+        <p class="text-subtitle-1 mt-2">
           Automate sending personalized SMS messages each time a new row is
           added to your Google Sheets document using Zapier. You don't need to
           write any code to make this happen and you can personalize the SMS
           messages which are sent out.
         </p>
 
-        <h2 class="text-headline-medium mb-4">Prerequisites</h2>
-        <ul class="text-body-large pl-6 mb-6">
-          <li>Basic understanding of Google Sheets</li>
-          <li>Basic understanding of Zapier</li>
+        <h3 class="text-h4 mt-8 mb-2">Prerequisites</h3>
+        <ul>
+          <li>Basic understanding of Google Sheets.</li>
+          <li>Basic understanding of Zapier.</li>
           <li>
             An account on
-            <a href="https://httpsms.com" target="_blank" rel="noopener"
-              >httpsms.com</a
+            <NuxtLink class="text-decoration-none" to="/login"
+              >httpsms.com</NuxtLink
             >
           </li>
         </ul>
 
-        <h2 class="text-headline-medium mb-4">
-          Step 1: Create trigger on Zapier
-        </h2>
-        <p class="text-body-large mb-6">
-          In Zapier, create a new Zap and select Google Sheets as your trigger
-          app. Choose the <strong>New Spreadsheet Row</strong> event, then
-          select the Spreadsheet and the correct Worksheet you want to watch for
-          new rows.
+        <h3 class="text-h4 mt-8 mb-2">Step 1: Create trigger on Zapier</h3>
+        <p>
+          Create a new Zap on Zapier and select Google Sheets as the trigger.
+          The event name should be <b>"New Spreadsheet Row"</b> if you want to
+          send an SMS message every time a new row is added to your Google
+          Sheets document.
         </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="zapier trigger"
+          src="/img/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier/zapier-trigger.png"
+        />
+        <p class="mt-8">
+          On the Zap, select the <b>Spreadsheet</b> which you have on google
+          drive and make sure to select the correct <b>Worksheet</b>.
+        </p>
+        <VAlert type="info" variant="outlined">
+          In the sample spreadsheet below, we are mimicking an e-commerce store.
+          The first column contains the name of the customer, the second column
+          is the name of the product which was bought and the third column is
+          the phone number of the customer who made the purchase. You can use
+          your own custom spreadsheet with your own set of columns.
+        </VAlert>
+        <VImg
+          style="border-radius: 4px"
+          alt="google sheets"
+          src="/img/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier/google-sheets.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">
-          Step 2: Create an action on Zapier
-        </h2>
-        <p class="text-body-large mb-4">
-          Add a new action step and select
-          <strong>Webhooks by Zapier</strong> as the action app. Choose the
-          <strong>Custom Request</strong> event and configure it with the
-          following values:
+        <h3 class="text-h4 mt-8 mb-2">Step 2: Create an action on Zapier</h3>
+        <p>
+          An action is what happens after the trigger. In this case, we want to
+          send an SMS message to the customer who made the purchase. Select
+          <b>Webhooks By Zapier</b> as the action app and select
+          <b>Custom Request</b> as the action event.
         </p>
-        <ul class="text-body-large pl-6 mb-4">
-          <li>Method: Post</li>
-          <li>URL: https://api.httpsms.com/v1/messages/send</li>
-          <li>Data Pass-Through: false</li>
-        </ul>
+        <VImg
+          style="border-radius: 4px"
+          alt="zapier action event"
+          src="/img/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier/zapier-action-event.png"
+        />
+        <p class="mt-8">
+          On the <b>Action</b> section in Zapier, set the Method to
+          <code>Post</code>. Set the URL to
+          <code>https://api.httpsms.com/v1/messages/send</code>. Set the
+          <code>Data Pass-Through</code> to <code>false</code>. In the Data
+          field, add the following JSON payload.
+        </p>
         <pre
-          v-pre
           class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
         ><code class="language-json text-body-medium">{
-  "content": "Hi {{1.Name}}, your order is ready for pickup.",
-  "from": "{{1.FromPhoneNumber}}",
-  "to": "{{1.ToPhoneNumber}}"
+  "content": "Hello [Name]\nThanks for ordering [Product] via our shopify store. Your order will be shipped today!",
+  "from": "+18005550199",
+  "to": "[ToPhoneNumber]"
 }</code></pre>
-        <pre
-          v-pre
-          class="pa-4 mb-6 rounded bg-surface-variant overflow-x-auto"
-        ><code class="language-json text-body-medium">{
-  "x-api-key": "YOUR_API_KEY",
-  "Content-Type": "application/json"
-}</code></pre>
+        <VAlert type="info" variant="outlined" class="mt-4">
+          In the JSON message above, we are mimicking an e-commerce store. The
+          <code>[Name]</code> variable contains the name of the customer on the
+          spreadsheet. <code>[Product]</code> contains the name of the product
+          which was bought and <code>[ToPhoneNumber]</code> contains the phone
+          number of the customer who made the purchase. You can use your own
+          custom message with your own set of variables according to your
+          spreadsheet. Change the <code>from</code> field to the phone number
+          which you registered on httpsms.com.
+        </VAlert>
+        <p class="mt-8">
+          On the headers section add a new header called
+          <code>x-api-key</code> and the value of this header should be your API
+          key on
+          <NuxtLink class="text-decoration-none" to="/settings"
+            >httpsms.com</NuxtLink
+          >
+          and you can copy your API key from the settings page
+          <NuxtLink class="text-decoration-none" to="/settings"
+            >https://httpsms.com/settings</NuxtLink
+          >.
+        </p>
+        <p>
+          Also add a new header called <code>Content-Type</code> and the value
+          of this header should be <code>application/json</code>
+        </p>
+        <p>
+          The final configuration of the action should look like the screenshot
+          below.
+        </p>
+        <VImg
+          style="border-radius: 4px"
+          alt="zapier action action"
+          src="/img/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier/zapier-action-action.png"
+        />
 
-        <h2 class="text-headline-medium mb-4">Conclusion</h2>
-        <p class="text-body-large mb-6">
+        <h3 class="text-h4 mb-4 mt-16">Conclusion</h3>
+        <p>
           Publish your zap and you will automatically trigger httpsms to send an
           SMS to your customer when ever you add a new row in the google sheet.
-          Don't hesitate to contact us if you face any issues configuring your
-          zap to send SMS messages from your Google Sheets by following this
-          tutorial. Until the next time ✌️
+          Don't hesitate to
+          <a class="text-decoration-none" href="mailto:arnold@httpsms.com"
+            >contact us</a
+          >
+          if you face any issues configuring your zap to send SMS messages from
+          your Google Sheets by following this tutorial.
         </p>
+        <p>Until the next time✌️</p>
 
         <BlogAuthorBio />
+        <VDivider class="mx-16" />
+        <div class="text-center mt-8 mb-4">
+          <BackButton />
+        </div>
       </VCol>
     </VRow>
   </VContainer>

--- a/web/app/pages/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier.vue
+++ b/web/app/pages/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { useDisplay } from "vuetify";
+
+const { mdAndUp } = useDisplay();
+
 definePageMeta({ layout: "website" });
 
 useHead({
@@ -32,20 +36,24 @@ useHead({
   <VContainer class="pt-8">
     <VRow class="mt-16">
       <VCol cols="12" md="9">
-        <h1 class="text-h3 text-md-h2 mt-1">
+        <h1
+          :class="
+            mdAndUp ? 'text-display-medium mt-1' : 'text-display-small mt-1'
+          "
+        >
           Send an SMS message when a new row is added to Google Sheets using
           Zapier
         </h1>
         <BlogInfo date="October 29, 2023" readTime="5 min read" />
 
-        <p class="text-subtitle-1 mt-2">
+        <p class="text-body-large mt-2">
           Automate sending personalized SMS messages each time a new row is
           added to your Google Sheets document using Zapier. You don't need to
           write any code to make this happen and you can personalize the SMS
           messages which are sent out.
         </p>
 
-        <h3 class="text-h4 mt-8 mb-2">Prerequisites</h3>
+        <h3 class="text-headline-large mt-8 mb-2">Prerequisites</h3>
         <ul>
           <li>Basic understanding of Google Sheets.</li>
           <li>Basic understanding of Zapier.</li>
@@ -57,7 +65,9 @@ useHead({
           </li>
         </ul>
 
-        <h3 class="text-h4 mt-8 mb-2">Step 1: Create trigger on Zapier</h3>
+        <h3 class="text-headline-large mt-8 mb-2">
+          Step 1: Create trigger on Zapier
+        </h3>
         <p>
           Create a new Zap on Zapier and select Google Sheets as the trigger.
           The event name should be <b>"New Spreadsheet Row"</b> if you want to
@@ -86,7 +96,9 @@ useHead({
           src="/img/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier/google-sheets.png"
         />
 
-        <h3 class="text-h4 mt-8 mb-2">Step 2: Create an action on Zapier</h3>
+        <h3 class="text-headline-large mt-8 mb-2">
+          Step 2: Create an action on Zapier
+        </h3>
         <p>
           An action is what happens after the trigger. In this case, we want to
           send an SMS message to the customer who made the purchase. Select
@@ -148,7 +160,7 @@ useHead({
           src="/img/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier/zapier-action-action.png"
         />
 
-        <h3 class="text-h4 mb-4 mt-16">Conclusion</h3>
+        <h3 class="text-headline-large mb-4 mt-16">Conclusion</h3>
         <p>
           Publish your zap and you will automatically trigger httpsms to send an
           SMS to your customer when ever you add a new row in the google sheet.

--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -105,7 +105,7 @@ const planYearlyMonthlyPrice = computed(
             </VBtn>
           </div>
           <p class="text-body-medium mt-2">
-            ✅Trusted by <b>23,273+</b> users who send/receive more than
+            ⚡Trusted by <b>23,273+</b> users who send/receive more than
             <b>500,000</b> messages per month.
           </p>
           <div class="mt-4" :class="{ 'text-center': mdAndDown }">

--- a/web/app/pages/privacy-policy/index.vue
+++ b/web/app/pages/privacy-policy/index.vue
@@ -172,8 +172,16 @@ useHead({
         <p class="text-body-large mb-10">
           If you have any questions or suggestions about our Privacy Policy, do
           not hesitate to contact us at
-          <a href="mailto:support@httpsms.com">support@httpsms.com</a>.
+          <a
+            class="text-decoration-none font-weight-bold"
+            href="mailto:support@httpsms.com"
+            >support@httpsms.com</a
+          >.
         </p>
+        <VDivider class="mx-16" />
+        <div class="text-center mt-8 mb-4">
+          <BackButton />
+        </div>
       </VCol>
     </VRow>
   </VContainer>

--- a/web/app/pages/terms-and-conditions/index.vue
+++ b/web/app/pages/terms-and-conditions/index.vue
@@ -148,8 +148,16 @@ useHead({
         <p class="text-body-large mb-10">
           If you have any questions or suggestions about our Terms and
           Conditions, do not hesitate to contact us at
-          <a href="mailto:support@httpsms.com">support@httpsms.com</a>.
+          <a
+            class="text-decoration-none font-weight-bold"
+            href="mailto:support@httpsms.com"
+            >support@httpsms.com</a
+          >.
         </p>
+        <VDivider class="mx-16" />
+        <div class="text-center mt-8 mb-4">
+          <BackButton />
+        </div>
       </VCol>
     </VRow>
   </VContainer>


### PR DESCRIPTION
## Summary

Restores word-for-word content from the original Nuxt 2/Vuetify 2 version on all statically generated pages, while keeping Vuetify 4 component syntax.

## Problem

During the Nuxt 4 + Vuetify 4 migration, blog posts and static pages had their content altered:
- Titles were simplified/changed
- Images were removed
- Warning/info alerts were dropped
- Code blocks (with JS/Go tabs) were simplified to single-language snippets
- Internal links (\NuxtLink\) were removed or converted to external links
- Bold text, \<code>\ tags, and formatting were lost
- Meta tags (OG, Twitter) were incomplete
- Footer elements (BackButton, Divider) were removed

## Fix

Compared each page against \ackup/web-nuxt2-vuetify2\ branch and restored all original content using Vuetify 4 syntax:

### Pages Fixed (11 total)
- **Blog posts (7):** grant-sms-permissions, e2e-encryption, forward-webhook, excel, csv, python, zapier
- **Blog index:** Corrected titles, descriptions, subtitle
- **Homepage:** Fixed emoji
- **Privacy policy:** Added BackButton + styled contact link
- **Terms and conditions:** Added BackButton + styled contact link

### What was restored
- ✅ Original titles (word-for-word)
- ✅ All images (\VImg\ with \/img/blog/\ paths)
- ✅ Alert boxes (\VAlert\ type=warning/info)
- ✅ Code blocks with tabbed JS/Go examples (\VTabs\/\VTabsWindow\)
- ✅ Internal links (\NuxtLink\)
- ✅ Bold text, \<code>\ tags, formatting
- ✅ Full meta tags (og:title, og:description, og:image, twitter:card, og:url)
- ✅ Footer (BlogAuthorBio + VDivider + BackButton)

## Testing
- Build passes (\pnpm build\ ✅)