### PR TITLE
feat: add USSD management feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ Sometimes it happens that the phone doesn't get the push notification in time an
 possible to set a timeout for which a message is valid and if a message becomes expired after the timeout elapses, you
 will be notified.
 
+### USSD Support
+
+You can send and receive USSD (Unstructured Supplementary Service Data) messages through your Android phone. 
+USSD sessions are fully tracked with status management (pending, active, completed, failed, timed-out) and 
+support both MO-to-App (mobile originated) and App-to-MO (application originated) directions.
+
+```go
+// Sending a USSD response using Go
+client := httpsms.New(httpsms.WithAPIKey(/* API Key */))
+
+client.USSD.Send(context.Background(), &httpsms.USSDSendParams{
+    To:        "+18005550199",
+    From:      "+18005550100",
+    Content:   "Welcome to USSD menu",
+    SessionID: "USSDSESSION12345",
+})
+```
+
 ## API Clients
 
 - [x] Go: https://github.com/NdoleStudio/httpsms-go

--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -156,6 +156,9 @@ func NewContainer(projectID string, version string) (container *Container) {
 	container.RegisterPhoneAPIKeyRoutes()
 	container.RegisterPhoneAPIKeyListeners()
 
+	container.RegisterUSSDListeners()
+	container.RegisterUSSDRoutes()
+
 	container.RegisterMarketingListeners()
 	container.RegisterWebsocketListeners()
 
@@ -412,6 +415,10 @@ ALTER TABLE discords ADD CONSTRAINT IF NOT EXISTS uni_discords_server_id CHECK (
 
 	if err = db.AutoMigrate(&entities.PhoneAPIKey{}); err != nil {
 		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.PhoneAPIKey{})))
+	}
+
+	if err = db.AutoMigrate(&entities.USSD{}); err != nil {
+		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.USSD{})))
 	}
 
 	return container.db
@@ -1791,6 +1798,60 @@ func (container *Container) UserRistrettoCache() *ristretto.Cache[string, entiti
 	}
 	container.userRistrettoCache = ristrettoCache
 	return ristrettoCache
+}
+
+// USSDRepository creates a new instance of repositories.USSDRepository
+func (container *Container) USSDRepository() repositories.USSDRepository {
+	container.logger.Debug("creating GORM repositories.USSDRepository")
+	return repositories.NewGormUSSDRepository(
+		container.Logger(),
+		container.Tracer(),
+		container.DB(),
+	)
+}
+
+// USSDService creates a new instance of services.USSDService
+func (container *Container) USSDService() *services.USSDService {
+	container.logger.Debug("creating services.USSDService")
+	return services.NewUSSDService(
+		container.Logger(),
+		container.Tracer(),
+		container.USSDRepository(),
+		container.EventDispatcher(),
+	)
+}
+
+// USSDHandlerValidator creates a new instance of validators.USSDHandlerValidator
+func (container *Container) USSDHandlerValidator() *validators.USSDHandlerValidator {
+	container.logger.Debug("creating validators.USSDHandlerValidator")
+	return validators.NewUSSDHandlerValidator(
+		container.Logger(),
+		container.Tracer(),
+	)
+}
+
+// USSDHandler creates a new instance of handlers.USSDHandler
+func (container *Container) USSDHandler() *handlers.USSDHandler {
+	container.logger.Debug("creating handlers.USSDHandler")
+	return handlers.NewUSSDHandler(
+		container.Logger(),
+		container.Tracer(),
+		container.USSDService(),
+		container.USSDHandlerValidator(),
+	)
+}
+
+// RegisterUSSDRoutes registers routes for the /ussd prefix
+func (container *Container) RegisterUSSDRoutes() {
+	container.logger.Debug(fmt.Sprintf("registering %T routes", &handlers.USSDHandler{}))
+	container.USSDHandler().RegisterRoutes(container.App(), container.AuthenticatedMiddleware())
+	container.USSDHandler().RegisterPhoneAPIKeyRoutes(container.App(), container.PhoneAPIKeyMiddleware(), container.AuthenticatedMiddleware())
+}
+
+// RegisterUSSDListeners registers event listeners for USSD events
+func (container *Container) RegisterUSSDListeners() {
+	container.logger.Debug(fmt.Sprintf("registering listeners for USSD"))
+	// USSD events are handled directly by the service, no additional listeners needed
 }
 
 // InitializeTraceProvider initializes the open telemetry trace provider

--- a/api/pkg/entities/ussd.go
+++ b/api/pkg/entities/ussd.go
@@ -1,0 +1,116 @@
+package entities
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// USSDType represents the type of USSD session
+type USSDType string
+
+const (
+	// USSDTypeRequest is a USSD request from a mobile phone
+	USSDTypeRequest = USSDType("request")
+	// USSDTypeResponse is a USSD response from the application
+	USSDTypeResponse = USSDType("response")
+)
+
+// USSDDirection represents the direction of USSD communication
+type USSDDirection string
+
+const (
+	// USSDDirectionMoToApp means the USSD message comes from the mobile phone to the application
+	USSDDirectionMoToApp = USSDDirection("MO-to-App")
+	// USSDDirectionAppToMO means the USSD message goes from the application to the mobile phone
+	USSDDirectionAppToMO = USSDDirection("App-to-MO")
+)
+
+// USSDStatus represents the status of a USSD session
+type USSDStatus string
+
+const (
+	// USSDStatusPending means the USSD session is pending
+	USSDStatusPending = USSDStatus("pending")
+	// USSDStatusActive means the USSD session is active
+	USSDStatusActive = USSDStatus("active")
+	// USSDStatusCompleted means the USSD session is completed
+	USSDStatusCompleted = USSDStatus("completed")
+	// USSDStatusFailed means the USSD session has failed
+	USSDStatusFailed = USSDStatus("failed")
+	// USSDStatusTimedOut means the USSD session has timed out
+	USSDStatusTimedOut = USSDStatus("timed-out")
+)
+
+// USSD represents a USSD session on the phone
+type USSD struct {
+	ID             uuid.UUID    `json:"id" gorm:"primaryKey;type:uuid;" example:"32343a19-da5e-4b1b-a767-3298a73703cb"`
+	UserID         UserID       `json:"user_id" gorm:"index:idx_ussds__user_id" example:"WB7DRDWrJZRGbYrv2CKGkqbzvqdC"`
+	PhoneID        uuid.UUID    `json:"phone_id" gorm:"type:uuid;index:idx_ussds__phone_id" example:"32343a19-da5e-4b1b-a767-3298a73703cb"`
+	Owner          string       `json:"owner" example:"+18005550199"`
+	SessionID      string       `json:"session_id" example:"USSDSESSION12345" gorm:"index:idx_ussds__session_id"`
+	Type           USSDType     `json:"type" example:"request"`
+	Direction      USSDDirection `json:"direction" example:"MO-to-App"`
+	Content        string       `json:"content" example:"*123#"`
+	Response       *string      `json:"response" example:"Welcome to USSD menu" validate:"optional"`
+	Status         USSDStatus   `json:"status" example:"pending" gorm:"default:pending"`
+	SIM            SIM          `json:"sim" example:"SIM1"`
+	Timestamp      time.Time    `json:"timestamp" example:"2022-06-05T14:26:09.527976+03:00"`
+	CreatedAt      time.Time    `json:"created_at" example:"2022-06-05T14:26:02.302718+03:00"`
+	UpdatedAt      time.Time    `json:"updated_at" example:"2022-06-05T14:26:10.303278+03:00"`
+}
+
+// TableName specifies the table name for the USSD entity
+func (USSD) TableName() string {
+	return "ussds"
+}
+
+// IsActive checks if the USSD session is active
+func (ussd *USSD) IsActive() bool {
+	return ussd.Status == USSDStatusActive
+}
+
+// IsPending checks if the USSD session is pending
+func (ussd *USSD) IsPending() bool {
+	return ussd.Status == USSDStatusPending
+}
+
+// IsCompleted checks if the USSD session is completed
+func (ussd *USSD) IsCompleted() bool {
+	return ussd.Status == USSDStatusCompleted
+}
+
+// IsFailed checks if the USSD session has failed
+func (ussd *USSD) IsFailed() bool {
+	return ussd.Status == USSDStatusFailed
+}
+
+// IsTimedOut checks if the USSD session has timed out
+func (ussd *USSD) IsTimedOut() bool {
+	return ussd.Status == USSDStatusTimedOut
+}
+
+// MarkActive marks the USSD session as active
+func (ussd *USSD) MarkActive() *USSD {
+	ussd.Status = USSDStatusActive
+	return ussd
+}
+
+// MarkCompleted marks the USSD session as completed
+func (ussd *USSD) MarkCompleted(response string) *USSD {
+	ussd.Status = USSDStatusCompleted
+	ussd.Response = &response
+	return ussd
+}
+
+// MarkFailed marks the USSD session as failed
+func (ussd *USSD) MarkFailed() *USSD {
+	ussd.Status = USSDStatusFailed
+	return ussd
+}
+
+// MarkTimedOut marks the USSD session as timed out
+func (ussd *USSD) MarkTimedOut() *USSD {
+	ussd.Status = USSDStatusTimedOut
+	return ussd
+}

--- a/api/pkg/events/ussd_received_event.go
+++ b/api/pkg/events/ussd_received_event.go
@@ -1,0 +1,24 @@
+package events
+
+import (
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+
+	"github.com/google/uuid"
+)
+
+// EventTypeUSSDReceived is emitted when a USSD request is received from a mobile phone
+const EventTypeUSSDReceived = "ussd.phone.received"
+
+// USSDReceivedPayload is the payload of the EventTypeUSSDReceived event
+type USSDReceivedPayload struct {
+	USSDID    uuid.UUID       `json:"ussd_id"`
+	UserID    entities.UserID `json:"user_id"`
+	PhoneID   uuid.UUID       `json:"phone_id"`
+	Owner     string          `json:"owner"`
+	SessionID string          `json:"session_id"`
+	Content   string          `json:"content"`
+	SIM       entities.SIM    `json:"sim"`
+	Timestamp time.Time       `json:"timestamp"`
+}

--- a/api/pkg/events/ussd_sent_event.go
+++ b/api/pkg/events/ussd_sent_event.go
@@ -1,0 +1,24 @@
+package events
+
+import (
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+
+	"github.com/google/uuid"
+)
+
+// EventTypeUSSDResponse is emitted when a USSD response is sent to a mobile phone
+const EventTypeUSSDResponse = "ussd.phone.sent"
+
+// USSDResponsePayload is the payload of the EventTypeUSSDResponse event
+type USSDResponsePayload struct {
+	USSDID    uuid.UUID       `json:"ussd_id"`
+	UserID    entities.UserID `json:"user_id"`
+	PhoneID   uuid.UUID       `json:"phone_id"`
+	Owner     string          `json:"owner"`
+	SessionID string          `json:"session_id"`
+	Response  string          `json:"response"`
+	SIM       entities.SIM    `json:"sim"`
+	Timestamp time.Time       `json:"timestamp"`
+}

--- a/api/pkg/handlers/ussd_handler.go
+++ b/api/pkg/handlers/ussd_handler.go
@@ -1,0 +1,245 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/requests"
+	"github.com/NdoleStudio/httpsms/pkg/services"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/httpsms/pkg/validators"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/palantir/stacktrace"
+)
+
+// USSDHandler handles USSD http requests.
+type USSDHandler struct {
+	handler
+	logger    telemetry.Logger
+	tracer    telemetry.Tracer
+	service   *services.USSDService
+	validator *validators.USSDHandlerValidator
+}
+
+// NewUSSDHandler creates a new USSDHandler
+func NewUSSDHandler(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+	service *services.USSDService,
+	validator *validators.USSDHandlerValidator,
+) (h *USSDHandler) {
+	return &USSDHandler{
+		logger:    logger.WithService(fmt.Sprintf("%T", h)),
+		tracer:    tracer,
+		validator: validator,
+		service:   service,
+	}
+}
+
+// RegisterRoutes registers the routes for the USSDHandler
+func (h *USSDHandler) RegisterRoutes(router fiber.Router, middlewares ...fiber.Handler) {
+	h.register(router, fiber.MethodPost, "/v1/ussd/receive", middlewares, h.Receive)
+	h.register(router, fiber.MethodPost, "/v1/ussd/send", middlewares, h.Send)
+	h.register(router, fiber.MethodGet, "/v1/ussd", middlewares, h.Index)
+	h.register(router, fiber.MethodDelete, "/v1/ussd/:ussdID", middlewares, h.Delete)
+}
+
+// RegisterPhoneAPIKeyRoutes registers the phone API key routes for the USSDHandler
+func (h *USSDHandler) RegisterPhoneAPIKeyRoutes(router fiber.Router, middlewares ...fiber.Handler) {
+	h.register(router, fiber.MethodPost, "/v1/ussd/receive", middlewares, h.Receive)
+	h.register(router, fiber.MethodPost, "/v1/ussd/send", middlewares, h.Send)
+}
+
+// Receive handles incoming USSD requests from a mobile phone
+// @Summary      Receive USSD request
+// @Description  Receive a USSD request from a mobile phone
+// @Security	 ApiKeyAuth
+// @Tags         USSD
+// @Accept       json
+// @Produce      json
+// @Param        payload   	body 		requests.USSDReceive  			true 	"USSD request payload"
+// @Success      200 		{object}	responses.USSDResponse
+// @Failure      400		{object}	responses.BadRequest
+// @Failure 	 401    	{object}	responses.Unauthorized
+// @Failure      422		{object}	responses.UnprocessableEntity
+// @Failure      500		{object}	responses.InternalServerError
+// @Router       /ussd/receive [post]
+func (h *USSDHandler) Receive(c fiber.Ctx) error {
+	ctx, span := h.tracer.StartFromFiberCtx(c)
+	defer span.End()
+
+	ctxLogger := h.tracer.CtxLogger(h.logger, span)
+
+	var request requests.USSDReceive
+	if err := c.Bind().Body(&request); err != nil {
+		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
+		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		return h.responseBadRequest(c, err)
+	}
+
+	if errors := h.validator.ValidateReceive(ctx, request.Sanitize()); len(errors) != 0 {
+		msg := fmt.Sprintf("validation errors [%s], while receiving USSD [%+#v]", spew.Sdump(errors), request)
+		ctxLogger.Warn(stacktrace.NewError(msg))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while receiving USSD")
+	}
+
+	authUser := h.userFromContext(c)
+
+	ussd, err := h.service.Receive(ctx, request.ToUSSDReceiveParams(authUser.ID, c.OriginalURL()), uuid.Nil)
+	if err != nil {
+		msg := fmt.Sprintf("cannot receive USSD with params [%+#v]", request)
+		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseOK(c, "USSD request received successfully", ussd)
+}
+
+// Send handles sending a USSD response to a mobile phone
+// @Summary      Send USSD response
+// @Description  Send a USSD response to a mobile phone
+// @Security	 ApiKeyAuth
+// @Tags         USSD
+// @Accept       json
+// @Produce      json
+// @Param        payload   	body 		requests.USSDSend  			true 	"USSD response payload"
+// @Success      200 		{object}	responses.USSDResponse
+// @Failure      400		{object}	responses.BadRequest
+// @Failure 	 401    	{object}	responses.Unauthorized
+// @Failure      422		{object}	responses.UnprocessableEntity
+// @Failure      500		{object}	responses.InternalServerError
+// @Router       /ussd/send [post]
+func (h *USSDHandler) Send(c fiber.Ctx) error {
+	ctx, span := h.tracer.StartFromFiberCtx(c)
+	defer span.End()
+
+	ctxLogger := h.tracer.CtxLogger(h.logger, span)
+
+	var request requests.USSDSend
+	if err := c.Bind().Body(&request); err != nil {
+		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
+		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		return h.responseBadRequest(c, err)
+	}
+
+	if errors := h.validator.ValidateSend(ctx, request.Sanitize()); len(errors) != 0 {
+		msg := fmt.Sprintf("validation errors [%s], while sending USSD [%+#v]", spew.Sdump(errors), request)
+		ctxLogger.Warn(stacktrace.NewError(msg))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while sending USSD")
+	}
+
+	authUser := h.userFromContext(c)
+
+	ussd, err := h.service.Send(ctx, request.ToUSSDSendParams(authUser.ID, c.OriginalURL()))
+	if err != nil {
+		msg := fmt.Sprintf("cannot send USSD with params [%+#v]", request)
+		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseOK(c, "USSD response sent successfully", ussd)
+}
+
+// Index returns the USSD session history for a user
+// @Summary      Get USSD session history
+// @Description  Get list of USSD sessions for a user
+// @Security	 ApiKeyAuth
+// @Tags         USSD
+// @Accept       json
+// @Produce      json
+// @Param        skip		query  int  	false	"number of USSD sessions to skip"		minimum(0)
+// @Param        query		query  string  	false 	"filter USSD sessions containing query"
+// @Param        limit		query  int  	false	"number of USSD sessions to return"		minimum(1)	maximum(20)
+// @Param        phone_id	query  string  	false 	"filter USSD sessions by phone ID"
+// @Success      200 		{object}	responses.USSDsResponse
+// @Failure      400		{object}	responses.BadRequest
+// @Failure 	 401    	{object}	responses.Unauthorized
+// @Failure      422		{object}	responses.UnprocessableEntity
+// @Failure      500		{object}	responses.InternalServerError
+// @Router       /ussd [get]
+func (h *USSDHandler) Index(c fiber.Ctx) error {
+	ctx, span := h.tracer.StartFromFiberCtx(c)
+	defer span.End()
+
+	ctxLogger := h.tracer.CtxLogger(h.logger, span)
+
+	var request requests.USSDIndex
+	if err := c.Bind().Query(&request); err != nil {
+		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
+		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		return h.responseBadRequest(c, err)
+	}
+
+	sanitized := request.Sanitize()
+	if errors := h.validator.ValidateIndex(ctx, sanitized); len(errors) != 0 {
+		msg := fmt.Sprintf("validation errors [%s], while fetching USSD sessions [%+#v]", spew.Sdump(errors), sanitized)
+		ctxLogger.Warn(stacktrace.NewError(msg))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching USSD sessions")
+	}
+
+	var phoneID *uuid.UUID
+	if sanitized.PhoneID != "" {
+		pid, err := uuid.Parse(sanitized.PhoneID)
+		if err == nil {
+			phoneID = &pid
+		}
+	}
+
+	ussds, err := h.service.Index(ctx, h.userFromContext(c), sanitized.ToIndexParams(), phoneID)
+	if err != nil {
+		msg := fmt.Sprintf("cannot index USSD sessions with params [%+#v]", sanitized)
+		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseOK(c, fmt.Sprintf("fetched %d %s", len(*ussds), h.pluralize("USSD session", len(*ussds))), ussds)
+}
+
+// Delete a USSD session
+// @Summary      Delete USSD session
+// @Description  Delete a USSD session from the database
+// @Security	 ApiKeyAuth
+// @Tags         USSD
+// @Accept       json
+// @Produce      json
+// @Param 		 ussdID 	path		string 							true 	"ID of the USSD session"	default(32343a19-da5e-4b1b-a767-3298a73703ca)
+// @Success      204		{object}    responses.NoContent
+// @Failure      400		{object}	responses.BadRequest
+// @Failure 	 401    	{object}	responses.Unauthorized
+// @Failure      422		{object}	responses.UnprocessableEntity
+// @Failure      500		{object}	responses.InternalServerError
+// @Router       /ussd/{ussdID} [delete]
+func (h *USSDHandler) Delete(c fiber.Ctx) error {
+	ctx, span := h.tracer.StartFromFiberCtx(c)
+	defer span.End()
+
+	ctxLogger := h.tracer.CtxLogger(h.logger, span)
+
+	request := requests.USSDDelete{USSDID: c.Params("ussdID")}
+	if errors := h.validator.ValidateDelete(ctx, request); len(errors) != 0 {
+		msg := fmt.Sprintf("validation errors [%s], while deleting USSD session [%+#v]", spew.Sdump(errors), request)
+		ctxLogger.Warn(stacktrace.NewError(msg))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while deleting USSD session")
+	}
+
+	ussdID, err := uuid.Parse(request.USSDID)
+	if err != nil {
+		msg := fmt.Sprintf("invalid USSD session ID [%s]", request.USSDID)
+		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		return h.responseBadRequest(c, err)
+	}
+
+	err = h.service.Delete(ctx, c.OriginalURL(), h.userIDFomContext(c), ussdID)
+	if stacktrace.GetCode(err) == repositories.ErrCodeNotFound {
+		return h.responseNotFound(c, fmt.Sprintf("cannot find USSD session with ID [%s]", request.USSDID))
+	}
+	if err != nil {
+		msg := fmt.Sprintf("cannot delete USSD session with params [%+#v]", request)
+		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseOK(c, "USSD session deleted successfully", nil)
+}

--- a/api/pkg/repositories/gorm_ussd_repository.go
+++ b/api/pkg/repositories/gorm_ussd_repository.go
@@ -1,0 +1,184 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/google/uuid"
+	"github.com/palantir/stacktrace"
+	"gorm.io/gorm"
+)
+
+// gormUSSDRepository is responsible for persisting entities.USSD
+type gormUSSDRepository struct {
+	logger telemetry.Logger
+	tracer telemetry.Tracer
+	db     *gorm.DB
+}
+
+// NewGormUSSDRepository creates the GORM version of the USSDRepository
+func NewGormUSSDRepository(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+	db *gorm.DB,
+) USSDRepository {
+	return &gormUSSDRepository{
+		logger: logger.WithService(fmt.Sprintf("%T", &gormUSSDRepository{})),
+		tracer: tracer,
+		db:     db,
+	}
+}
+
+// Store saves a new USSD session
+func (repository *gormUSSDRepository) Store(ctx context.Context, ussd *entities.USSD) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	if err := repository.db.WithContext(ctx).Create(ussd).Error; err != nil {
+		msg := fmt.Sprintf("cannot save USSD session with ID [%s]", ussd.ID)
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	return nil
+}
+
+// Update updates an existing USSD session
+func (repository *gormUSSDRepository) Update(ctx context.Context, ussd *entities.USSD) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	if err := repository.db.WithContext(ctx).Save(ussd).Error; err != nil {
+		msg := fmt.Sprintf("cannot update USSD session with ID [%s]", ussd.ID)
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	return nil
+}
+
+// Load loads a USSD session by ID and user ID
+func (repository *gormUSSDRepository) Load(ctx context.Context, userID entities.UserID, ussdID uuid.UUID) (*entities.USSD, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	ussd := new(entities.USSD)
+	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", ussdID).First(ussd).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		msg := fmt.Sprintf("USSD session with ID [%s] and userID [%s] does not exist", ussdID, userID)
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+	}
+
+	if err != nil {
+		msg := fmt.Sprintf("cannot load USSD session with ID [%s]", ussdID)
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	return ussd, nil
+}
+
+// LoadBySessionID loads a USSD session by session ID and user ID
+func (repository *gormUSSDRepository) LoadBySessionID(ctx context.Context, userID entities.UserID, sessionID string) (*entities.USSD, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	ussd := new(entities.USSD)
+	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("session_id = ?", sessionID).Order("created_at DESC").First(ussd).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		msg := fmt.Sprintf("USSD session with sessionID [%s] and userID [%s] does not exist", sessionID, userID)
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+	}
+
+	if err != nil {
+		msg := fmt.Sprintf("cannot load USSD session with sessionID [%s]", sessionID)
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	return ussd, nil
+}
+
+// Index fetches paginated USSD sessions for a user
+func (repository *gormUSSDRepository) Index(ctx context.Context, userID entities.UserID, params IndexParams) (*[]entities.USSD, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	query := repository.db.
+		WithContext(ctx).
+		Where("user_id = ?", userID)
+
+	if len(params.Query) > 0 {
+		queryPattern := "%" + params.Query + "%"
+		subQuery := repository.db.Where("content ILIKE ?", queryPattern).
+			Or("session_id ILIKE ?", queryPattern).
+			Or("owner ILIKE ?", queryPattern)
+
+		if _, err := uuid.Parse(params.Query); err == nil {
+			subQuery = subQuery.Or("id = ?", params.Query)
+		}
+
+		query = query.Where(subQuery)
+	}
+
+	ussds := new([]entities.USSD)
+	if err := query.Order("created_at DESC").Limit(params.Limit).Offset(params.Skip).Find(&ussds).Error; err != nil {
+		msg := fmt.Sprintf("cannot fetch USSD sessions for user [%s] with params [%+#v]", userID, params)
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	return ussds, nil
+}
+
+// IndexByPhoneID fetches paginated USSD sessions for a phone
+func (repository *gormUSSDRepository) IndexByPhoneID(ctx context.Context, userID entities.UserID, phoneID uuid.UUID, params IndexParams) (*[]entities.USSD, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	query := repository.db.
+		WithContext(ctx).
+		Where("user_id = ?", userID).
+		Where("phone_id = ?", phoneID)
+
+	if len(params.Query) > 0 {
+		queryPattern := "%" + params.Query + "%"
+		subQuery := repository.db.Where("content ILIKE ?", queryPattern).
+			Or("session_id ILIKE ?", queryPattern)
+
+		query = query.Where(subQuery)
+	}
+
+	ussds := new([]entities.USSD)
+	if err := query.Order("created_at DESC").Limit(params.Limit).Offset(params.Skip).Find(&ussds).Error; err != nil {
+		msg := fmt.Sprintf("cannot fetch USSD sessions for phone [%s] with params [%+#v]", phoneID, params)
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	return ussds, nil
+}
+
+// Delete deletes a USSD session by ID and user ID
+func (repository *gormUSSDRepository) Delete(ctx context.Context, userID entities.UserID, ussdID uuid.UUID) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", ussdID).Delete(&entities.USSD{}).Error
+	if err != nil {
+		msg := fmt.Sprintf("cannot delete USSD session with ID [%s] for user with ID [%s]", ussdID, userID)
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	return nil
+}
+
+// DeleteAllForPhone deletes all USSD sessions for a phone
+func (repository *gormUSSDRepository) DeleteAllForPhone(ctx context.Context, phoneID uuid.UUID) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	if err := repository.db.WithContext(ctx).Where("phone_id = ?", phoneID).Delete(&entities.USSD{}).Error; err != nil {
+		msg := fmt.Sprintf("cannot delete all USSD sessions for phone with ID [%s]", phoneID)
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	return nil
+}

--- a/api/pkg/repositories/ussd_repository.go
+++ b/api/pkg/repositories/ussd_repository.go
@@ -1,0 +1,35 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/google/uuid"
+)
+
+// USSDRepository manages persistence of USSD sessions
+type USSDRepository interface {
+	// Store saves a new USSD session
+	Store(ctx context.Context, ussd *entities.USSD) error
+
+	// Update updates an existing USSD session
+	Update(ctx context.Context, ussd *entities.USSD) error
+
+	// Load loads a USSD session by ID and user ID
+	Load(ctx context.Context, userID entities.UserID, ussdID uuid.UUID) (*entities.USSD, error)
+
+	// LoadBySessionID loads a USSD session by session ID and user ID
+	LoadBySessionID(ctx context.Context, userID entities.UserID, sessionID string) (*entities.USSD, error)
+
+	// Index fetches paginated USSD sessions for a user
+	Index(ctx context.Context, userID entities.UserID, params IndexParams) (*[]entities.USSD, error)
+
+	// IndexByPhoneID fetches paginated USSD sessions for a phone
+	IndexByPhoneID(ctx context.Context, userID entities.UserID, phoneID uuid.UUID, params IndexParams) (*[]entities.USSD, error)
+
+	// Delete deletes a USSD session by ID and user ID
+	Delete(ctx context.Context, userID entities.UserID, ussdID uuid.UUID) error
+
+	// DeleteAllForPhone deletes all USSD sessions for a phone
+	DeleteAllForPhone(ctx context.Context, phoneID uuid.UUID) error
+}

--- a/api/pkg/requests/ussd_send_request.go
+++ b/api/pkg/requests/ussd_send_request.go
@@ -1,0 +1,118 @@
+package requests
+
+import (
+	"strings"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/services"
+)
+
+// USSDReceive is the payload for receiving a USSD request from a phone
+type USSDReceive struct {
+	request
+	From      string       `json:"from" example:"+18005550199"`
+	To        string       `json:"to" example:"+18005550100"`
+	Content   string       `json:"content" example:"*123#"`
+	SessionID string       `json:"session_id" example:"USSDSESSION12345"`
+	SIM       entities.SIM `json:"sim" example:"SIM1"`
+	Timestamp time.Time    `json:"timestamp" example:"2022-06-05T14:26:09.527976+03:00"`
+}
+
+// Sanitize sets defaults to USSDReceive
+func (input *USSDReceive) Sanitize() USSDReceive {
+	input.To = input.sanitizeAddress(input.To)
+	input.From = input.sanitizeContact(input.To, input.From)
+	input.SessionID = strings.TrimSpace(input.SessionID)
+	if strings.TrimSpace(string(input.SIM)) == "" || input.SIM == ("DEFAULT") {
+		input.SIM = entities.SIM1
+	}
+	return *input
+}
+
+// ToUSSDReceiveParams converts USSDReceive to services.USSDReceiveParams
+func (input *USSDReceive) ToUSSDReceiveParams(userID entities.UserID, source string) *services.USSDReceiveParams {
+	return &services.USSDReceiveParams{
+		Source:    source,
+		UserID:    userID,
+		Owner:     input.To,
+		Contact:   input.From,
+		Content:   input.Content,
+		SessionID: input.SessionID,
+		SIM:       input.SIM,
+		Timestamp: input.Timestamp,
+	}
+}
+
+// USSDSend is the payload for sending a USSD response to a phone
+type USSDSend struct {
+	request
+	To      string `json:"to" example:"+18005550199"`
+	From    string `json:"from" example:"+18005550100"`
+	Content string `json:"content" example:"Welcome to USSD menu"`
+	// SessionID is the USSD session identifier
+	SessionID string `json:"session_id" example:"USSDSESSION12345"`
+}
+
+// Sanitize sets defaults to USSDSend
+func (input *USSDSend) Sanitize() USSDSend {
+	input.To = input.sanitizeAddress(input.To)
+	input.From = input.sanitizeAddress(input.From)
+	input.SessionID = strings.TrimSpace(input.SessionID)
+	return *input
+}
+
+// ToUSSDSendParams converts USSDSend to services.USSDSendParams
+func (input *USSDSend) ToUSSDSendParams(userID entities.UserID, source string) *services.USSDSendParams {
+	return &services.USSDSendParams{
+		Source:    source,
+		UserID:    userID,
+		Owner:     input.To,
+		Contact:   input.From,
+		Content:   input.Content,
+		SessionID: input.SessionID,
+	}
+}
+
+// USSDIndex is the payload for fetching USSD session history
+type USSDIndex struct {
+	request
+	Skip    int    `query:"skip" json:"skip" example:"0"`
+	Query   string `query:"query" json:"query" example:"*123#"`
+	Limit   int    `query:"limit" json:"limit" example:"10"`
+	PhoneID string `query:"phone_id" json:"phone_id" example:"32343a19-da5e-4b1b-a767-3298a73703cb"`
+}
+
+// Sanitize sets defaults to USSDIndex
+func (input *USSDIndex) Sanitize() USSDIndex {
+	if input.Limit <= 0 || input.Limit > 20 {
+		input.Limit = 10
+	}
+	if input.Skip < 0 {
+		input.Skip = 0
+	}
+	input.Query = strings.TrimSpace(input.Query)
+	input.PhoneID = strings.TrimSpace(input.PhoneID)
+	return *input
+}
+
+// ToIndexParams converts USSDIndex to repositories.IndexParams
+func (input *USSDIndex) ToIndexParams() repositories.IndexParams {
+	return repositories.IndexParams{
+		Skip:  input.Skip,
+		Query: input.Query,
+		Limit: input.Limit,
+	}
+}
+
+// USSDDelete is the payload for deleting a USSD session
+type USSDDelete struct {
+	request
+	USSDID string `json:"ussd_id" example:"32343a19-da5e-4b1b-a767-3298a73703cb"`
+}
+
+// USSDIDUuid returns the USSDID as uuid.UUID
+func (input *USSDDelete) USSDIDUuid() string {
+	return input.USSDID
+}

--- a/api/pkg/responses/ussd_responses.go
+++ b/api/pkg/responses/ussd_responses.go
@@ -1,0 +1,15 @@
+package responses
+
+import "github.com/NdoleStudio/httpsms/pkg/entities"
+
+// USSDsResponse is the payload containing a list of entities.USSD
+type USSDsResponse struct {
+	response
+	Data []entities.USSD `json:"data"`
+}
+
+// USSDResponse is the payload containing a single entities.USSD
+type USSDResponse struct {
+	response
+	Data entities.USSD `json:"data"`
+}

--- a/api/pkg/services/ussd_service.go
+++ b/api/pkg/services/ussd_service.go
@@ -1,0 +1,263 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/events"
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/uuid"
+	"github.com/palantir/stacktrace"
+)
+
+// USSDReceiveParams are parameters for receiving a USSD request from a phone
+type USSDReceiveParams struct {
+	Source    string
+	UserID    entities.UserID
+	Owner     string
+	Contact   string
+	Content   string
+	SessionID string
+	SIM       entities.SIM
+	Timestamp time.Time
+}
+
+// USSDSendParams are parameters for sending a USSD response to a phone
+type USSDSendParams struct {
+	Source    string
+	UserID    entities.UserID
+	Owner     string
+	Contact   string
+	Content   string
+	SessionID string
+}
+
+// USSDService handles USSD requests
+type USSDService struct {
+	service
+	logger     telemetry.Logger
+	tracer     telemetry.Tracer
+	repository repositories.USSDRepository
+	dispatcher *EventDispatcher
+}
+
+// NewUSSDService creates a new USSDService
+func NewUSSDService(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+	repository repositories.USSDRepository,
+	dispatcher *EventDispatcher,
+) (s *USSDService) {
+	return &USSDService{
+		logger:     logger.WithService(fmt.Sprintf("%T", s)),
+		tracer:     tracer,
+		repository: repository,
+		dispatcher: dispatcher,
+	}
+}
+
+// Receive handles an incoming USSD request from a mobile phone
+func (service *USSDService) Receive(ctx context.Context, params *USSDReceiveParams, phoneID uuid.UUID) (*entities.USSD, error) {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	ctxLogger := service.tracer.CtxLogger(service.logger, span)
+
+	ussd := &entities.USSD{
+		ID:        uuid.New(),
+		UserID:    params.UserID,
+		PhoneID:   phoneID,
+		Owner:     params.Owner,
+		SessionID: params.SessionID,
+		Type:      entities.USSDTypeRequest,
+		Direction: entities.USSDDirectionMoToApp,
+		Content:   params.Content,
+		Status:    entities.USSDStatusPending,
+		SIM:       params.SIM,
+		Timestamp: params.Timestamp,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+
+	if err := service.repository.Store(ctx, ussd); err != nil {
+		msg := fmt.Sprintf("cannot store USSD session with sessionID [%s]", params.SessionID)
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	ctxLogger.Info(fmt.Sprintf("USSD session stored with id [%s] and sessionID [%s]", ussd.ID, ussd.SessionID))
+
+	if err := service.dispatchUSSDReceivedEvent(ctx, ussd); err != nil {
+		msg := fmt.Sprintf("cannot dispatch USSD received event for session [%s]", ussd.ID)
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	return ussd, nil
+}
+
+// Send handles sending a USSD response to a mobile phone
+func (service *USSDService) Send(ctx context.Context, params *USSDSendParams) (*entities.USSD, error) {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	ctxLogger := service.tracer.CtxLogger(service.logger, span)
+
+	ussd := &entities.USSD{
+		ID:        uuid.New(),
+		UserID:    params.UserID,
+		Owner:     params.Owner,
+		SessionID: params.SessionID,
+		Type:      entities.USSDTypeResponse,
+		Direction: entities.USSDDirectionAppToMO,
+		Content:   params.Content,
+		Status:    entities.USSDStatusPending,
+		Timestamp: time.Now().UTC(),
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+
+	if err := service.repository.Store(ctx, ussd); err != nil {
+		msg := fmt.Sprintf("cannot store USSD response with sessionID [%s]", params.SessionID)
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	ctxLogger.Info(fmt.Sprintf("USSD response stored with id [%s] and sessionID [%s]", ussd.ID, ussd.SessionID))
+
+	if err := service.dispatchUSSDSentEvent(ctx, ussd); err != nil {
+		msg := fmt.Sprintf("cannot dispatch USSD sent event for session [%s]", ussd.ID)
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	return ussd, nil
+}
+
+// Index fetches paginated USSD sessions for a user
+func (service *USSDService) Index(ctx context.Context, authUser entities.AuthContext, params repositories.IndexParams, phoneID *uuid.UUID) (*[]entities.USSD, error) {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	ctxLogger := service.tracer.CtxLogger(service.logger, span)
+
+	var ussds *[]entities.USSD
+	var err error
+
+	if phoneID != nil {
+		ussds, err = service.repository.IndexByPhoneID(ctx, authUser.ID, *phoneID, params)
+	} else {
+		ussds, err = service.repository.Index(ctx, authUser.ID, params)
+	}
+
+	if err != nil {
+		msg := fmt.Sprintf("could not fetch USSD sessions with params [%+#v]", params)
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	ctxLogger.Info(fmt.Sprintf("fetched [%d] USSD sessions with params [%+#v]", len(*ussds), params))
+	return ussds, nil
+}
+
+// Delete deletes a USSD session
+func (service *USSDService) Delete(ctx context.Context, source string, userID entities.UserID, ussdID uuid.UUID) error {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	ctxLogger := service.tracer.CtxLogger(service.logger, span)
+
+	ussd, err := service.repository.Load(ctx, userID, ussdID)
+	if err != nil {
+		msg := fmt.Sprintf("cannot load USSD session with ID [%s]", ussdID)
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	if err = service.repository.Delete(ctx, userID, ussdID); err != nil {
+		msg := fmt.Sprintf("cannot delete USSD session with ID [%s]", ussdID)
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	ctxLogger.Info(fmt.Sprintf("deleted USSD session with ID [%s]", ussdID))
+
+	// Dispatch deleted event
+	event, err := service.createEvent("ussd.deleted", source, map[string]interface{}{
+		"ussd_id":    ussd.ID,
+		"user_id":    ussd.UserID,
+		"session_id": ussd.SessionID,
+	})
+	if err != nil {
+		msg := fmt.Sprintf("cannot create USSD deleted event for session [%s]", ussd.ID)
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
+		msg := fmt.Sprintf("cannot dispatch USSD deleted event for session [%s]", ussd.ID)
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	return nil
+}
+
+func (service *USSDService) dispatchUSSDReceivedEvent(ctx context.Context, ussd *entities.USSD) error {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	event, err := service.createUSSDReceivedEvent(ussd)
+	if err != nil {
+		msg := fmt.Sprintf("cannot create event when USSD is received for session [%s]", ussd.ID)
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
+		msg := fmt.Sprintf("cannot dispatch event [%s] for USSD session with id [%s]", event.Type(), ussd.ID)
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+	return nil
+}
+
+func (service *USSDService) dispatchUSSDSentEvent(ctx context.Context, ussd *entities.USSD) error {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	event, err := service.createUSSDSentEvent(ussd)
+	if err != nil {
+		msg := fmt.Sprintf("cannot create event when USSD is sent for session [%s]", ussd.ID)
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+
+	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
+		msg := fmt.Sprintf("cannot dispatch event [%s] for USSD session with id [%s]", event.Type(), ussd.ID)
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+	}
+	return nil
+}
+
+func (service *USSDService) createUSSDReceivedEvent(ussd *entities.USSD) (cloudevents.Event, error) {
+	return service.createEvent(events.EventTypeUSSDReceived, fmt.Sprintf("/v1/ussd/receive"), events.USSDReceivedPayload{
+		USSDID:    ussd.ID,
+		UserID:    ussd.UserID,
+		PhoneID:   ussd.PhoneID,
+		Owner:     ussd.Owner,
+		SessionID: ussd.SessionID,
+		Content:   ussd.Content,
+		SIM:       ussd.SIM,
+		Timestamp: ussd.Timestamp,
+	})
+}
+
+func (service *USSDService) createUSSDSentEvent(ussd *entities.USSD) (cloudevents.Event, error) {
+	response := ""
+	if ussd.Response != nil {
+		response = *ussd.Response
+	}
+	return service.createEvent(events.EventTypeUSSDResponse, fmt.Sprintf("/v1/ussd/send"), events.USSDResponsePayload{
+		USSDID:    ussd.ID,
+		UserID:    ussd.UserID,
+		PhoneID:   ussd.PhoneID,
+		Owner:     ussd.Owner,
+		SessionID: ussd.SessionID,
+		Response:  response,
+		SIM:       ussd.SIM,
+		Timestamp: ussd.Timestamp,
+	})
+}

--- a/api/pkg/validators/ussd_handler_validator.go
+++ b/api/pkg/validators/ussd_handler_validator.go
@@ -1,0 +1,122 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"github.com/NdoleStudio/httpsms/pkg/requests"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+)
+
+// USSDHandlerValidator validates USSD requests
+type USSDHandlerValidator struct {
+	logger telemetry.Logger
+	tracer telemetry.Tracer
+}
+
+// NewUSSDHandlerValidator creates a new USSDHandlerValidator
+func NewUSSDHandlerValidator(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+) (v *USSDHandlerValidator) {
+	return &USSDHandlerValidator{
+		logger: logger.WithService(fmt.Sprintf("%T", v)),
+		tracer: tracer,
+	}
+}
+
+// ValidateReceive validates a USSD receive request
+func (v *USSDHandlerValidator) ValidateReceive(ctx context.Context, request requests.USSDReceive) url.Values {
+	_, span := v.tracer.Start(ctx)
+	defer span.End()
+
+	errs := url.Values{}
+
+	if len(request.From) == 0 {
+		errs.Add("from", "cannot be blank")
+	}
+
+	if len(request.To) == 0 {
+		errs.Add("to", "cannot be blank")
+	}
+
+	if len(request.Content) == 0 {
+		errs.Add("content", "cannot be blank")
+	}
+
+	if len(request.SessionID) == 0 {
+		errs.Add("session_id", "cannot be blank")
+	}
+
+	if request.Timestamp.IsZero() {
+		errs.Add("timestamp", "cannot be blank")
+	}
+
+	return errs
+}
+
+// ValidateSend validates a USSD send request
+func (v *USSDHandlerValidator) ValidateSend(ctx context.Context, request requests.USSDSend) url.Values {
+	_, span := v.tracer.Start(ctx)
+	defer span.End()
+
+	errs := url.Values{}
+
+	if len(request.From) == 0 {
+		errs.Add("from", "cannot be blank")
+	}
+
+	if len(request.To) == 0 {
+		errs.Add("to", "cannot be blank")
+	}
+
+	if len(request.Content) == 0 {
+		errs.Add("content", "cannot be blank")
+	}
+
+	if len(request.SessionID) == 0 {
+		errs.Add("session_id", "cannot be blank")
+	}
+
+	return errs
+}
+
+// ValidateIndex validates a USSD index request
+func (v *USSDHandlerValidator) ValidateIndex(ctx context.Context, request requests.USSDIndex) url.Values {
+	_, span := v.tracer.Start(ctx)
+	defer span.End()
+
+	errs := url.Values{}
+
+	if request.Limit < 0 || request.Limit > 20 {
+		errs.Add("limit", "must be between 0 and 20")
+	}
+
+	if request.Skip < 0 {
+		errs.Add("skip", "cannot be less than 0")
+	}
+
+	if len(request.PhoneID) > 0 {
+		if matched, _ := regexp.MatchString("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$", request.PhoneID); !matched {
+			errs.Add("phone_id", "must be a valid UUID")
+		}
+	}
+
+	return errs
+}
+
+// ValidateDelete validates a USSD delete request
+func (v *USSDHandlerValidator) ValidateDelete(ctx context.Context, request requests.USSDDelete) url.Values {
+	_, span := v.tracer.Start(ctx)
+	defer span.End()
+
+	errs := url.Values{}
+
+	if matched, _ := regexp.MatchString("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$", request.USSDID); !matched {
+		errs.Add("ussd_id", "must be a valid UUID")
+	}
+
+	return errs
+}


### PR DESCRIPTION
- Add USSD entity with session management (types, directions, statuses)
- Add USSD repository (interface + GORM implementation)
- Add USSD events (received and sent)
- Add USSD request/response models
- Add USSD service for receiving and sending USSD messages
- Add USSD handler with routes for receive, send, index, delete
- Add USSD validator
- Register USSD routes, listeners, and DB migration in DI container

API endpoints:
  POST /v1/ussd/receive - Receive USSD request from phone POST /v1/ussd/send - Send USSD response to phone GET /v1/ussd - List USSD session history DELETE /v1/ussd/:ussdID - Delete a USSD session