### PR TITLE
feat(web): add affiliates landing page

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 11
+          version: 11.3.0
 
       - name: Install dependencies 📦
         run: pnpm install
@@ -66,7 +66,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 11
+          version: 11.3.0
 
       - name: Install dependencies 📦
         run: pnpm install

--- a/web/app/layouts/website.vue
+++ b/web/app/layouts/website.vue
@@ -194,13 +194,13 @@ function goToPricing() {
                 </a>
               </li>
               <li class="mb-2">
-                <a
-                  href="https://httpsms.lemonsqueezy.com/affiliates"
+                <NuxtLink
+                  to="/affiliates"
                   class="text-white text-decoration-none footer-link"
                 >
                   Affiliates
                   <v-icon color="warning" size="small" :icon="mdiShieldStar" />
-                </a>
+                </NuxtLink>
               </li>
               <li class="mb-2">
                 <a

--- a/web/app/layouts/website.vue
+++ b/web/app/layouts/website.vue
@@ -14,6 +14,7 @@ import {
   mdiScaleBalance,
   mdiEmailOutline,
   mdiBookOpenVariant,
+  mdiRocketLaunchOutline,
 } from '@mdi/js'
 
 const router = useRouter()
@@ -183,6 +184,19 @@ function goToPricing() {
           <v-col cols="12" md="3">
             <h2 class="text-headline-small mb-2">Resources</h2>
             <ul style="list-style: none" class="pa-0">
+              <li class="mb-2">
+                <NuxtLink
+                  to="/getting-started"
+                  class="text-white text-decoration-none footer-link"
+                >
+                  Getting Started
+                  <v-icon
+                    color="primary"
+                    size="small"
+                    :icon="mdiRocketLaunchOutline"
+                  />
+                </NuxtLink>
+              </li>
               <li class="mb-2">
                 <a
                   class="text-white text-decoration-none footer-link"

--- a/web/app/pages/affiliates/index.vue
+++ b/web/app/pages/affiliates/index.vue
@@ -90,16 +90,17 @@ const scrollToFaq = () => {
             <VIcon start :icon="mdiCashMultiple" />
             Affiliate Program
           </VChip>
-          <h1 class="text-display-large font-weight-bold gradient-header pb-1">
+          <h1 class="text-display-large font-weight-bold pb-1">
             Get paid to share httpSMS
           </h1>
           <h2
             class="text-medium-emphasis text-headline-small font-weight-light mt-8 mb-8"
           >
-            Earn <span class="gradient-underline">20% commission</span> — up to
-            <span class="gradient-underline">$70.00</span> — on every customer
-            you refer. Recommend httpSMS on your blog, videos, or social, and
-            we'll track every click and pay you.
+            Earn
+            <span class="text-primary font-weight-bold">20% commission</span> —
+            up to <span class="text-primary font-weight-bold">$70.00</span> — on
+            every customer you refer. Recommend httpSMS on your blog, videos, or
+            social, and we'll track every click and pay you.
           </h2>
           <div>
             <VBtn
@@ -138,9 +139,7 @@ const scrollToFaq = () => {
             md="3"
             class="text-center"
           >
-            <p
-              class="text-display-medium font-weight-bold gradient-header mb-1"
-            >
+            <p class="text-display-medium font-weight-bold text-primary mb-1">
               {{ highlight.value }}
             </p>
             <p class="text-title-large font-weight-light text-medium-emphasis">
@@ -227,20 +226,3 @@ const scrollToFaq = () => {
     </VSheet>
   </div>
 </template>
-
-<style lang="scss" scoped>
-.gradient-header {
-  color: #1ad37f;
-  background-image: -webkit-linear-gradient(0deg, #1ad37f 14%, #329ef4 55%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-}
-
-.gradient-underline {
-  color: #fff;
-  background-image: -webkit-linear-gradient(0deg, #1ad37f 14%, #329ef4 55%);
-  background-repeat: no-repeat;
-  background-position: 0 100%;
-  background-size: 100% 3px;
-}
-</style>

--- a/web/app/pages/affiliates/index.vue
+++ b/web/app/pages/affiliates/index.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import {
   mdiCashMultiple,
-  mdiRepeatVariant,
-  mdiMagnet,
-  mdiCreditCardCheckOutline,
+  mdiCreation,
+  mdiLinkVariant,
+  mdiWalletOutline,
+  mdiCalendarClock,
+  mdiCursorDefaultClick,
   mdiArrowRightThin,
   mdiChevronDown,
 } from '@mdi/js'
@@ -13,90 +15,68 @@ definePageMeta({
 })
 
 useSeoMeta({
-  title: 'Affiliate Program — Earn up to $70 per Sale | httpSMS',
+  title: 'Affiliate Program — Earn 20% on every sale | httpSMS',
   description:
-    'Join the httpSMS affiliate program and earn up to $70 for every customer you refer, with recurring commissions. Free to join, powered by LemonSqueezy.',
-  ogTitle: 'Get paid to share httpSMS — earn up to $70 per sale',
+    'Become a httpSMS affiliate and earn 20% commission — up to $70.00 — on every customer you refer. Free to join, powered by Lemon Squeezy.',
+  ogTitle: 'Get paid to share httpSMS — earn 20% on every sale',
   ogDescription:
-    'Join the httpSMS affiliate program and earn up to $70 for every customer you refer, with recurring commissions. Free to join, powered by LemonSqueezy.',
+    'Become a httpSMS affiliate and earn 20% commission — up to $70.00 — on every customer you refer. Free to join, powered by Lemon Squeezy.',
   ogImage: 'https://httpsms.com/header.png',
   twitterCard: 'summary_large_image',
 })
 
-const { mdAndUp, mdAndDown } = useDisplay()
+const { mdAndDown } = useDisplay()
 
 const signupUrl = 'https://affiliates.lemonsqueezy.com/programs/httpsms'
 
-const benefits = [
-  {
-    icon: mdiCashMultiple,
-    title: 'Up to $70 per sale',
-    body: 'Real commission on real subscriptions, not pennies per click.',
-  },
-  {
-    icon: mdiRepeatVariant,
-    title: 'Recurring commission',
-    body: 'Get paid every month your referral stays, not just once.',
-  },
-  {
-    icon: mdiMagnet,
-    title: 'A product that sticks',
-    body: 'Developers wire httpSMS into daily workflows, so they rarely leave.',
-  },
-  {
-    icon: mdiCreditCardCheckOutline,
-    title: 'Payouts on autopilot',
-    body: 'LemonSqueezy tracks every referral and pays you automatically.',
-  },
-]
-
-const steps = [
-  {
-    title: 'Sign up free',
-    body: 'Join through LemonSqueezy in under a minute. No cost, no catch.',
-  },
-  {
-    title: 'Share your link',
-    body: 'Drop it in your blog posts, videos, docs, or DMs.',
-  },
-  {
-    title: 'Get paid',
-    body: 'We handle tracking and payouts. You collect on every sale.',
-  },
+const highlights = [
+  { value: '20%', label: 'commission on every sale' },
+  { value: '$70', label: 'max earned per referral' },
+  { value: 'NET30', label: 'payout terms' },
+  { value: '$10', label: 'minimum payout' },
 ]
 
 const faqs = [
   {
+    icon: mdiCreation,
+    question: 'Why promote us?',
+    answer:
+      "Affiliate partnerships are one of the simplest yet most profitable ways to make money online. You send customers our way, and we'll pay you for it.",
+  },
+  {
+    icon: mdiLinkVariant,
+    question: 'How do I make money as an affiliate?',
+    answer:
+      'All you have to do is recommend us using your affiliate link on your website, blog, and social media. We track your clicks and transactions so you can get paid.',
+  },
+  {
+    icon: mdiCashMultiple,
     question: 'How much can I earn?',
     answer:
-      'Up to $70 per sale, plus recurring commission for as long as your referral stays subscribed.',
+      "You earn 20% commission — up to $70.00 — on every referral that results in a successful sale. There's no limit to how much you can make by promoting us.",
   },
   {
-    question: 'How do I get paid?',
+    icon: mdiWalletOutline,
+    question: 'What are the payout minimums?',
     answer:
-      'LemonSqueezy tracks your referrals and pays you automatically on their schedule.',
+      'We require a minimum balance of $10.00 before processing an affiliate payout. We set this to avoid any fraudulent issues with our affiliate program.',
   },
   {
-    question: 'Who can join?',
+    icon: mdiCalendarClock,
+    question: 'When do I get paid?',
     answer:
-      "Anyone. Bloggers, YouTubers, developers, agencies — and it's free to join.",
+      'We payout on NET30 terms to account for refunds and chargebacks. For example, commissions generated in January would be paid out on March 15th (NET30).',
   },
   {
-    question: 'How do I track my referrals?',
+    icon: mdiCursorDefaultClick,
+    question: 'How do I sign up?',
     answer:
-      'Your LemonSqueezy dashboard shows clicks, referrals, and earnings in real time.',
-  },
-  {
-    question: 'What converts best?',
-    answer:
-      'Tutorials, honest reviews, and comparisons that show how httpSMS turns an Android phone into an SMS gateway.',
+      'The Lemon Squeezy affiliate hub hosts our affiliate program. Click the "Become an affiliate" button below to create a Lemon Squeezy account and join our program.',
   },
 ]
 
-const scrollToHowItWorks = () => {
-  document
-    .getElementById('how-it-works')
-    ?.scrollIntoView({ behavior: 'smooth' })
+const scrollToFaq = () => {
+  document.getElementById('faq')?.scrollIntoView({ behavior: 'smooth' })
 }
 </script>
 
@@ -106,22 +86,20 @@ const scrollToHowItWorks = () => {
     <VContainer>
       <VRow>
         <VCol cols="12" md="8" offset-md="2" class="pt-16 pb-8 text-center">
-          <p
-            class="text-overline text-medium-emphasis mb-2"
-            style="letter-spacing: 0.3em !important"
-          >
+          <VChip color="pink" label class="mb-6">
+            <VIcon start :icon="mdiCashMultiple" />
             Affiliate Program
-          </p>
-          <h1 class="text-display-medium font-weight-bold gradient-header mb-6">
+          </VChip>
+          <h1 class="text-display-large font-weight-bold gradient-header pb-1">
             Get paid to share httpSMS
           </h1>
           <h2
-            class="text-headline-small font-weight-light text-medium-emphasis mb-8"
+            class="text-medium-emphasis text-headline-small font-weight-light mt-8 mb-8"
           >
-            Earn up to <span class="text-white font-weight-bold">$70</span> for
-            every customer you refer — and keep earning every month they stay
-            subscribed. If you already tell people to ditch expensive short
-            codes, you might as well get paid for it.
+            Earn <span class="gradient-underline">20% commission</span> — up to
+            <span class="gradient-underline">$70.00</span> — on every customer
+            you refer. Recommend httpSMS on your blog, videos, or social, and
+            we'll track every click and pay you.
           </h2>
           <div>
             <VBtn
@@ -139,9 +117,9 @@ const scrollToHowItWorks = () => {
               size="large"
               variant="tonal"
               class="ma-2"
-              @click="scrollToHowItWorks"
+              @click="scrollToFaq"
             >
-              See how it works
+              How it works
               <VIcon end :icon="mdiChevronDown" />
             </VBtn>
           </div>
@@ -149,118 +127,92 @@ const scrollToHowItWorks = () => {
       </VRow>
     </VContainer>
 
-    <!-- Why promote httpSMS -->
+    <!-- Highlights -->
     <VSheet class="py-16">
       <VContainer>
-        <h2 class="text-headline-large font-weight-bold text-center mb-2">
-          Why promote httpSMS
-        </h2>
-        <p class="text-body-large text-medium-emphasis text-center mb-10">
-          A generous program built on a product people actually keep.
-        </p>
         <VRow>
           <VCol
-            v-for="benefit in benefits"
-            :key="benefit.title"
-            cols="12"
-            sm="6"
+            v-for="highlight in highlights"
+            :key="highlight.label"
+            cols="6"
             md="3"
+            class="text-center"
           >
-            <VCard height="100%" class="pa-4" variant="tonal">
-              <VIcon size="40" color="primary" :icon="benefit.icon" />
-              <h3 class="text-title-large font-weight-bold mt-4 mb-2">
-                {{ benefit.title }}
-              </h3>
-              <p class="text-body-medium text-medium-emphasis">
-                {{ benefit.body }}
-              </p>
-            </VCard>
+            <p
+              class="text-display-medium font-weight-bold gradient-header mb-1"
+            >
+              {{ highlight.value }}
+            </p>
+            <p class="text-title-large font-weight-light text-medium-emphasis">
+              {{ highlight.label }}
+            </p>
           </VCol>
         </VRow>
       </VContainer>
     </VSheet>
 
-    <!-- How it works -->
-    <VContainer id="how-it-works" class="py-16">
-      <h2 class="text-headline-large font-weight-bold text-center mb-2">
-        How it works
-      </h2>
-      <p class="text-body-large text-medium-emphasis text-center mb-10">
-        From sign-up to payout in three steps.
-      </p>
+    <!-- FAQ -->
+    <VContainer id="faq" class="py-16">
+      <VRow>
+        <VCol cols="12" md="8" offset-md="2">
+          <h2
+            class="text-md-display-large text-display-medium text-center mb-4"
+          >
+            Frequently Asked Questions
+          </h2>
+          <p class="text-center text-title-large text-medium-emphasis mb-8">
+            Everything you need to know before you start earning with httpSMS.
+          </p>
+        </VCol>
+      </VRow>
       <VRow>
         <VCol
-          v-for="(step, index) in steps"
-          :key="step.title"
+          v-for="faq in faqs"
+          :key="faq.question"
           cols="12"
-          md="4"
-          :class="{ 'text-center': mdAndDown }"
+          md="6"
+          class="py-6"
         >
-          <div
-            class="d-flex align-center justify-center gradient-step mb-4"
-            :class="{ 'mx-auto': mdAndDown }"
-          >
-            <span class="text-headline-small font-weight-bold">
-              {{ index + 1 }}
-            </span>
+          <div class="d-flex" :class="{ 'flex-column text-center': mdAndDown }">
+            <VIcon
+              size="32"
+              color="primary"
+              class="mr-4 mb-2"
+              :class="{ 'mx-auto': mdAndDown }"
+              :icon="faq.icon"
+            />
+            <div>
+              <h3 class="text-headline-small font-weight-bold mb-2">
+                {{ faq.question }}
+              </h3>
+              <p
+                class="text-title-large font-weight-light text-medium-emphasis"
+              >
+                {{ faq.answer }}
+              </p>
+            </div>
           </div>
-          <h3 class="text-title-large font-weight-bold mb-2">
-            {{ step.title }}
-          </h3>
-          <p class="text-body-large text-medium-emphasis">
-            {{ step.body }}
-          </p>
         </VCol>
       </VRow>
     </VContainer>
 
-    <!-- FAQ -->
+    <!-- Closing CTA -->
     <VSheet class="py-16">
       <VContainer>
         <VRow>
-          <VCol cols="12" md="10" offset-md="1">
-            <h2 class="text-headline-large font-weight-bold mb-10">
-              Frequently asked questions
-            </h2>
-            <VRow>
-              <VCol
-                v-for="faq in faqs"
-                :key="faq.question"
-                cols="12"
-                md="6"
-                class="mb-4"
-              >
-                <h3 class="text-title-large font-weight-bold mb-2">
-                  {{ faq.question }}
-                </h3>
-                <p class="text-body-large text-medium-emphasis">
-                  {{ faq.answer }}
-                </p>
-              </VCol>
-            </VRow>
-          </VCol>
-        </VRow>
-      </VContainer>
-    </VSheet>
-
-    <!-- Closing CTA -->
-    <VContainer class="py-16">
-      <VRow>
-        <VCol cols="12" md="8" offset-md="2">
-          <VCard
-            class="pa-8 text-center gradient-cta"
-            :class="{ 'pa-md-16': mdAndUp }"
-          >
-            <h2 class="text-headline-large font-weight-bold mb-2">
+          <VCol cols="12" md="8" offset-md="2" class="text-center">
+            <h2 class="text-display-medium font-weight-bold mb-4">
               Ready to start earning?
             </h2>
-            <p class="text-body-large text-medium-emphasis mb-6">
+            <p
+              class="text-title-large font-weight-light text-medium-emphasis mb-8"
+            >
               Join free, grab your link, and turn your audience into recurring
               income.
             </p>
             <VBtn
               color="primary"
-              size="large"
+              size="x-large"
               :href="signupUrl"
               target="_blank"
               rel="noopener"
@@ -269,10 +221,10 @@ const scrollToHowItWorks = () => {
               Become an affiliate
               <VIcon end :icon="mdiArrowRightThin" />
             </VBtn>
-          </VCard>
-        </VCol>
-      </VRow>
-    </VContainer>
+          </VCol>
+        </VRow>
+      </VContainer>
+    </VSheet>
   </div>
 </template>
 
@@ -284,15 +236,11 @@ const scrollToHowItWorks = () => {
   -webkit-text-fill-color: transparent;
 }
 
-.gradient-step {
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  background-image: -webkit-linear-gradient(0deg, #1ad37f 14%, #329ef4 55%);
+.gradient-underline {
   color: #fff;
-}
-
-.gradient-cta {
-  border: 1px solid rgba(26, 211, 127, 0.4);
+  background-image: -webkit-linear-gradient(0deg, #1ad37f 14%, #329ef4 55%);
+  background-repeat: no-repeat;
+  background-position: 0 100%;
+  background-size: 100% 3px;
 }
 </style>

--- a/web/app/pages/affiliates/index.vue
+++ b/web/app/pages/affiliates/index.vue
@@ -1,0 +1,298 @@
+<script setup lang="ts">
+import {
+  mdiCashMultiple,
+  mdiRepeatVariant,
+  mdiMagnet,
+  mdiCreditCardCheckOutline,
+  mdiArrowRightThin,
+  mdiChevronDown,
+} from '@mdi/js'
+
+definePageMeta({
+  layout: 'website',
+})
+
+useSeoMeta({
+  title: 'Affiliate Program — Earn up to $70 per Sale | httpSMS',
+  description:
+    'Join the httpSMS affiliate program and earn up to $70 for every customer you refer, with recurring commissions. Free to join, powered by LemonSqueezy.',
+  ogTitle: 'Get paid to share httpSMS — earn up to $70 per sale',
+  ogDescription:
+    'Join the httpSMS affiliate program and earn up to $70 for every customer you refer, with recurring commissions. Free to join, powered by LemonSqueezy.',
+  ogImage: 'https://httpsms.com/header.png',
+  twitterCard: 'summary_large_image',
+})
+
+const { mdAndUp, mdAndDown } = useDisplay()
+
+const signupUrl = 'https://affiliates.lemonsqueezy.com/programs/httpsms'
+
+const benefits = [
+  {
+    icon: mdiCashMultiple,
+    title: 'Up to $70 per sale',
+    body: 'Real commission on real subscriptions, not pennies per click.',
+  },
+  {
+    icon: mdiRepeatVariant,
+    title: 'Recurring commission',
+    body: 'Get paid every month your referral stays, not just once.',
+  },
+  {
+    icon: mdiMagnet,
+    title: 'A product that sticks',
+    body: 'Developers wire httpSMS into daily workflows, so they rarely leave.',
+  },
+  {
+    icon: mdiCreditCardCheckOutline,
+    title: 'Payouts on autopilot',
+    body: 'LemonSqueezy tracks every referral and pays you automatically.',
+  },
+]
+
+const steps = [
+  {
+    title: 'Sign up free',
+    body: 'Join through LemonSqueezy in under a minute. No cost, no catch.',
+  },
+  {
+    title: 'Share your link',
+    body: 'Drop it in your blog posts, videos, docs, or DMs.',
+  },
+  {
+    title: 'Get paid',
+    body: 'We handle tracking and payouts. You collect on every sale.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'How much can I earn?',
+    answer:
+      'Up to $70 per sale, plus recurring commission for as long as your referral stays subscribed.',
+  },
+  {
+    question: 'How do I get paid?',
+    answer:
+      'LemonSqueezy tracks your referrals and pays you automatically on their schedule.',
+  },
+  {
+    question: 'Who can join?',
+    answer:
+      "Anyone. Bloggers, YouTubers, developers, agencies — and it's free to join.",
+  },
+  {
+    question: 'How do I track my referrals?',
+    answer:
+      'Your LemonSqueezy dashboard shows clicks, referrals, and earnings in real time.',
+  },
+  {
+    question: 'What converts best?',
+    answer:
+      'Tutorials, honest reviews, and comparisons that show how httpSMS turns an Android phone into an SMS gateway.',
+  },
+]
+
+const scrollToHowItWorks = () => {
+  document
+    .getElementById('how-it-works')
+    ?.scrollIntoView({ behavior: 'smooth' })
+}
+</script>
+
+<template>
+  <div>
+    <!-- Hero -->
+    <VContainer>
+      <VRow>
+        <VCol cols="12" md="8" offset-md="2" class="pt-16 pb-8 text-center">
+          <p
+            class="text-overline text-medium-emphasis mb-2"
+            style="letter-spacing: 0.3em !important"
+          >
+            Affiliate Program
+          </p>
+          <h1 class="text-display-medium font-weight-bold gradient-header mb-6">
+            Get paid to share httpSMS
+          </h1>
+          <h2
+            class="text-headline-small font-weight-light text-medium-emphasis mb-8"
+          >
+            Earn up to <span class="text-white font-weight-bold">$70</span> for
+            every customer you refer — and keep earning every month they stay
+            subscribed. If you already tell people to ditch expensive short
+            codes, you might as well get paid for it.
+          </h2>
+          <div>
+            <VBtn
+              color="primary"
+              size="large"
+              class="ma-2"
+              :href="signupUrl"
+              target="_blank"
+              rel="noopener"
+            >
+              <VIcon start :icon="mdiCashMultiple" />
+              Become an affiliate
+            </VBtn>
+            <VBtn
+              size="large"
+              variant="tonal"
+              class="ma-2"
+              @click="scrollToHowItWorks"
+            >
+              See how it works
+              <VIcon end :icon="mdiChevronDown" />
+            </VBtn>
+          </div>
+        </VCol>
+      </VRow>
+    </VContainer>
+
+    <!-- Why promote httpSMS -->
+    <VSheet class="py-16">
+      <VContainer>
+        <h2 class="text-headline-large font-weight-bold text-center mb-2">
+          Why promote httpSMS
+        </h2>
+        <p class="text-body-large text-medium-emphasis text-center mb-10">
+          A generous program built on a product people actually keep.
+        </p>
+        <VRow>
+          <VCol
+            v-for="benefit in benefits"
+            :key="benefit.title"
+            cols="12"
+            sm="6"
+            md="3"
+          >
+            <VCard height="100%" class="pa-4" variant="tonal">
+              <VIcon size="40" color="primary" :icon="benefit.icon" />
+              <h3 class="text-title-large font-weight-bold mt-4 mb-2">
+                {{ benefit.title }}
+              </h3>
+              <p class="text-body-medium text-medium-emphasis">
+                {{ benefit.body }}
+              </p>
+            </VCard>
+          </VCol>
+        </VRow>
+      </VContainer>
+    </VSheet>
+
+    <!-- How it works -->
+    <VContainer id="how-it-works" class="py-16">
+      <h2 class="text-headline-large font-weight-bold text-center mb-2">
+        How it works
+      </h2>
+      <p class="text-body-large text-medium-emphasis text-center mb-10">
+        From sign-up to payout in three steps.
+      </p>
+      <VRow>
+        <VCol
+          v-for="(step, index) in steps"
+          :key="step.title"
+          cols="12"
+          md="4"
+          :class="{ 'text-center': mdAndDown }"
+        >
+          <div
+            class="d-flex align-center justify-center gradient-step mb-4"
+            :class="{ 'mx-auto': mdAndDown }"
+          >
+            <span class="text-headline-small font-weight-bold">
+              {{ index + 1 }}
+            </span>
+          </div>
+          <h3 class="text-title-large font-weight-bold mb-2">
+            {{ step.title }}
+          </h3>
+          <p class="text-body-large text-medium-emphasis">
+            {{ step.body }}
+          </p>
+        </VCol>
+      </VRow>
+    </VContainer>
+
+    <!-- FAQ -->
+    <VSheet class="py-16">
+      <VContainer>
+        <VRow>
+          <VCol cols="12" md="10" offset-md="1">
+            <h2 class="text-headline-large font-weight-bold mb-10">
+              Frequently asked questions
+            </h2>
+            <VRow>
+              <VCol
+                v-for="faq in faqs"
+                :key="faq.question"
+                cols="12"
+                md="6"
+                class="mb-4"
+              >
+                <h3 class="text-title-large font-weight-bold mb-2">
+                  {{ faq.question }}
+                </h3>
+                <p class="text-body-large text-medium-emphasis">
+                  {{ faq.answer }}
+                </p>
+              </VCol>
+            </VRow>
+          </VCol>
+        </VRow>
+      </VContainer>
+    </VSheet>
+
+    <!-- Closing CTA -->
+    <VContainer class="py-16">
+      <VRow>
+        <VCol cols="12" md="8" offset-md="2">
+          <VCard
+            class="pa-8 text-center gradient-cta"
+            :class="{ 'pa-md-16': mdAndUp }"
+          >
+            <h2 class="text-headline-large font-weight-bold mb-2">
+              Ready to start earning?
+            </h2>
+            <p class="text-body-large text-medium-emphasis mb-6">
+              Join free, grab your link, and turn your audience into recurring
+              income.
+            </p>
+            <VBtn
+              color="primary"
+              size="large"
+              :href="signupUrl"
+              target="_blank"
+              rel="noopener"
+            >
+              <VIcon start :icon="mdiCashMultiple" />
+              Become an affiliate
+              <VIcon end :icon="mdiArrowRightThin" />
+            </VBtn>
+          </VCard>
+        </VCol>
+      </VRow>
+    </VContainer>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.gradient-header {
+  color: #1ad37f;
+  background-image: -webkit-linear-gradient(0deg, #1ad37f 14%, #329ef4 55%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.gradient-step {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background-image: -webkit-linear-gradient(0deg, #1ad37f 14%, #329ef4 55%);
+  color: #fff;
+}
+
+.gradient-cta {
+  border: 1px solid rgba(26, 211, 127, 0.4);
+}
+</style>

--- a/web/app/pages/affiliates/index.vue
+++ b/web/app/pages/affiliates/index.vue
@@ -93,7 +93,7 @@ const scrollToFaq = () => {
           <h1 class="text-display-large font-weight-bold pb-1">
             Get paid to share httpSMS
           </h1>
-          <h2
+          <p
             class="text-medium-emphasis text-headline-small font-weight-light mt-8 mb-8"
           >
             Earn
@@ -101,7 +101,7 @@ const scrollToFaq = () => {
             up to <span class="text-primary font-weight-bold">$70.00</span> — on
             every customer you refer. Recommend httpSMS on your blog, videos, or
             social, and we'll track every click and pay you.
-          </h2>
+          </p>
           <div>
             <VBtn
               color="primary"

--- a/web/app/pages/getting-started.vue
+++ b/web/app/pages/getting-started.vue
@@ -1,0 +1,347 @@
+<script setup lang="ts">
+import {
+  mdiDownload,
+  mdiAccountPlusOutline,
+  mdiOpenInNew,
+  mdiCheckCircle,
+  mdiLanguagePython,
+  mdiMicrosoftExcel,
+  mdiFileDelimitedOutline,
+  mdiLightningBolt,
+  mdiWebhook,
+  mdiLockOutline,
+} from '@mdi/js'
+import { useDisplay } from 'vuetify'
+
+const { mdAndUp } = useDisplay()
+
+const apkUrl =
+  'https://github.com/NdoleStudio/httpsms/releases/latest/download/HttpSms.apk'
+
+definePageMeta({ layout: 'website' })
+
+useSeoMeta({
+  title: 'Getting Started - Send your first SMS with httpSMS',
+  description:
+    'Turn your Android phone into an SMS gateway in 5 minutes. Download the app, sign in with your API key, and send your first text message with httpSMS.',
+  ogTitle: 'Getting Started with httpSMS - Send your first SMS in 5 minutes',
+  ogDescription:
+    'Turn your Android phone into an SMS gateway in 5 minutes. Download the app, sign in with your API key, and send your first text message.',
+  ogImage: 'https://httpsms.com/header.png',
+  twitterCard: 'summary_large_image',
+})
+
+type AutomationLink = {
+  title: string
+  description: string
+  to: string
+  icon: string
+}
+
+const automations: AutomationLink[] = [
+  {
+    title: 'Send SMS with Python',
+    description: 'Automate text messages from your scripts in a few lines.',
+    to: '/blog/send-sms-from-android-phone-with-python',
+    icon: mdiLanguagePython,
+  },
+  {
+    title: 'Send SMS from Excel',
+    description:
+      'Message a whole list of contacts straight from a spreadsheet.',
+    to: '/blog/how-to-send-sms-messages-from-excel',
+    icon: mdiMicrosoftExcel,
+  },
+  {
+    title: 'Send bulk SMS from a CSV',
+    description: 'Upload a CSV and text everyone on it — no code needed.',
+    to: '/blog/send-bulk-sms-from-csv-file-with-no-code',
+    icon: mdiFileDelimitedOutline,
+  },
+  {
+    title: 'Send SMS with Zapier',
+    description: 'Text a contact when a new row lands in Google Sheets.',
+    to: '/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier',
+    icon: mdiLightningBolt,
+  },
+  {
+    title: 'Forward SMS to a webhook',
+    description: 'Push every incoming message to your own server in real time.',
+    to: '/blog/forward-incoming-sms-from-phone-to-webhook',
+    icon: mdiWebhook,
+  },
+  {
+    title: 'Encrypt your messages',
+    description: 'Add end-to-end encryption so only you can read your texts.',
+    to: '/blog/end-to-end-encryption-to-sms-messages',
+    icon: mdiLockOutline,
+  },
+]
+</script>
+
+<template>
+  <VContainer class="pt-8">
+    <VRow :class="{ 'mt-16': mdAndUp }">
+      <VCol cols="12" md="9">
+        <!-- Hero -->
+        <span class="text-overline text-primary">Getting started</span>
+        <h1
+          :class="
+            mdAndUp ? 'text-display-medium mt-1' : 'text-display-small mt-n2'
+          "
+        >
+          Send your first SMS in 5 minutes
+        </h1>
+        <p class="text-body-large mt-4 text-medium-emphasis">
+          httpSMS turns the Android phone in your pocket into an SMS gateway. No
+          new SIM card, no per-message contracts — just your phone, the app, and
+          the four steps below.
+        </p>
+
+        <div class="d-flex flex-wrap ga-3 mt-6">
+          <VBtn
+            color="primary"
+            size="large"
+            variant="flat"
+            :href="apkUrl"
+            :prepend-icon="mdiDownload"
+          >
+            Download the Android app
+          </VBtn>
+          <VBtn
+            color="primary"
+            size="large"
+            variant="outlined"
+            to="/login"
+            :prepend-icon="mdiAccountPlusOutline"
+          >
+            Create a free account
+          </VBtn>
+        </div>
+
+        <VDivider class="my-10" />
+
+        <!-- Step 1 -->
+        <div class="d-flex align-center mb-3">
+          <VAvatar color="primary" size="40" class="mr-3">
+            <span class="text-title-large font-weight-bold">1</span>
+          </VAvatar>
+          <h2 class="text-headline-large">
+            Create your account &amp; copy your API key
+          </h2>
+        </div>
+        <p>
+          Sign up at
+          <NuxtLink
+            class="text-decoration-none hover:text-decoration-underline"
+            to="/login"
+            >httpsms.com</NuxtLink
+          >, then open
+          <NuxtLink
+            class="text-decoration-none hover:text-decoration-underline"
+            to="/settings"
+            >Settings</NuxtLink
+          >
+          and copy your API key. You'll paste it into the app in Step 3, so keep
+          it handy.
+        </p>
+        <VImg
+          class="rounded mt-4"
+          alt="httpSMS settings page showing the API key"
+          src="/img/blog/forward-incoming-sms-from-phone-to-webhook/settings.png"
+        />
+
+        <VDivider class="my-10" />
+
+        <!-- Step 2 -->
+        <div class="d-flex align-center mb-3">
+          <VAvatar color="primary" size="40" class="mr-3">
+            <span class="text-title-large font-weight-bold">2</span>
+          </VAvatar>
+          <h2 class="text-headline-large">Download &amp; install the app</h2>
+        </div>
+        <p>
+          <a
+            class="text-decoration-none hover:text-decoration-underline"
+            :href="apkUrl"
+            >⬇️ Download the httpSMS app</a
+          >
+          onto your Android phone and open the file to install it. If Android
+          asks, allow installs from this source — that's normal for apps
+          downloaded outside the Play Store.
+        </p>
+
+        <!-- Placeholder: replace with a GIF of installing the APK -->
+        <div class="media-placeholder rounded mt-4">
+          <div class="text-h4">📹</div>
+          <p class="text-title-medium mt-2 mb-0">
+            GIF: Downloading &amp; installing the app
+          </p>
+          <p class="text-body-small text-medium-emphasis mb-0">
+            /img/getting-started/install-app.gif
+          </p>
+        </div>
+
+        <VDivider class="my-10" />
+
+        <!-- Step 3 -->
+        <div class="d-flex align-center mb-3">
+          <VAvatar color="primary" size="40" class="mr-3">
+            <span class="text-title-large font-weight-bold">3</span>
+          </VAvatar>
+          <h2 class="text-headline-large">Sign in on your phone</h2>
+        </div>
+        <p>
+          Open the app, paste the API key from Step 1, and enter the phone
+          number of this Android phone. This is the phone that will send your
+          messages.
+        </p>
+        <VAlert type="info" variant="tonal" class="my-4">
+          Enter your phone number in international format, e.g.
+          <code>+18005550199</code>.
+        </VAlert>
+
+        <VRow class="mt-2">
+          <VCol cols="12" sm="6">
+            <VImg
+              class="rounded"
+              alt="httpSMS Android app sign-in screen"
+              max-height="520"
+              src="/img/blog/forward-incoming-sms-from-phone-to-webhook/android-app.png"
+            />
+          </VCol>
+          <VCol cols="12" sm="6">
+            <!-- Placeholder: replace with a GIF of signing in -->
+            <div class="media-placeholder media-placeholder-tall rounded">
+              <div class="text-h4">📹</div>
+              <p class="text-title-medium mt-2 mb-0">GIF: Signing in</p>
+              <p class="text-body-small text-medium-emphasis mb-0">
+                /img/getting-started/sign-in.gif
+              </p>
+            </div>
+          </VCol>
+        </VRow>
+
+        <VAlert
+          type="info"
+          variant="outlined"
+          class="mt-6"
+          :icon="mdiCheckCircle"
+        >
+          On Android 15+ you'll need to grant SMS permissions before the app can
+          send texts. Follow our short guide:
+          <NuxtLink
+            class="text-decoration-none hover:text-decoration-underline font-weight-bold"
+            to="/blog/grant-send-and-read-sms-permissions-on-android"
+            >How to grant SMS permissions on Android 15+</NuxtLink
+          >.
+        </VAlert>
+
+        <VDivider class="my-10" />
+
+        <!-- Step 4 -->
+        <div class="d-flex align-center mb-3">
+          <VAvatar color="primary" size="40" class="mr-3">
+            <span class="text-title-large font-weight-bold">4</span>
+          </VAvatar>
+          <h2 class="text-headline-large">Send your first SMS</h2>
+        </div>
+        <p>
+          Head to your dashboard, start a new message, and text yourself a quick
+          hello. Your phone sends it over the network, and you'll see it arrive
+          on the other device. That's it — you're up and running.
+        </p>
+
+        <!-- Placeholder: replace with a GIF of composing and sending a message -->
+        <div class="media-placeholder rounded mt-4">
+          <div class="text-h4">📹</div>
+          <p class="text-title-medium mt-2 mb-0">
+            GIF: Composing &amp; sending a message
+          </p>
+          <p class="text-body-small text-medium-emphasis mb-0">
+            /img/getting-started/send-sms.gif
+          </p>
+        </div>
+
+        <div class="mt-6">
+          <VBtn
+            color="primary"
+            size="large"
+            variant="flat"
+            to="/threads"
+            :append-icon="mdiOpenInNew"
+          >
+            Open your dashboard
+          </VBtn>
+        </div>
+
+        <VDivider class="my-10" />
+
+        <!-- Automate it -->
+        <h2 class="text-headline-large mb-1">Ready to automate?</h2>
+        <p class="text-body-large text-medium-emphasis mt-0 mb-4">
+          Now that your phone is sending texts, wire it into the tools you
+          already use.
+        </p>
+        <VRow>
+          <VCol v-for="item in automations" :key="item.to" cols="12" sm="6">
+            <NuxtLink
+              :to="item.to"
+              class="text-decoration-none hover:text-decoration-underline"
+            >
+              <VHover v-slot="{ isHovering, props: hoverProps }">
+                <VCard
+                  v-bind="hoverProps"
+                  :elevation="isHovering ? 8 : 2"
+                  :color="isHovering ? 'blue-darken-4' : undefined"
+                  class="automation-card d-flex align-center pa-4"
+                >
+                  <VAvatar
+                    color="primary"
+                    variant="tonal"
+                    size="44"
+                    class="mr-4"
+                  >
+                    <VIcon :icon="item.icon" />
+                  </VAvatar>
+                  <div>
+                    <div class="text-title-medium">{{ item.title }}</div>
+                    <div class="text-body-small text-medium-emphasis">
+                      {{ item.description }}
+                    </div>
+                  </div>
+                </VCard>
+              </VHover>
+            </NuxtLink>
+          </VCol>
+        </VRow>
+      </VCol>
+      <VCol v-if="mdAndUp" md="3">
+        <BlogSidebar />
+      </VCol>
+    </VRow>
+  </VContainer>
+</template>
+
+<style scoped>
+.media-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  min-height: 220px;
+  padding: 24px;
+  border: 2px dashed rgb(var(--v-theme-primary));
+  background: rgb(var(--v-theme-primary), 0.04);
+}
+
+.media-placeholder-tall {
+  min-height: 520px;
+  height: 100%;
+}
+
+.automation-card {
+  transition: all 0.3s ease;
+}
+</style>

--- a/web/app/pages/threads/index.vue
+++ b/web/app/pages/threads/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { mdiRocketLaunchOutline } from '@mdi/js'
+
 definePageMeta({
   middleware: ['auth'],
 })
@@ -47,6 +49,15 @@ onMounted(async () => {
             >
             if you have any questions
           </p>
+          <VBtn
+            color="primary"
+            variant="tonal"
+            class="mt-2"
+            to="/getting-started"
+            :prepend-icon="mdiRocketLaunchOutline"
+          >
+            New here? Get started
+          </VBtn>
         </div>
       </div>
     </VRow>

--- a/web/public/img/getting-started/README.md
+++ b/web/public/img/getting-started/README.md
@@ -1,0 +1,11 @@
+# Getting Started media
+
+Drop the following assets here to replace the placeholders on
+`/getting-started` (`web/app/pages/getting-started.vue`):
+
+- `install-app.gif` — downloading & installing the APK on Android
+- `sign-in.gif` — signing in with the API key in the app
+- `send-sms.gif` — composing & sending a message from the dashboard
+
+Once a file is added, replace the matching `.media-placeholder` block on the
+page with a `<VImg src="/img/getting-started/<file>" />`.


### PR DESCRIPTION
## Summary
Adds a dedicated `/affiliates` landing page and replaces the external Affiliates footer link with an internal link to it. Also adds a beginner-friendly `/getting-started` onboarding page that walks new users through sending their first SMS.

## Changes

### Affiliates page
- **New page** `web/app/pages/affiliates/index.vue` (route `/affiliates`), using the `website` layout and the site's dark theme + gradient identity with Vuetify 4 components:
  - Hero with headline, `up to \/sale` copy, and a primary CTA
  - `Why promote httpSMS` benefit cards
  - `How it works` 3-step section
  - FAQ shown directly in a two-column grid on desktop (single column on mobile)
  - Closing CTA banner
- All CTAs link to the LemonSqueezy signup: https://affiliates.lemonsqueezy.com/programs/httpsms
- **Edited** `web/app/layouts/website.vue` — footer `Affiliates` link now points to the internal `/affiliates` page instead of the external LemonSqueezy URL.

### Getting started page
- **New page** `web/app/pages/getting-started.vue` (route `/getting-started`), using the `website` layout. A short, dummy-proof onboarding flow aimed at non-technical users:
  - Hero — "Send your first SMS in 5 minutes" with two CTAs: download the Android APK and create a free account
  - Four numbered steps: create account & copy API key → download & install the app → sign in on the phone → send your first SMS
  - Reuses existing blog images (`settings.png`, `android-app.png`) and adds three dashed-border GIF placeholders under `/img/getting-started/` (`install-app.gif`, `sign-in.gif`, `send-sms.gif`) for screen recordings to be added later
  - Info alert linking to the Android 15+ SMS permissions guide
  - "Ready to automate?" grid linking to the existing how-to blog posts (Python, Excel, CSV, Zapier, Webhook, Encryption)
- **Discoverability**:
  - `web/app/layouts/website.vue` — added a `Getting Started` link to the footer Resources section
  - `web/app/pages/threads/index.vue` — added a "New here? Get started" CTA below the Discord message in the desktop empty state
- Added `web/public/img/getting-started/README.md` documenting the expected GIF assets.

## Verification
- `pnpm eslint`, `pnpm stylelint`, and `pnpm prettier --check` pass on changed files
- `/affiliates` and `/getting-started` render on the dev server (200, no compile/runtime errors)
