### PR TITLE
fix(api): resolve Go vet errors

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -74,6 +74,12 @@ jobs:
           docker compose wait seed || true
           sleep 2
 
+      - name: Run Handler Integration Tests
+        working-directory: ./api
+        env:
+          USER_API_KEY: test-user-api-key
+        run: go test -tags integration -v -timeout 60s ./pkg/handlers
+
       - name: Run Integration Tests
         working-directory: ./tests
         run: go test -v -timeout 300s ./...

--- a/api/pkg/cache/memory_cache.go
+++ b/api/pkg/cache/memory_cache.go
@@ -31,7 +31,7 @@ func (cache *memoryCache) Get(ctx context.Context, key string) (value string, er
 
 	response, ok := cache.store.Get(key)
 	if !ok {
-		return "", stacktrace.NewError(fmt.Sprintf("no item found in cache with key [%s]", key))
+		return "", stacktrace.NewError("%s", fmt.Sprintf("no item found in cache with key [%s]", key))
 	}
 
 	return response.(string), nil

--- a/api/pkg/cache/memory_cache.go
+++ b/api/pkg/cache/memory_cache.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/NdoleStudio/httpsms/pkg/telemetry"
@@ -31,7 +30,7 @@ func (cache *memoryCache) Get(ctx context.Context, key string) (value string, er
 
 	response, ok := cache.store.Get(key)
 	if !ok {
-		return "", stacktrace.NewError("%s", fmt.Sprintf("no item found in cache with key [%s]", key))
+		return "", stacktrace.NewError("no item found in cache with key [%s]", key)
 	}
 
 	return response.(string), nil

--- a/api/pkg/cache/redis_cache.go
+++ b/api/pkg/cache/redis_cache.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/NdoleStudio/httpsms/pkg/telemetry"
@@ -32,10 +31,10 @@ func (cache *redisCache) Get(ctx context.Context, key string) (value string, err
 
 	response, err := cache.client.Get(ctx, key).Result()
 	if errors.Is(err, redis.Nil) {
-		return "", stacktrace.Propagate(err, "%s", fmt.Sprintf("no item found in redis with key [%s]", key))
+		return "", stacktrace.Propagate(err, "no item found in redis with key [%s]", key)
 	}
 	if err != nil {
-		return "", stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot get item in redis with key [%s]", key))
+		return "", stacktrace.Propagate(err, "cannot get item in redis with key [%s]", key)
 	}
 	return response, nil
 }

--- a/api/pkg/cache/redis_cache.go
+++ b/api/pkg/cache/redis_cache.go
@@ -32,10 +32,10 @@ func (cache *redisCache) Get(ctx context.Context, key string) (value string, err
 
 	response, err := cache.client.Get(ctx, key).Result()
 	if errors.Is(err, redis.Nil) {
-		return "", stacktrace.Propagate(err, fmt.Sprintf("no item found in redis with key [%s]", key))
+		return "", stacktrace.Propagate(err, "%s", fmt.Sprintf("no item found in redis with key [%s]", key))
 	}
 	if err != nil {
-		return "", stacktrace.Propagate(err, fmt.Sprintf("cannot get item in redis with key [%s]", key))
+		return "", stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot get item in redis with key [%s]", key))
 	}
 	return response, nil
 }

--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -279,11 +279,11 @@ func (container *Container) DedicatedDB() (db *gorm.DB) {
 
 	container.logger.Debug(fmt.Sprintf("Running migrations for dedicated [%T]", db))
 	if err = db.AutoMigrate(&entities.Heartbeat{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.Heartbeat{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.Heartbeat{})))
 	}
 
 	if err = db.AutoMigrate(&entities.HeartbeatMonitor{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.HeartbeatMonitor{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.HeartbeatMonitor{})))
 	}
 
 	return container.dedicatedDB
@@ -371,47 +371,47 @@ ALTER TABLE discords ADD CONSTRAINT IF NOT EXISTS uni_discords_server_id CHECK (
 	}
 
 	if err = db.AutoMigrate(&entities.Message{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.Message{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.Message{})))
 	}
 
 	if err = db.AutoMigrate(&entities.MessageThread{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.MessageThread{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.MessageThread{})))
 	}
 
 	if err = db.AutoMigrate(&entities.User{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.User{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.User{})))
 	}
 
 	if err = db.AutoMigrate(&entities.MessageSendSchedule{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.MessageSendSchedule{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.MessageSendSchedule{})))
 	}
 
 	if err = db.AutoMigrate(&entities.Phone{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.Phone{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.Phone{})))
 	}
 
 	if err = db.AutoMigrate(&entities.PhoneNotification{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.PhoneNotification{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.PhoneNotification{})))
 	}
 
 	if err = db.AutoMigrate(&entities.BillingUsage{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.BillingUsage{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.BillingUsage{})))
 	}
 
 	if err = db.AutoMigrate(&entities.Webhook{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.Webhook{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.Webhook{})))
 	}
 
 	if err = db.AutoMigrate(&entities.Discord{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.Discord{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.Discord{})))
 	}
 
 	if err = db.AutoMigrate(&entities.Integration3CX{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.Integration3CX{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.Integration3CX{})))
 	}
 
 	if err = db.AutoMigrate(&entities.PhoneAPIKey{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot migrate %T", &entities.PhoneAPIKey{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.PhoneAPIKey{})))
 	}
 
 	return container.db
@@ -424,7 +424,7 @@ func (container *Container) FirebaseApp() (app *firebase.App) {
 	app, err := firebase.NewApp(context.Background(), nil, option.WithCredentialsJSON(container.FirebaseCredentials()))
 	if err != nil {
 		msg := "cannot initialize firebase application"
-		container.logger.Fatal(stacktrace.Propagate(err, msg))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", msg))
 	}
 	return app
 }
@@ -445,7 +445,7 @@ func (container *Container) Cache() cache.Cache {
 	container.logger.Debug("creating cache.Cache")
 	opt, err := redis.ParseURL(os.Getenv("REDIS_URL"))
 	if err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, fmt.Sprintf("cannot parse redis url [%s]", os.Getenv("REDIS_URL"))))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot parse redis url [%s]", os.Getenv("REDIS_URL"))))
 	}
 	if strings.HasPrefix(os.Getenv("REDIS_URL"), "rediss://") {
 		opt.TLSConfig = &tls.Config{
@@ -474,7 +474,7 @@ func (container *Container) FirebaseAuthClient() (client *auth.Client) {
 	authClient, err := container.FirebaseApp().Auth(context.Background())
 	if err != nil {
 		msg := "cannot initialize firebase auth client"
-		container.logger.Fatal(stacktrace.Propagate(err, msg))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", msg))
 	}
 	return authClient
 }
@@ -554,7 +554,7 @@ func (container *Container) FCMClient() services.FCMClient {
 	messagingClient, err := container.FirebaseApp().Messaging(context.Background())
 	if err != nil {
 		msg := "cannot initialize firebase messaging client"
-		container.logger.Fatal(stacktrace.Propagate(err, msg))
+		container.logger.Fatal(stacktrace.Propagate(err, "%s", msg))
 	}
 	return services.NewFirebaseFCMClient(messagingClient)
 }

--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -279,11 +279,11 @@ func (container *Container) DedicatedDB() (db *gorm.DB) {
 
 	container.logger.Debug(fmt.Sprintf("Running migrations for dedicated [%T]", db))
 	if err = db.AutoMigrate(&entities.Heartbeat{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.Heartbeat{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot migrate %T", &entities.Heartbeat{}))
 	}
 
 	if err = db.AutoMigrate(&entities.HeartbeatMonitor{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.HeartbeatMonitor{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot migrate %T", &entities.HeartbeatMonitor{}))
 	}
 
 	return container.dedicatedDB
@@ -371,47 +371,47 @@ ALTER TABLE discords ADD CONSTRAINT IF NOT EXISTS uni_discords_server_id CHECK (
 	}
 
 	if err = db.AutoMigrate(&entities.Message{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.Message{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot migrate %T", &entities.Message{}))
 	}
 
 	if err = db.AutoMigrate(&entities.MessageThread{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.MessageThread{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot migrate %T", &entities.MessageThread{}))
 	}
 
 	if err = db.AutoMigrate(&entities.User{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.User{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot migrate %T", &entities.User{}))
 	}
 
 	if err = db.AutoMigrate(&entities.MessageSendSchedule{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.MessageSendSchedule{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot migrate %T", &entities.MessageSendSchedule{}))
 	}
 
 	if err = db.AutoMigrate(&entities.Phone{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.Phone{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot migrate %T", &entities.Phone{}))
 	}
 
 	if err = db.AutoMigrate(&entities.PhoneNotification{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.PhoneNotification{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot migrate %T", &entities.PhoneNotification{}))
 	}
 
 	if err = db.AutoMigrate(&entities.BillingUsage{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.BillingUsage{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot migrate %T", &entities.BillingUsage{}))
 	}
 
 	if err = db.AutoMigrate(&entities.Webhook{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.Webhook{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot migrate %T", &entities.Webhook{}))
 	}
 
 	if err = db.AutoMigrate(&entities.Discord{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.Discord{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot migrate %T", &entities.Discord{}))
 	}
 
 	if err = db.AutoMigrate(&entities.Integration3CX{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.Integration3CX{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot migrate %T", &entities.Integration3CX{}))
 	}
 
 	if err = db.AutoMigrate(&entities.PhoneAPIKey{}); err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot migrate %T", &entities.PhoneAPIKey{})))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot migrate %T", &entities.PhoneAPIKey{}))
 	}
 
 	return container.db
@@ -423,8 +423,7 @@ func (container *Container) FirebaseApp() (app *firebase.App) {
 
 	app, err := firebase.NewApp(context.Background(), nil, option.WithCredentialsJSON(container.FirebaseCredentials()))
 	if err != nil {
-		msg := "cannot initialize firebase application"
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", msg))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot initialize firebase application"))
 	}
 	return app
 }
@@ -445,7 +444,7 @@ func (container *Container) Cache() cache.Cache {
 	container.logger.Debug("creating cache.Cache")
 	opt, err := redis.ParseURL(os.Getenv("REDIS_URL"))
 	if err != nil {
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot parse redis url [%s]", os.Getenv("REDIS_URL"))))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot parse redis url [%s]", os.Getenv("REDIS_URL")))
 	}
 	if strings.HasPrefix(os.Getenv("REDIS_URL"), "rediss://") {
 		opt.TLSConfig = &tls.Config{
@@ -473,8 +472,7 @@ func (container *Container) FirebaseAuthClient() (client *auth.Client) {
 	container.logger.Debug(fmt.Sprintf("creating %T", client))
 	authClient, err := container.FirebaseApp().Auth(context.Background())
 	if err != nil {
-		msg := "cannot initialize firebase auth client"
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", msg))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot initialize firebase auth client"))
 	}
 	return authClient
 }
@@ -553,8 +551,7 @@ func (container *Container) FCMClient() services.FCMClient {
 	container.logger.Debug("creating FirebaseFCMClient")
 	messagingClient, err := container.FirebaseApp().Messaging(context.Background())
 	if err != nil {
-		msg := "cannot initialize firebase messaging client"
-		container.logger.Fatal(stacktrace.Propagate(err, "%s", msg))
+		container.logger.Fatal(stacktrace.Propagate(err, "cannot initialize firebase messaging client"))
 	}
 	return services.NewFirebaseFCMClient(messagingClient)
 }

--- a/api/pkg/handlers/attachment_handler.go
+++ b/api/pkg/handlers/attachment_handler.go
@@ -66,8 +66,7 @@ func (h *AttachmentHandler) GetAttachment(c fiber.Ctx) error {
 
 	data, err := h.storage.Download(ctx, path)
 	if err != nil {
-		msg := fmt.Sprintf("cannot download attachment from path [%s]", path)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot download attachment from path [%s]", path))
 		if stacktrace.GetCode(err) == repositories.ErrCodeNotFound {
 			return h.responseNotFound(c, "attachment not found")
 		}

--- a/api/pkg/handlers/attachment_handler.go
+++ b/api/pkg/handlers/attachment_handler.go
@@ -67,7 +67,7 @@ func (h *AttachmentHandler) GetAttachment(c fiber.Ctx) error {
 	data, err := h.storage.Download(ctx, path)
 	if err != nil {
 		msg := fmt.Sprintf("cannot download attachment from path [%s]", path)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		if stacktrace.GetCode(err) == repositories.ErrCodeNotFound {
 			return h.responseNotFound(c, "attachment not found")
 		}

--- a/api/pkg/handlers/billing_handler.go
+++ b/api/pkg/handlers/billing_handler.go
@@ -65,21 +65,18 @@ func (h *BillingHandler) UsageHistory(c fiber.Ctx) error {
 
 	var request requests.BillingUsageHistory
 	if err := c.Bind().Query(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.Body(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateHistory(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while fetching heartbeats [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while fetching heartbeats [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching usage history")
 	}
 
 	heartbeats, err := h.service.GetUsageHistory(ctx, h.userIDFomContext(c), request.ToIndexParams())
 	if err != nil {
-		msg := fmt.Sprintf("cannot get billing usage history with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot get billing usage history with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -107,8 +104,7 @@ func (h *BillingHandler) Usage(c fiber.Ctx) error {
 
 	billingUsage, err := h.service.GetCurrentUsage(ctx, h.userIDFomContext(c))
 	if err != nil {
-		msg := fmt.Sprintf("cannot get current usage record for user [%s]", h.userFromContext(c))
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot get current usage record for user [%s]", h.userFromContext(c)))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/billing_handler.go
+++ b/api/pkg/handlers/billing_handler.go
@@ -66,20 +66,20 @@ func (h *BillingHandler) UsageHistory(c fiber.Ctx) error {
 	var request requests.BillingUsageHistory
 	if err := c.Bind().Query(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateHistory(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while fetching heartbeats [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching usage history")
 	}
 
 	heartbeats, err := h.service.GetUsageHistory(ctx, h.userIDFomContext(c), request.ToIndexParams())
 	if err != nil {
 		msg := fmt.Sprintf("cannot get billing usage history with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -108,7 +108,7 @@ func (h *BillingHandler) Usage(c fiber.Ctx) error {
 	billingUsage, err := h.service.GetCurrentUsage(ctx, h.userIDFomContext(c))
 	if err != nil {
 		msg := fmt.Sprintf("cannot get current usage record for user [%s]", h.userFromContext(c))
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/bulk_message_handler.go
+++ b/api/pkg/handlers/bulk_message_handler.go
@@ -67,8 +67,7 @@ func (h *BulkMessageHandler) Index(c fiber.Ctx) error {
 
 	orders, err := h.messageService.GetBulkMessages(ctx, h.userIDFomContext(c))
 	if err != nil {
-		msg := fmt.Sprintf("cannot fetch bulk messages for user [%s]", h.userIDFomContext(c))
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot fetch bulk messages for user [%s]", h.userIDFomContext(c)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -95,20 +94,18 @@ func (h *BulkMessageHandler) Store(c fiber.Ctx) error {
 
 	file, err := c.FormFile("document")
 	if err != nil {
-		msg := fmt.Sprintf("cannot fetch file with name [%s] from request", "document")
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot fetch file with name [%s] from request", "document"))
 		return h.responseBadRequest(c, err)
 	}
 
 	messages, userLocation, validationErrors := h.validator.ValidateStore(ctx, h.userIDFomContext(c), file)
 	if len(validationErrors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while sending bulk sms from CSV file [%s] for [%s]", spew.Sdump(validationErrors), file.Filename, h.userIDFomContext(c))
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while sending bulk sms from CSV file [%s] for [%s]", spew.Sdump(validationErrors), file.Filename, h.userIDFomContext(c)))
 		return h.responseUnprocessableEntity(c, validationErrors, "validation errors while sending bulk SMS")
 	}
 
 	if msg := h.billingService.IsEntitledWithCount(ctx, h.userIDFomContext(c), uint(len(messages))); msg != nil {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] is not entitled to send [%d] messages", h.userIDFomContext(c), len(messages))))
+		ctxLogger.Warn(stacktrace.NewError("user with ID [%s] is not entitled to send [%d] messages", h.userIDFomContext(c), len(messages)))
 		return h.responsePaymentRequired(c, *msg)
 	}
 
@@ -135,8 +132,8 @@ func (h *BulkMessageHandler) Store(c fiber.Ctx) error {
 			)
 			if err != nil {
 				count.Add(-1)
-				msg := fmt.Sprintf("cannot send message with payload [%s] at index [%d]", spew.Sdump(message), index)
-				ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+
+				ctxLogger.Error(stacktrace.Propagate(err, "cannot send message with payload [%s] at index [%d]", spew.Sdump(message), index))
 			}
 			wg.Done()
 		}(message, perPhoneIndex)

--- a/api/pkg/handlers/bulk_message_handler.go
+++ b/api/pkg/handlers/bulk_message_handler.go
@@ -68,7 +68,7 @@ func (h *BulkMessageHandler) Index(c fiber.Ctx) error {
 	orders, err := h.messageService.GetBulkMessages(ctx, h.userIDFomContext(c))
 	if err != nil {
 		msg := fmt.Sprintf("cannot fetch bulk messages for user [%s]", h.userIDFomContext(c))
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -96,19 +96,19 @@ func (h *BulkMessageHandler) Store(c fiber.Ctx) error {
 	file, err := c.FormFile("document")
 	if err != nil {
 		msg := fmt.Sprintf("cannot fetch file with name [%s] from request", "document")
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	messages, userLocation, validationErrors := h.validator.ValidateStore(ctx, h.userIDFomContext(c), file)
 	if len(validationErrors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while sending bulk sms from CSV file [%s] for [%s]", spew.Sdump(validationErrors), file.Filename, h.userIDFomContext(c))
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, validationErrors, "validation errors while sending bulk SMS")
 	}
 
 	if msg := h.billingService.IsEntitledWithCount(ctx, h.userIDFomContext(c), uint(len(messages))); msg != nil {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("user with ID [%s] is not entitled to send [%d] messages", h.userIDFomContext(c), len(messages))))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] is not entitled to send [%d] messages", h.userIDFomContext(c), len(messages))))
 		return h.responsePaymentRequired(c, *msg)
 	}
 
@@ -136,7 +136,7 @@ func (h *BulkMessageHandler) Store(c fiber.Ctx) error {
 			if err != nil {
 				count.Add(-1)
 				msg := fmt.Sprintf("cannot send message with payload [%s] at index [%d]", spew.Sdump(message), index)
-				ctxLogger.Error(stacktrace.Propagate(err, msg))
+				ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 			}
 			wg.Done()
 		}(message, perPhoneIndex)

--- a/api/pkg/handlers/discord_handler.go
+++ b/api/pkg/handlers/discord_handler.go
@@ -89,20 +89,20 @@ func (h *DiscordHandler) Index(c fiber.Ctx) error {
 	var request requests.DiscordIndex
 	if err := c.Bind().Query(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall URL [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateIndex(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while fetching discord integrations [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching discord integrations")
 	}
 
 	discordIntegrations, err := h.service.Index(ctx, h.userIDFomContext(c), request.ToIndexParams())
 	if err != nil {
 		msg := fmt.Sprintf("cannot get discord integrations with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -130,14 +130,14 @@ func (h *DiscordHandler) Delete(c fiber.Ctx) error {
 	discordID := c.Params("discordID")
 	if errors := h.validator.ValidateUUID(discordID, "discordID"); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while deleting discord integration with ID [%s]", spew.Sdump(errors), discordID)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while deleting discord integration")
 	}
 
 	err := h.service.Delete(ctx, h.userIDFomContext(c), uuid.MustParse(discordID))
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete discord integration with ID [%+#v]", discordID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -166,21 +166,21 @@ func (h *DiscordHandler) Update(c fiber.Ctx) error {
 	var request requests.DiscordUpdate
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into [%T]", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	request.DiscordID = c.Params("discordID")
 	if errors := h.validator.ValidateUpdate(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while updating user [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating discord integration")
 	}
 
 	user, err := h.service.Update(ctx, request.ToUpdateParams(h.userFromContext(c)))
 	if err != nil {
 		msg := fmt.Sprintf("cannot update discord integration with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -210,31 +210,31 @@ func (h *DiscordHandler) Store(c fiber.Ctx) error {
 	var request requests.DiscordStore
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall body [%s] into [%T]", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateStore(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while storing discord integration [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing discord integration")
 	}
 
 	discordIntegrations, err := h.service.Index(ctx, h.userIDFomContext(c), repositories.IndexParams{Skip: 0, Limit: 1})
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot index discord integrations for user [%s]", h.userIDFomContext(c))))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot index discord integrations for user [%s]", h.userIDFomContext(c))))
 		return h.responseInternalServerError(c)
 	}
 
 	if len(discordIntegrations) > 0 {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("user with ID [%s] wants to create more than 1 discord integration", h.userIDFomContext(c))))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] wants to create more than 1 discord integration", h.userIDFomContext(c))))
 		return h.responsePaymentRequired(c, "You can't create more than 1 discord integration contact us to upgrade your account.")
 	}
 
 	discordIntegration, err := h.service.Store(ctx, request.ToStoreParams(h.userFromContext(c)))
 	if err != nil {
 		msg := fmt.Sprintf("cannot store discord integration with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -264,7 +264,7 @@ func (h *DiscordHandler) Event(c fiber.Ctx) error {
 	var payload map[string]any
 	if err := json.Unmarshal(c.Body(), &payload); err != nil {
 		msg := fmt.Sprintf("cannot unmarshall [%s] to [%T]", string(c.Body()), payload)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return h.responseBadRequest(c, err)
 	}
 
@@ -278,7 +278,7 @@ func (h *DiscordHandler) Event(c fiber.Ctx) error {
 		return h.sendSMS(ctx, c, payload)
 	}
 
-	return h.responseBadRequest(c, stacktrace.NewError(fmt.Sprintf("unknown type [%d]", payload["type"])))
+	return h.responseBadRequest(c, stacktrace.NewError("%s", fmt.Sprintf("unknown type [%d]", payload["type"])))
 }
 
 func (h *DiscordHandler) createRequest(payload map[string]any) requests.MessageSend {
@@ -304,7 +304,7 @@ func (h *DiscordHandler) sendSMS(ctx context.Context, c fiber.Ctx, payload map[s
 	discord, err := h.service.GetByServerID(ctx, payload["guild_id"].(string))
 	if err != nil {
 		msg := fmt.Sprintf("cannot get discord integration by server ID [%s]", payload["guild_id"].(string))
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return c.JSON(
 			fiber.Map{
 				"type": 4,
@@ -343,7 +343,7 @@ func (h *DiscordHandler) sendSMS(ctx context.Context, c fiber.Ctx, payload map[s
 
 	if errors := h.messageValidator.ValidateMessageSend(ctx, discord.UserID, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while sending payload [%s]", spew.Sdump(errors), c.Body())
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 
 		var embeds []fiber.Map
 		for _, value := range errors {
@@ -365,7 +365,7 @@ func (h *DiscordHandler) sendSMS(ctx context.Context, c fiber.Ctx, payload map[s
 	}
 
 	if msg := h.billingService.IsEntitled(ctx, discord.UserID); msg != nil {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("user with ID [%s] can't send a message", discord.UserID)))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] can't send a message", discord.UserID)))
 		return c.JSON(
 			fiber.Map{
 				"type": 4,
@@ -385,7 +385,7 @@ func (h *DiscordHandler) sendSMS(ctx context.Context, c fiber.Ctx, payload map[s
 	message, err := h.messageService.SendMessage(ctx, request.ToMessageSendParams(discord.UserID, c.OriginalURL()))
 	if err != nil {
 		msg := fmt.Sprintf("cannot send message with paylod [%s] from discord server [%s]", c.Body(), discord.ServerID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return c.JSON(
 			fiber.Map{
 				"type": 4,

--- a/api/pkg/handlers/discord_handler.go
+++ b/api/pkg/handlers/discord_handler.go
@@ -88,21 +88,18 @@ func (h *DiscordHandler) Index(c fiber.Ctx) error {
 
 	var request requests.DiscordIndex
 	if err := c.Bind().Query(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall URL [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall URL [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateIndex(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while fetching discord integrations [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while fetching discord integrations [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching discord integrations")
 	}
 
 	discordIntegrations, err := h.service.Index(ctx, h.userIDFomContext(c), request.ToIndexParams())
 	if err != nil {
-		msg := fmt.Sprintf("cannot get discord integrations with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot get discord integrations with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -129,15 +126,13 @@ func (h *DiscordHandler) Delete(c fiber.Ctx) error {
 
 	discordID := c.Params("discordID")
 	if errors := h.validator.ValidateUUID(discordID, "discordID"); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while deleting discord integration with ID [%s]", spew.Sdump(errors), discordID)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while deleting discord integration with ID [%s]", spew.Sdump(errors), discordID))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while deleting discord integration")
 	}
 
 	err := h.service.Delete(ctx, h.userIDFomContext(c), uuid.MustParse(discordID))
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete discord integration with ID [%+#v]", discordID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot delete discord integration with ID [%+#v]", discordID))
 		return h.responseInternalServerError(c)
 	}
 
@@ -165,22 +160,19 @@ func (h *DiscordHandler) Update(c fiber.Ctx) error {
 
 	var request requests.DiscordUpdate
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into [%T]", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into [%T]", c.Body(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	request.DiscordID = c.Params("discordID")
 	if errors := h.validator.ValidateUpdate(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while updating user [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while updating user [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating discord integration")
 	}
 
 	user, err := h.service.Update(ctx, request.ToUpdateParams(h.userFromContext(c)))
 	if err != nil {
-		msg := fmt.Sprintf("cannot update discord integration with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot update discord integration with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -209,32 +201,29 @@ func (h *DiscordHandler) Store(c fiber.Ctx) error {
 
 	var request requests.DiscordStore
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall body [%s] into [%T]", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall body [%s] into [%T]", c.Body(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateStore(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while storing discord integration [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while storing discord integration [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing discord integration")
 	}
 
 	discordIntegrations, err := h.service.Index(ctx, h.userIDFomContext(c), repositories.IndexParams{Skip: 0, Limit: 1})
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot index discord integrations for user [%s]", h.userIDFomContext(c))))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot index discord integrations for user [%s]", h.userIDFomContext(c)))
 		return h.responseInternalServerError(c)
 	}
 
 	if len(discordIntegrations) > 0 {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] wants to create more than 1 discord integration", h.userIDFomContext(c))))
+		ctxLogger.Warn(stacktrace.NewError("user with ID [%s] wants to create more than 1 discord integration", h.userIDFomContext(c)))
 		return h.responsePaymentRequired(c, "You can't create more than 1 discord integration contact us to upgrade your account.")
 	}
 
 	discordIntegration, err := h.service.Store(ctx, request.ToStoreParams(h.userFromContext(c)))
 	if err != nil {
-		msg := fmt.Sprintf("cannot store discord integration with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot store discord integration with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -263,8 +252,7 @@ func (h *DiscordHandler) Event(c fiber.Ctx) error {
 
 	var payload map[string]any
 	if err := json.Unmarshal(c.Body(), &payload); err != nil {
-		msg := fmt.Sprintf("cannot unmarshall [%s] to [%T]", string(c.Body()), payload)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot unmarshall [%s] to [%T]", string(c.Body()), payload)))
 		return h.responseBadRequest(c, err)
 	}
 
@@ -278,7 +266,7 @@ func (h *DiscordHandler) Event(c fiber.Ctx) error {
 		return h.sendSMS(ctx, c, payload)
 	}
 
-	return h.responseBadRequest(c, stacktrace.NewError("%s", fmt.Sprintf("unknown type [%d]", payload["type"])))
+	return h.responseBadRequest(c, stacktrace.NewError("unknown type [%d]", payload["type"]))
 }
 
 func (h *DiscordHandler) createRequest(payload map[string]any) requests.MessageSend {
@@ -303,8 +291,7 @@ func (h *DiscordHandler) sendSMS(ctx context.Context, c fiber.Ctx, payload map[s
 
 	discord, err := h.service.GetByServerID(ctx, payload["guild_id"].(string))
 	if err != nil {
-		msg := fmt.Sprintf("cannot get discord integration by server ID [%s]", payload["guild_id"].(string))
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot get discord integration by server ID [%s]", payload["guild_id"].(string))))
 		return c.JSON(
 			fiber.Map{
 				"type": 4,
@@ -342,8 +329,7 @@ func (h *DiscordHandler) sendSMS(ctx context.Context, c fiber.Ctx, payload map[s
 	}
 
 	if errors := h.messageValidator.ValidateMessageSend(ctx, discord.UserID, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while sending payload [%s]", spew.Sdump(errors), c.Body())
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while sending payload [%s]", spew.Sdump(errors), c.Body()))
 
 		var embeds []fiber.Map
 		for _, value := range errors {
@@ -365,7 +351,7 @@ func (h *DiscordHandler) sendSMS(ctx context.Context, c fiber.Ctx, payload map[s
 	}
 
 	if msg := h.billingService.IsEntitled(ctx, discord.UserID); msg != nil {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] can't send a message", discord.UserID)))
+		ctxLogger.Warn(stacktrace.NewError("user with ID [%s] can't send a message", discord.UserID))
 		return c.JSON(
 			fiber.Map{
 				"type": 4,
@@ -384,8 +370,7 @@ func (h *DiscordHandler) sendSMS(ctx context.Context, c fiber.Ctx, payload map[s
 
 	message, err := h.messageService.SendMessage(ctx, request.ToMessageSendParams(discord.UserID, c.OriginalURL()))
 	if err != nil {
-		msg := fmt.Sprintf("cannot send message with paylod [%s] from discord server [%s]", c.Body(), discord.ServerID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot send message with paylod [%s] from discord server [%s]", c.Body(), discord.ServerID))
 		return c.JSON(
 			fiber.Map{
 				"type": 4,

--- a/api/pkg/handlers/events_handler.go
+++ b/api/pkg/handlers/events_handler.go
@@ -49,28 +49,24 @@ func (h *EventsHandler) Dispatch(c fiber.Ctx) error {
 
 	var request cloudevents.Event
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if err := request.Validate(); err != nil {
-		msg := fmt.Sprintf("validation errors [%s], while dispatching event [%+#v]", spew.Sdump(err.Error()), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while dispatching event [%+#v]", spew.Sdump(err.Error()), request))
 		return h.responseUnprocessableEntity(c, map[string][]string{"event": {err.Error()}}, "validation errors while dispatching event")
 	}
 
 	if h.userIDFomContext(c) != h.queueConfig.UserID {
-		msg := fmt.Sprintf("user with ID [%s], cannot dispatch event [%+#v]", h.userIDFomContext(c), request)
-		ctxLogger.Error(stacktrace.NewError("%s", msg))
+		ctxLogger.Error(stacktrace.NewError("user with ID [%s], cannot dispatch event [%+#v]", h.userIDFomContext(c), request))
 		return h.responseForbidden(c)
 	}
 
 	ctxLogger.Info(fmt.Sprintf("handling [%s] event with ID [%s]", request.Type(), request.ID()))
 	err := h.service.DispatchSync(ctx, request)
 	if err != nil {
-		msg := fmt.Sprintf("cannot dispatch [%s] event with ID [%s]", request.Type(), request.ID())
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot dispatch [%s] event with ID [%s]", request.Type(), request.ID()))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/events_handler.go
+++ b/api/pkg/handlers/events_handler.go
@@ -50,19 +50,19 @@ func (h *EventsHandler) Dispatch(c fiber.Ctx) error {
 	var request cloudevents.Event
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if err := request.Validate(); err != nil {
 		msg := fmt.Sprintf("validation errors [%s], while dispatching event [%+#v]", spew.Sdump(err.Error()), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, map[string][]string{"event": {err.Error()}}, "validation errors while dispatching event")
 	}
 
 	if h.userIDFomContext(c) != h.queueConfig.UserID {
 		msg := fmt.Sprintf("user with ID [%s], cannot dispatch event [%+#v]", h.userIDFomContext(c), request)
-		ctxLogger.Error(stacktrace.NewError(msg))
+		ctxLogger.Error(stacktrace.NewError("%s", msg))
 		return h.responseForbidden(c)
 	}
 
@@ -70,7 +70,7 @@ func (h *EventsHandler) Dispatch(c fiber.Ctx) error {
 	err := h.service.DispatchSync(ctx, request)
 	if err != nil {
 		msg := fmt.Sprintf("cannot dispatch [%s] event with ID [%s]", request.Type(), request.ID())
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/handler_test.go
+++ b/api/pkg/handlers/handler_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package handlers
 
 import (

--- a/api/pkg/handlers/heartbeat_handler.go
+++ b/api/pkg/handlers/heartbeat_handler.go
@@ -75,20 +75,20 @@ func (h *HeartbeatHandler) Index(c fiber.Ctx) error {
 	var request requests.HeartbeatIndex
 	if err := c.Bind().Query(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateIndex(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while fetching heartbeats [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching heartbeats")
 	}
 
 	heartbeats, err := h.service.Index(ctx, h.userIDFomContext(c), request.Owner, request.ToIndexParams())
 	if err != nil {
 		msg := fmt.Sprintf("cannot get messgaes with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -118,19 +118,19 @@ func (h *HeartbeatHandler) Store(c fiber.Ctx) error {
 	var request requests.HeartbeatStore
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateStore(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while storing heartbeat [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing heartbeat")
 	}
 
 	for _, phoneNumber := range request.PhoneNumbers {
 		if !h.authorizePhoneAPIKey(c, phoneNumber) {
-			ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("phone API Key ID [%s] is not authorized to store heartbeat for phone number [%s]", h.userFromContext(c).PhoneAPIKeyID, phoneNumber)))
+			ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("phone API Key ID [%s] is not authorized to store heartbeat for phone number [%s]", h.userFromContext(c).PhoneAPIKeyID, phoneNumber)))
 			return h.responsePhoneAPIKeyUnauthorized(c, phoneNumber, h.userFromContext(c))
 		}
 	}
@@ -145,7 +145,7 @@ func (h *HeartbeatHandler) Store(c fiber.Ctx) error {
 			response, err := h.service.Store(ctx, input)
 			if err != nil {
 				msg := fmt.Sprintf("cannot store heartbeat with params [%+#v]", request)
-				ctxLogger.Error(stacktrace.Propagate(err, msg))
+				ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 			}
 			responses[index] = response
 			wg.Done()

--- a/api/pkg/handlers/heartbeat_handler.go
+++ b/api/pkg/handlers/heartbeat_handler.go
@@ -74,21 +74,18 @@ func (h *HeartbeatHandler) Index(c fiber.Ctx) error {
 
 	var request requests.HeartbeatIndex
 	if err := c.Bind().Query(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateIndex(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while fetching heartbeats [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while fetching heartbeats [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching heartbeats")
 	}
 
 	heartbeats, err := h.service.Index(ctx, h.userIDFomContext(c), request.Owner, request.ToIndexParams())
 	if err != nil {
-		msg := fmt.Sprintf("cannot get messgaes with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot get messgaes with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -117,20 +114,18 @@ func (h *HeartbeatHandler) Store(c fiber.Ctx) error {
 
 	var request requests.HeartbeatStore
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateStore(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while storing heartbeat [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while storing heartbeat [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing heartbeat")
 	}
 
 	for _, phoneNumber := range request.PhoneNumbers {
 		if !h.authorizePhoneAPIKey(c, phoneNumber) {
-			ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("phone API Key ID [%s] is not authorized to store heartbeat for phone number [%s]", h.userFromContext(c).PhoneAPIKeyID, phoneNumber)))
+			ctxLogger.Warn(stacktrace.NewError("phone API Key ID [%s] is not authorized to store heartbeat for phone number [%s]", h.userFromContext(c).PhoneAPIKeyID, phoneNumber))
 			return h.responsePhoneAPIKeyUnauthorized(c, phoneNumber, h.userFromContext(c))
 		}
 	}
@@ -144,8 +139,7 @@ func (h *HeartbeatHandler) Store(c fiber.Ctx) error {
 		go func(input services.HeartbeatStoreParams, index int) {
 			response, err := h.service.Store(ctx, input)
 			if err != nil {
-				msg := fmt.Sprintf("cannot store heartbeat with params [%+#v]", request)
-				ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+				ctxLogger.Error(stacktrace.Propagate(err, "cannot store heartbeat with params [%+#v]", request))
 			}
 			responses[index] = response
 			wg.Done()

--- a/api/pkg/handlers/integration_3cx_handler.go
+++ b/api/pkg/handlers/integration_3cx_handler.go
@@ -74,7 +74,7 @@ func (h *Integration3CXHandler) Messages(c fiber.Ctx) error {
 	request.Sanitize()
 	message, err := h.messageService.SendMessage(ctx, request.ToMessageSendParams(h.userIDFomContext(c), c.OriginalURL()))
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "cannot send [3cx] message with paylod [%s]", c.Body()))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot send [3cx] message with payload [%s]", c.Body()))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/integration_3cx_handler.go
+++ b/api/pkg/handlers/integration_3cx_handler.go
@@ -62,21 +62,19 @@ func (h *Integration3CXHandler) Messages(c fiber.Ctx) error {
 
 	var request requests.Integration3CXMessage
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall [%s] into %T", c.Body(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if msg := h.billingService.IsEntitled(ctx, h.userIDFomContext(c)); msg != nil {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] can't send a [3cx] message", h.userIDFomContext(c))))
+		ctxLogger.Warn(stacktrace.NewError("user with ID [%s] can't send a [3cx] message", h.userIDFomContext(c)))
 		return h.responsePaymentRequired(c, *msg)
 	}
 
 	request.Sanitize()
 	message, err := h.messageService.SendMessage(ctx, request.ToMessageSendParams(h.userIDFomContext(c), c.OriginalURL()))
 	if err != nil {
-		msg := fmt.Sprintf("cannot send [3cx] message with paylod [%s]", c.Body())
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot send [3cx] message with paylod [%s]", c.Body()))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/integration_3cx_handler.go
+++ b/api/pkg/handlers/integration_3cx_handler.go
@@ -63,12 +63,12 @@ func (h *Integration3CXHandler) Messages(c fiber.Ctx) error {
 	var request requests.Integration3CXMessage
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if msg := h.billingService.IsEntitled(ctx, h.userIDFomContext(c)); msg != nil {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("user with ID [%s] can't send a [3cx] message", h.userIDFomContext(c))))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] can't send a [3cx] message", h.userIDFomContext(c))))
 		return h.responsePaymentRequired(c, *msg)
 	}
 
@@ -76,7 +76,7 @@ func (h *Integration3CXHandler) Messages(c fiber.Ctx) error {
 	message, err := h.messageService.SendMessage(ctx, request.ToMessageSendParams(h.userIDFomContext(c), c.OriginalURL()))
 	if err != nil {
 		msg := fmt.Sprintf("cannot send [3cx] message with paylod [%s]", c.Body())
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/lemonsqueezy_handler.go
+++ b/api/pkg/handlers/lemonsqueezy_handler.go
@@ -51,14 +51,12 @@ func (h *LemonsqueezyHandler) Event(c fiber.Ctx) error {
 
 	signature := c.Get("X-Signature")
 	if errors := h.validator.ValidateEvent(ctx, signature, c.Body()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while storing request [%s] and signature [%s]", spew.Sdump(errors), c.Body(), signature)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while storing request [%s] and signature [%s]", spew.Sdump(errors), c.Body(), signature))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing lemonsqueezy event")
 	}
 
 	if err := h.handleRequest(ctx, c); err != nil {
-		msg := fmt.Sprintf("cannot handle lemonsqueezy event [%s]", c.Body())
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot handle lemonsqueezy event [%s]", c.Body()))
 		return h.responseInternalServerError(c)
 	}
 
@@ -72,31 +70,31 @@ func (h *LemonsqueezyHandler) handleRequest(ctx context.Context, c fiber.Ctx) er
 		var request lemonsqueezy.WebhookRequestSubscription
 		err := json.Unmarshal(c.Body(), &request)
 		if err != nil {
-			return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot marshall [%s] to [%T]", c.Body(), request))
+			return stacktrace.Propagate(err, "cannot marshall [%s] to [%T]", c.Body(), request)
 		}
 		return h.service.HandleSubscriptionCreatedEvent(ctx, c.OriginalURL(), &request)
 	case "subscription_cancelled":
 		var request lemonsqueezy.WebhookRequestSubscription
 		err := json.Unmarshal(c.Body(), &request)
 		if err != nil {
-			return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot marshall [%s] to [%T]", c.Body(), request))
+			return stacktrace.Propagate(err, "cannot marshall [%s] to [%T]", c.Body(), request)
 		}
 		return h.service.HandleSubscriptionCanceledEvent(ctx, c.OriginalURL(), &request)
 	case "subscription_expired":
 		var request lemonsqueezy.WebhookRequestSubscription
 		err := json.Unmarshal(c.Body(), &request)
 		if err != nil {
-			return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot marshall [%s] to [%T]", c.Body(), request))
+			return stacktrace.Propagate(err, "cannot marshall [%s] to [%T]", c.Body(), request)
 		}
 		return h.service.HandleSubscriptionExpiredEvent(ctx, c.OriginalURL(), &request)
 	case "subscription_updated":
 		var request lemonsqueezy.WebhookRequestSubscription
 		err := json.Unmarshal(c.Body(), &request)
 		if err != nil {
-			return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot marshall [%s] to [%T]", c.Body(), request))
+			return stacktrace.Propagate(err, "cannot marshall [%s] to [%T]", c.Body(), request)
 		}
 		return h.service.HandleSubscriptionUpdatedEvent(ctx, c.OriginalURL(), &request)
 	default:
-		return stacktrace.NewError("%s", fmt.Sprintf("invalid event [%s] received with request [%s]", eventName, c.Body()))
+		return stacktrace.NewError("invalid event [%s] received with request [%s]", eventName, c.Body())
 	}
 }

--- a/api/pkg/handlers/lemonsqueezy_handler.go
+++ b/api/pkg/handlers/lemonsqueezy_handler.go
@@ -52,13 +52,13 @@ func (h *LemonsqueezyHandler) Event(c fiber.Ctx) error {
 	signature := c.Get("X-Signature")
 	if errors := h.validator.ValidateEvent(ctx, signature, c.Body()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while storing request [%s] and signature [%s]", spew.Sdump(errors), c.Body(), signature)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing lemonsqueezy event")
 	}
 
 	if err := h.handleRequest(ctx, c); err != nil {
 		msg := fmt.Sprintf("cannot handle lemonsqueezy event [%s]", c.Body())
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -72,31 +72,31 @@ func (h *LemonsqueezyHandler) handleRequest(ctx context.Context, c fiber.Ctx) er
 		var request lemonsqueezy.WebhookRequestSubscription
 		err := json.Unmarshal(c.Body(), &request)
 		if err != nil {
-			return stacktrace.Propagate(err, fmt.Sprintf("cannot marshall [%s] to [%T]", c.Body(), request))
+			return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot marshall [%s] to [%T]", c.Body(), request))
 		}
 		return h.service.HandleSubscriptionCreatedEvent(ctx, c.OriginalURL(), &request)
 	case "subscription_cancelled":
 		var request lemonsqueezy.WebhookRequestSubscription
 		err := json.Unmarshal(c.Body(), &request)
 		if err != nil {
-			return stacktrace.Propagate(err, fmt.Sprintf("cannot marshall [%s] to [%T]", c.Body(), request))
+			return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot marshall [%s] to [%T]", c.Body(), request))
 		}
 		return h.service.HandleSubscriptionCanceledEvent(ctx, c.OriginalURL(), &request)
 	case "subscription_expired":
 		var request lemonsqueezy.WebhookRequestSubscription
 		err := json.Unmarshal(c.Body(), &request)
 		if err != nil {
-			return stacktrace.Propagate(err, fmt.Sprintf("cannot marshall [%s] to [%T]", c.Body(), request))
+			return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot marshall [%s] to [%T]", c.Body(), request))
 		}
 		return h.service.HandleSubscriptionExpiredEvent(ctx, c.OriginalURL(), &request)
 	case "subscription_updated":
 		var request lemonsqueezy.WebhookRequestSubscription
 		err := json.Unmarshal(c.Body(), &request)
 		if err != nil {
-			return stacktrace.Propagate(err, fmt.Sprintf("cannot marshall [%s] to [%T]", c.Body(), request))
+			return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot marshall [%s] to [%T]", c.Body(), request))
 		}
 		return h.service.HandleSubscriptionUpdatedEvent(ctx, c.OriginalURL(), &request)
 	default:
-		return stacktrace.NewError(fmt.Sprintf("invalid event [%s] received with request [%s]", eventName, c.Body()))
+		return stacktrace.NewError("%s", fmt.Sprintf("invalid event [%s] received with request [%s]", eventName, c.Body()))
 	}
 }

--- a/api/pkg/handlers/message_handler.go
+++ b/api/pkg/handlers/message_handler.go
@@ -89,25 +89,25 @@ func (h *MessageHandler) PostSend(c fiber.Ctx) error {
 	var request requests.MessageSend
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateMessageSend(ctx, h.userIDFomContext(c), request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while sending payload [%s]", spew.Sdump(errors), c.Body())
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while sending message")
 	}
 
 	if msg := h.billingService.IsEntitled(ctx, h.userIDFomContext(c)); msg != nil {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("user with ID [%s] can't send a message", h.userIDFomContext(c))))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] can't send a message", h.userIDFomContext(c))))
 		return h.responsePaymentRequired(c, *msg)
 	}
 
 	message, err := h.service.SendMessage(ctx, request.ToMessageSendParams(h.userIDFomContext(c), c.OriginalURL()))
 	if err != nil {
 		msg := fmt.Sprintf("cannot send message with paylod [%s]", c.Body())
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -137,18 +137,18 @@ func (h *MessageHandler) BulkSend(c fiber.Ctx) error {
 	var request requests.MessageBulkSend
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateMessageBulkSend(ctx, h.userIDFomContext(c), request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while sending payload [%s]", spew.Sdump(errors), c.Body())
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while sending messages")
 	}
 
 	if msg := h.billingService.IsEntitledWithCount(ctx, h.userIDFomContext(c), uint(len(request.To))); msg != nil {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("user with ID [%s] is not entitled to send [%d] messages", h.userIDFomContext(c), len(request.To))))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] is not entitled to send [%d] messages", h.userIDFomContext(c), len(request.To))))
 		return h.responsePaymentRequired(c, *msg)
 	}
 
@@ -165,7 +165,7 @@ func (h *MessageHandler) BulkSend(c fiber.Ctx) error {
 			if err != nil {
 				count.Add(-1)
 				msg := fmt.Sprintf("cannot send message with paylod [%s] at index [%d]", spew.Sdump(message), index)
-				ctxLogger.Error(stacktrace.Propagate(err, msg))
+				ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 			}
 			responses[index] = response
 			wg.Done()
@@ -200,26 +200,26 @@ func (h *MessageHandler) GetOutstanding(c fiber.Ctx) error {
 	var request requests.MessageOutstanding
 	if err := c.Bind().Query(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateMessageOutstanding(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while fetching outstanding messages [%s]", spew.Sdump(errors), c.OriginalURL())
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching outstanding messages")
 	}
 
 	message, err := h.service.GetOutstanding(ctx, request.ToGetOutstandingParams(c.Path(), h.userFromContext(c), timestamp))
 	if stacktrace.GetCode(err) == repositories.ErrCodeNotFound {
 		msg := fmt.Sprintf("Cannot find outstanding message with ID [%s]", request.MessageID)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseNotFound(c, msg)
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot get outstanding messgage with ID [%s]", request.MessageID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -253,20 +253,20 @@ func (h *MessageHandler) Index(c fiber.Ctx) error {
 	var request requests.MessageIndex
 	if err := c.Bind().Query(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateMessageIndex(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while fetching messages [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching messages")
 	}
 
 	messages, err := h.service.GetMessages(ctx, request.ToGetParams(h.userIDFomContext(c)))
 	if err != nil {
 		msg := fmt.Sprintf("cannot get messages with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -298,7 +298,7 @@ func (h *MessageHandler) PostEvent(c fiber.Ctx) error {
 	var request requests.MessageEvent
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
@@ -309,7 +309,7 @@ func (h *MessageHandler) PostEvent(c fiber.Ctx) error {
 
 	if errors := h.validator.ValidateMessageEvent(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while storing event [%s] for message [%s]", spew.Sdump(errors), c.Body(), request.MessageID)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing event")
 	}
 
@@ -320,19 +320,19 @@ func (h *MessageHandler) PostEvent(c fiber.Ctx) error {
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot find message with id [%s]", request.MessageID)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return h.responseInternalServerError(c)
 	}
 
 	if !h.authorizePhoneAPIKey(c, message.Owner) {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("user with ID [%s] is not authorized to send event for message with ID [%s]", h.userIDFomContext(c), request.MessageID)))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] is not authorized to send event for message with ID [%s]", h.userIDFomContext(c), request.MessageID)))
 		return h.responsePhoneAPIKeyUnauthorized(c, message.Owner, h.userFromContext(c))
 	}
 
 	message, err = h.service.StoreEvent(ctx, message, request.ToMessageStoreEventParams(c.OriginalURL()))
 	if err != nil {
 		msg := fmt.Sprintf("cannot store event for message [%s] with paylod [%s]", request.MessageID, c.Body())
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -361,30 +361,30 @@ func (h *MessageHandler) PostReceive(c fiber.Ctx) error {
 	var request requests.MessageReceive
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateMessageReceive(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while sending payload [%s]", spew.Sdump(errors), c.Body())
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while receiving message")
 	}
 
 	if msg := h.billingService.IsEntitled(ctx, h.userIDFomContext(c)); msg != nil {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("user with ID [%s] can't receive a message becasuse they have exceeded the limit", h.userIDFomContext(c))))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] can't receive a message becasuse they have exceeded the limit", h.userIDFomContext(c))))
 		return h.responsePaymentRequired(c, *msg)
 	}
 
 	if !h.authorizePhoneAPIKey(c, request.To) {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("user with ID [%s] is not authorized to receive message to phone number [%s]", h.userIDFomContext(c), request.To)))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] is not authorized to receive message to phone number [%s]", h.userIDFomContext(c), request.To)))
 		return h.responsePhoneAPIKeyUnauthorized(c, request.To, h.userFromContext(c))
 	}
 
 	message, err := h.service.ReceiveMessage(ctx, request.ToMessageReceiveParams(h.userIDFomContext(c), c.OriginalURL()))
 	if err != nil {
 		msg := fmt.Sprintf("cannot receive message with payload [%s]", c.Body())
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -415,7 +415,7 @@ func (h *MessageHandler) Delete(c fiber.Ctx) error {
 	messageID := c.Params("messageID")
 	if errors := h.validator.ValidateUUID(messageID, "messageID"); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while deleting a message with ID [%s]", spew.Sdump(errors), messageID)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing event")
 	}
 
@@ -426,13 +426,13 @@ func (h *MessageHandler) Delete(c fiber.Ctx) error {
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot find message with id [%s]", messageID)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return h.responseInternalServerError(c)
 	}
 
 	if err = h.service.DeleteMessage(ctx, c.OriginalURL(), message); err != nil {
 		msg := fmt.Sprintf("cannot delete message with ID [%s] for user with ID [%s]", messageID, message.UserID)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -463,7 +463,7 @@ func (h *MessageHandler) Get(c fiber.Ctx) error {
 	messageID := c.Params("messageID")
 	if errors := h.validator.ValidateUUID(messageID, "messageID"); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while deleting a message with ID [%s]", spew.Sdump(errors), messageID)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing event")
 	}
 
@@ -474,7 +474,7 @@ func (h *MessageHandler) Get(c fiber.Ctx) error {
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot find message with id [%s]", messageID)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -505,25 +505,25 @@ func (h *MessageHandler) PostCallMissed(c fiber.Ctx) error {
 	var request requests.MessageCallMissed
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateCallMissed(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], for missed call event [%s]", spew.Sdump(errors), c.Body())
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing missed call event")
 	}
 
 	if !h.authorizePhoneAPIKey(c, request.To) {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("user with ID [%s] is not authorized to register missed phone call for phone number [%s]", h.userIDFomContext(c), request.To)))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] is not authorized to register missed phone call for phone number [%s]", h.userIDFomContext(c), request.To)))
 		return h.responsePhoneAPIKeyUnauthorized(c, request.To, h.userFromContext(c))
 	}
 
 	message, err := h.service.RegisterMissedCall(ctx, request.ToCallMissedParams(h.userIDFomContext(c), c.OriginalURL()))
 	if err != nil {
 		msg := fmt.Sprintf("cannot store missed call event for user [%s] with paylod [%s]", h.userIDFomContext(c), c.Body())
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -555,7 +555,7 @@ func (h *MessageHandler) Search(c fiber.Ctx) error {
 	var request requests.MessageSearch
 	if err := c.Bind().Query(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params in [%s] into [%T]", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
@@ -564,14 +564,14 @@ func (h *MessageHandler) Search(c fiber.Ctx) error {
 
 	if errors := h.validator.ValidateMessageSearch(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while searching messages [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while searching messages")
 	}
 
 	messages, err := h.service.SearchMessages(ctx, request.ToSearchParams(h.userIDFomContext(c)))
 	if err != nil {
 		msg := fmt.Sprintf("cannot search messages with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/message_handler.go
+++ b/api/pkg/handlers/message_handler.go
@@ -88,26 +88,23 @@ func (h *MessageHandler) PostSend(c fiber.Ctx) error {
 
 	var request requests.MessageSend
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall [%s] into %T", c.Body(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateMessageSend(ctx, h.userIDFomContext(c), request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while sending payload [%s]", spew.Sdump(errors), c.Body())
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while sending payload [%s]", spew.Sdump(errors), c.Body()))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while sending message")
 	}
 
 	if msg := h.billingService.IsEntitled(ctx, h.userIDFomContext(c)); msg != nil {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] can't send a message", h.userIDFomContext(c))))
+		ctxLogger.Warn(stacktrace.NewError("user with ID [%s] can't send a message", h.userIDFomContext(c)))
 		return h.responsePaymentRequired(c, *msg)
 	}
 
 	message, err := h.service.SendMessage(ctx, request.ToMessageSendParams(h.userIDFomContext(c), c.OriginalURL()))
 	if err != nil {
-		msg := fmt.Sprintf("cannot send message with paylod [%s]", c.Body())
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot send message with paylod [%s]", c.Body()))
 		return h.responseInternalServerError(c)
 	}
 
@@ -136,19 +133,17 @@ func (h *MessageHandler) BulkSend(c fiber.Ctx) error {
 
 	var request requests.MessageBulkSend
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall [%s] into %T", c.Body(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateMessageBulkSend(ctx, h.userIDFomContext(c), request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while sending payload [%s]", spew.Sdump(errors), c.Body())
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while sending payload [%s]", spew.Sdump(errors), c.Body()))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while sending messages")
 	}
 
 	if msg := h.billingService.IsEntitledWithCount(ctx, h.userIDFomContext(c), uint(len(request.To))); msg != nil {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] is not entitled to send [%d] messages", h.userIDFomContext(c), len(request.To))))
+		ctxLogger.Warn(stacktrace.NewError("user with ID [%s] is not entitled to send [%d] messages", h.userIDFomContext(c), len(request.To)))
 		return h.responsePaymentRequired(c, *msg)
 	}
 
@@ -164,8 +159,8 @@ func (h *MessageHandler) BulkSend(c fiber.Ctx) error {
 			response, err := h.service.SendMessage(ctx, message)
 			if err != nil {
 				count.Add(-1)
-				msg := fmt.Sprintf("cannot send message with paylod [%s] at index [%d]", spew.Sdump(message), index)
-				ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+
+				ctxLogger.Error(stacktrace.Propagate(err, "cannot send message with paylod [%s] at index [%d]", spew.Sdump(message), index))
 			}
 			responses[index] = response
 			wg.Done()
@@ -199,27 +194,24 @@ func (h *MessageHandler) GetOutstanding(c fiber.Ctx) error {
 
 	var request requests.MessageOutstanding
 	if err := c.Bind().Query(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateMessageOutstanding(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while fetching outstanding messages [%s]", spew.Sdump(errors), c.OriginalURL())
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while fetching outstanding messages [%s]", spew.Sdump(errors), c.OriginalURL()))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching outstanding messages")
 	}
 
 	message, err := h.service.GetOutstanding(ctx, request.ToGetOutstandingParams(c.Path(), h.userFromContext(c), timestamp))
 	if stacktrace.GetCode(err) == repositories.ErrCodeNotFound {
 		msg := fmt.Sprintf("Cannot find outstanding message with ID [%s]", request.MessageID)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "Cannot find outstanding message with ID [%s]", request.MessageID))
 		return h.responseNotFound(c, msg)
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot get outstanding messgage with ID [%s]", request.MessageID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot get outstanding messgage with ID [%s]", request.MessageID))
 		return h.responseInternalServerError(c)
 	}
 
@@ -252,21 +244,18 @@ func (h *MessageHandler) Index(c fiber.Ctx) error {
 
 	var request requests.MessageIndex
 	if err := c.Bind().Query(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateMessageIndex(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while fetching messages [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while fetching messages [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching messages")
 	}
 
 	messages, err := h.service.GetMessages(ctx, request.ToGetParams(h.userIDFomContext(c)))
 	if err != nil {
-		msg := fmt.Sprintf("cannot get messages with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot get messages with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -297,8 +286,7 @@ func (h *MessageHandler) PostEvent(c fiber.Ctx) error {
 
 	var request requests.MessageEvent
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall [%s] into %T", c.Body(), request))
 		return h.responseBadRequest(c, err)
 	}
 
@@ -308,8 +296,7 @@ func (h *MessageHandler) PostEvent(c fiber.Ctx) error {
 	}
 
 	if errors := h.validator.ValidateMessageEvent(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while storing event [%s] for message [%s]", spew.Sdump(errors), c.Body(), request.MessageID)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while storing event [%s] for message [%s]", spew.Sdump(errors), c.Body(), request.MessageID))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing event")
 	}
 
@@ -319,20 +306,18 @@ func (h *MessageHandler) PostEvent(c fiber.Ctx) error {
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot find message with id [%s]", request.MessageID)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find message with id [%s]", request.MessageID)))
 		return h.responseInternalServerError(c)
 	}
 
 	if !h.authorizePhoneAPIKey(c, message.Owner) {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] is not authorized to send event for message with ID [%s]", h.userIDFomContext(c), request.MessageID)))
+		ctxLogger.Warn(stacktrace.NewError("user with ID [%s] is not authorized to send event for message with ID [%s]", h.userIDFomContext(c), request.MessageID))
 		return h.responsePhoneAPIKeyUnauthorized(c, message.Owner, h.userFromContext(c))
 	}
 
 	message, err = h.service.StoreEvent(ctx, message, request.ToMessageStoreEventParams(c.OriginalURL()))
 	if err != nil {
-		msg := fmt.Sprintf("cannot store event for message [%s] with paylod [%s]", request.MessageID, c.Body())
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot store event for message [%s] with paylod [%s]", request.MessageID, c.Body())))
 		return h.responseInternalServerError(c)
 	}
 
@@ -360,31 +345,28 @@ func (h *MessageHandler) PostReceive(c fiber.Ctx) error {
 
 	var request requests.MessageReceive
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall [%s] into %T", c.Body(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateMessageReceive(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while sending payload [%s]", spew.Sdump(errors), c.Body())
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while sending payload [%s]", spew.Sdump(errors), c.Body()))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while receiving message")
 	}
 
 	if msg := h.billingService.IsEntitled(ctx, h.userIDFomContext(c)); msg != nil {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] can't receive a message becasuse they have exceeded the limit", h.userIDFomContext(c))))
+		ctxLogger.Warn(stacktrace.NewError("user with ID [%s] can't receive a message becasuse they have exceeded the limit", h.userIDFomContext(c)))
 		return h.responsePaymentRequired(c, *msg)
 	}
 
 	if !h.authorizePhoneAPIKey(c, request.To) {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] is not authorized to receive message to phone number [%s]", h.userIDFomContext(c), request.To)))
+		ctxLogger.Warn(stacktrace.NewError("user with ID [%s] is not authorized to receive message to phone number [%s]", h.userIDFomContext(c), request.To))
 		return h.responsePhoneAPIKeyUnauthorized(c, request.To, h.userFromContext(c))
 	}
 
 	message, err := h.service.ReceiveMessage(ctx, request.ToMessageReceiveParams(h.userIDFomContext(c), c.OriginalURL()))
 	if err != nil {
-		msg := fmt.Sprintf("cannot receive message with payload [%s]", c.Body())
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot receive message with payload [%s]", c.Body()))
 		return h.responseInternalServerError(c)
 	}
 
@@ -414,8 +396,7 @@ func (h *MessageHandler) Delete(c fiber.Ctx) error {
 
 	messageID := c.Params("messageID")
 	if errors := h.validator.ValidateUUID(messageID, "messageID"); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while deleting a message with ID [%s]", spew.Sdump(errors), messageID)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while deleting a message with ID [%s]", spew.Sdump(errors), messageID))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing event")
 	}
 
@@ -425,14 +406,12 @@ func (h *MessageHandler) Delete(c fiber.Ctx) error {
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot find message with id [%s]", messageID)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find message with id [%s]", messageID)))
 		return h.responseInternalServerError(c)
 	}
 
 	if err = h.service.DeleteMessage(ctx, c.OriginalURL(), message); err != nil {
-		msg := fmt.Sprintf("cannot delete message with ID [%s] for user with ID [%s]", messageID, message.UserID)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete message with ID [%s] for user with ID [%s]", messageID, message.UserID)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -462,8 +441,7 @@ func (h *MessageHandler) Get(c fiber.Ctx) error {
 
 	messageID := c.Params("messageID")
 	if errors := h.validator.ValidateUUID(messageID, "messageID"); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while deleting a message with ID [%s]", spew.Sdump(errors), messageID)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while deleting a message with ID [%s]", spew.Sdump(errors), messageID))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing event")
 	}
 
@@ -473,8 +451,7 @@ func (h *MessageHandler) Get(c fiber.Ctx) error {
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot find message with id [%s]", messageID)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find message with id [%s]", messageID)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -504,26 +481,23 @@ func (h *MessageHandler) PostCallMissed(c fiber.Ctx) error {
 
 	var request requests.MessageCallMissed
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall [%s] into %T", c.Body(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateCallMissed(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], for missed call event [%s]", spew.Sdump(errors), c.Body())
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], for missed call event [%s]", spew.Sdump(errors), c.Body()))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing missed call event")
 	}
 
 	if !h.authorizePhoneAPIKey(c, request.To) {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] is not authorized to register missed phone call for phone number [%s]", h.userIDFomContext(c), request.To)))
+		ctxLogger.Warn(stacktrace.NewError("user with ID [%s] is not authorized to register missed phone call for phone number [%s]", h.userIDFomContext(c), request.To))
 		return h.responsePhoneAPIKeyUnauthorized(c, request.To, h.userFromContext(c))
 	}
 
 	message, err := h.service.RegisterMissedCall(ctx, request.ToCallMissedParams(h.userIDFomContext(c), c.OriginalURL()))
 	if err != nil {
-		msg := fmt.Sprintf("cannot store missed call event for user [%s] with paylod [%s]", h.userIDFomContext(c), c.Body())
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot store missed call event for user [%s] with paylod [%s]", h.userIDFomContext(c), c.Body())))
 		return h.responseInternalServerError(c)
 	}
 
@@ -554,8 +528,7 @@ func (h *MessageHandler) Search(c fiber.Ctx) error {
 
 	var request requests.MessageSearch
 	if err := c.Bind().Query(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params in [%s] into [%T]", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params in [%s] into [%T]", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
@@ -563,15 +536,13 @@ func (h *MessageHandler) Search(c fiber.Ctx) error {
 	request.Token = c.Get("token")
 
 	if errors := h.validator.ValidateMessageSearch(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while searching messages [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while searching messages [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while searching messages")
 	}
 
 	messages, err := h.service.SearchMessages(ctx, request.ToSearchParams(h.userIDFomContext(c)))
 	if err != nil {
-		msg := fmt.Sprintf("cannot search messages with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot search messages with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/message_send_schedule_handler.go
+++ b/api/pkg/handlers/message_send_schedule_handler.go
@@ -69,7 +69,7 @@ func (h *MessageSendScheduleHandler) Index(c fiber.Ctx) error {
 
 	schedules, err := h.service.Index(ctx, userID)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot list send schedules for user [%s]", userID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot list send schedules for user [%s]", userID)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -102,7 +102,7 @@ func (h *MessageSendScheduleHandler) Store(c fiber.Ctx) error {
 		return h.service.CountByUser(ctx, userID)
 	})
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot check entitlement for send schedules for user [%s]", userID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot check entitlement for send schedules for user [%s]", userID)))
 		return h.responseInternalServerError(c)
 	}
 	if !result.Allowed {
@@ -126,7 +126,7 @@ func (h *MessageSendScheduleHandler) Store(c fiber.Ctx) error {
 
 	schedule, err := h.service.Store(ctx, request.ToParams(h.userFromContext(c)))
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot create send schedule for user [%s]", userID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create send schedule for user [%s]", userID)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -173,7 +173,7 @@ func (h *MessageSendScheduleHandler) Update(c fiber.Ctx) error {
 
 	schedule, err := h.service.Update(ctx, userID, scheduleID, request.ToParams(h.userFromContext(c)))
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot update send schedule for user [%s] and schedule [%s]", userID, scheduleID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot update send schedule for user [%s] and schedule [%s]", userID, scheduleID)))
 		if stacktrace.GetCode(err) == repositories.ErrCodeNotFound {
 			return h.responseNotFound(c, err.Error())
 		}
@@ -209,7 +209,7 @@ func (h *MessageSendScheduleHandler) Delete(c fiber.Ctx) error {
 	userID := h.userIDFomContext(c)
 
 	if _, err = h.service.Load(ctx, userID, scheduleID); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot load send schedule for deletion for user [%s] and schedule [%s]", userID, scheduleID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load send schedule for deletion for user [%s] and schedule [%s]", userID, scheduleID)))
 		if stacktrace.GetCode(err) == repositories.ErrCodeNotFound {
 			return h.responseNotFound(c, err.Error())
 		}
@@ -217,7 +217,7 @@ func (h *MessageSendScheduleHandler) Delete(c fiber.Ctx) error {
 	}
 
 	if err = h.service.Delete(ctx, userID, scheduleID); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot delete send schedule for user [%s] and schedule [%s]", userID, scheduleID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot delete send schedule for user [%s] and schedule [%s]", userID, scheduleID)))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/message_send_schedule_handler.go
+++ b/api/pkg/handlers/message_send_schedule_handler.go
@@ -69,7 +69,7 @@ func (h *MessageSendScheduleHandler) Index(c fiber.Ctx) error {
 
 	schedules, err := h.service.Index(ctx, userID)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot list send schedules for user [%s]", userID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot list send schedules for user [%s]", userID))
 		return h.responseInternalServerError(c)
 	}
 
@@ -102,7 +102,7 @@ func (h *MessageSendScheduleHandler) Store(c fiber.Ctx) error {
 		return h.service.CountByUser(ctx, userID)
 	})
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot check entitlement for send schedules for user [%s]", userID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot check entitlement for send schedules for user [%s]", userID))
 		return h.responseInternalServerError(c)
 	}
 	if !result.Allowed {
@@ -126,7 +126,7 @@ func (h *MessageSendScheduleHandler) Store(c fiber.Ctx) error {
 
 	schedule, err := h.service.Store(ctx, request.ToParams(h.userFromContext(c)))
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create send schedule for user [%s]", userID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot create send schedule for user [%s]", userID))
 		return h.responseInternalServerError(c)
 	}
 
@@ -173,7 +173,7 @@ func (h *MessageSendScheduleHandler) Update(c fiber.Ctx) error {
 
 	schedule, err := h.service.Update(ctx, userID, scheduleID, request.ToParams(h.userFromContext(c)))
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot update send schedule for user [%s] and schedule [%s]", userID, scheduleID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot update send schedule for user [%s] and schedule [%s]", userID, scheduleID))
 		if stacktrace.GetCode(err) == repositories.ErrCodeNotFound {
 			return h.responseNotFound(c, err.Error())
 		}
@@ -209,7 +209,7 @@ func (h *MessageSendScheduleHandler) Delete(c fiber.Ctx) error {
 	userID := h.userIDFomContext(c)
 
 	if _, err = h.service.Load(ctx, userID, scheduleID); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load send schedule for deletion for user [%s] and schedule [%s]", userID, scheduleID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot load send schedule for deletion for user [%s] and schedule [%s]", userID, scheduleID))
 		if stacktrace.GetCode(err) == repositories.ErrCodeNotFound {
 			return h.responseNotFound(c, err.Error())
 		}
@@ -217,7 +217,7 @@ func (h *MessageSendScheduleHandler) Delete(c fiber.Ctx) error {
 	}
 
 	if err = h.service.Delete(ctx, userID, scheduleID); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot delete send schedule for user [%s] and schedule [%s]", userID, scheduleID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot delete send schedule for user [%s] and schedule [%s]", userID, scheduleID))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/message_thread_handler.go
+++ b/api/pkg/handlers/message_thread_handler.go
@@ -73,21 +73,18 @@ func (h *MessageThreadHandler) Index(c fiber.Ctx) error {
 
 	var request requests.MessageThreadIndex
 	if err := c.Bind().Query(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateMessageThreadIndex(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while fetching message threads [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while fetching message threads [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching message threads")
 	}
 
 	threads, err := h.service.GetThreads(ctx, request.ToGetParams(h.userIDFomContext(c)))
 	if err != nil {
-		msg := fmt.Sprintf("cannot get message threads with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot get message threads with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -115,22 +112,19 @@ func (h *MessageThreadHandler) Update(c fiber.Ctx) error {
 
 	var request requests.MessageThreadUpdate
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	request.MessageThreadID = c.Params("messageThreadID")
 	if errors := h.validator.ValidateUpdate(ctx, request); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while updating message thread [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while updating message thread [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating message thread")
 	}
 
 	thread, err := h.service.UpdateStatus(ctx, request.ToUpdateParams(h.userIDFomContext(c)))
 	if err != nil {
-		msg := fmt.Sprintf("cannot update message thread with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot update message thread with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -158,8 +152,7 @@ func (h *MessageThreadHandler) Delete(c fiber.Ctx) error {
 
 	messageThreadID := c.Params("messageThreadID")
 	if errors := h.validator.ValidateUUID(messageThreadID, "messageThreadID"); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while deleting a thread thread with ID [%s]", spew.Sdump(errors), messageThreadID)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while deleting a thread thread with ID [%s]", spew.Sdump(errors), messageThreadID))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while deleting a thread thread")
 	}
 
@@ -169,14 +162,12 @@ func (h *MessageThreadHandler) Delete(c fiber.Ctx) error {
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot find thread thread with id [%s]", messageThreadID)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find thread thread with id [%s]", messageThreadID)))
 		return h.responseInternalServerError(c)
 	}
 
 	if err = h.service.DeleteThread(ctx, c.OriginalURL(), thread); err != nil {
-		msg := fmt.Sprintf("cannot delete thread thread with ID [%s] for user with ID [%s]", messageThreadID, thread.UserID)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete thread thread with ID [%s] for user with ID [%s]", messageThreadID, thread.UserID)))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/message_thread_handler.go
+++ b/api/pkg/handlers/message_thread_handler.go
@@ -74,20 +74,20 @@ func (h *MessageThreadHandler) Index(c fiber.Ctx) error {
 	var request requests.MessageThreadIndex
 	if err := c.Bind().Query(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateMessageThreadIndex(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while fetching message threads [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching message threads")
 	}
 
 	threads, err := h.service.GetThreads(ctx, request.ToGetParams(h.userIDFomContext(c)))
 	if err != nil {
 		msg := fmt.Sprintf("cannot get message threads with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -116,21 +116,21 @@ func (h *MessageThreadHandler) Update(c fiber.Ctx) error {
 	var request requests.MessageThreadUpdate
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	request.MessageThreadID = c.Params("messageThreadID")
 	if errors := h.validator.ValidateUpdate(ctx, request); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while updating message thread [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating message thread")
 	}
 
 	thread, err := h.service.UpdateStatus(ctx, request.ToUpdateParams(h.userIDFomContext(c)))
 	if err != nil {
 		msg := fmt.Sprintf("cannot update message thread with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -159,7 +159,7 @@ func (h *MessageThreadHandler) Delete(c fiber.Ctx) error {
 	messageThreadID := c.Params("messageThreadID")
 	if errors := h.validator.ValidateUUID(messageThreadID, "messageThreadID"); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while deleting a thread thread with ID [%s]", spew.Sdump(errors), messageThreadID)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while deleting a thread thread")
 	}
 
@@ -170,13 +170,13 @@ func (h *MessageThreadHandler) Delete(c fiber.Ctx) error {
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot find thread thread with id [%s]", messageThreadID)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return h.responseInternalServerError(c)
 	}
 
 	if err = h.service.DeleteThread(ctx, c.OriginalURL(), thread); err != nil {
 		msg := fmt.Sprintf("cannot delete thread thread with ID [%s] for user with ID [%s]", messageThreadID, thread.UserID)
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/phone_api_key_handler.go
+++ b/api/pkg/handlers/phone_api_key_handler.go
@@ -73,20 +73,20 @@ func (h *PhoneAPIKeyHandler) index(c fiber.Ctx) error {
 	var request requests.PhoneAPIKeyIndex
 	if err := c.Bind().Query(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateIndex(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while fetching phone API keys [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching phone API keys")
 	}
 
 	apiKeys, err := h.service.Index(ctx, h.userIDFomContext(c), request.ToIndexParams())
 	if err != nil {
 		msg := fmt.Sprintf("cannot index phone API keys with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -117,7 +117,7 @@ func (h *PhoneAPIKeyHandler) store(c fiber.Ctx) error {
 		return h.service.CountByUser(ctx, userID)
 	})
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot check entitlement for phone API keys for user [%s]", userID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot check entitlement for phone API keys for user [%s]", userID)))
 		return h.responseInternalServerError(c)
 	}
 	if !result.Allowed {
@@ -127,20 +127,20 @@ func (h *PhoneAPIKeyHandler) store(c fiber.Ctx) error {
 	var request requests.PhoneAPIKeyStoreRequest
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateStore(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while updating phones [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating phones")
 	}
 
 	phoneAPIKey, err := h.service.Create(ctx, h.userFromContext(c), request.Name)
 	if err != nil {
 		msg := fmt.Sprintf("cannot update phones with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -168,7 +168,7 @@ func (h *PhoneAPIKeyHandler) delete(c fiber.Ctx) error {
 	phoneAPIKeyID := c.Params("phoneAPIKeyID")
 	if errors := h.validator.ValidateUUID(phoneAPIKeyID, "phoneAPIKeyID"); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while deleting a phone API key with ID [%s]", spew.Sdump(errors), phoneAPIKeyID)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing event")
 	}
 
@@ -179,7 +179,7 @@ func (h *PhoneAPIKeyHandler) delete(c fiber.Ctx) error {
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete phone API key with ID [%s] for user with ID [%s]", phoneAPIKeyID, h.userIDFomContext(c))
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -209,7 +209,7 @@ func (h *PhoneAPIKeyHandler) deletePhone(c fiber.Ctx) error {
 	phoneID := c.Params("phoneID")
 	if errors := h.mergeErrors(h.validator.ValidateUUID(phoneAPIKeyID, "phoneAPIKeyID"), h.validator.ValidateUUID(phoneID, "phoneID")); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while deleting a phone API key with ID [%s]", spew.Sdump(errors), phoneAPIKeyID)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing event")
 	}
 
@@ -220,7 +220,7 @@ func (h *PhoneAPIKeyHandler) deletePhone(c fiber.Ctx) error {
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot remove phone with ID [%s] from phone API key with ID [%s] for user with ID [%s]", phoneID, phoneAPIKeyID, h.userIDFomContext(c))
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/phone_api_key_handler.go
+++ b/api/pkg/handlers/phone_api_key_handler.go
@@ -72,21 +72,18 @@ func (h *PhoneAPIKeyHandler) index(c fiber.Ctx) error {
 
 	var request requests.PhoneAPIKeyIndex
 	if err := c.Bind().Query(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateIndex(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while fetching phone API keys [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while fetching phone API keys [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching phone API keys")
 	}
 
 	apiKeys, err := h.service.Index(ctx, h.userIDFomContext(c), request.ToIndexParams())
 	if err != nil {
-		msg := fmt.Sprintf("cannot index phone API keys with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot index phone API keys with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -117,7 +114,7 @@ func (h *PhoneAPIKeyHandler) store(c fiber.Ctx) error {
 		return h.service.CountByUser(ctx, userID)
 	})
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot check entitlement for phone API keys for user [%s]", userID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot check entitlement for phone API keys for user [%s]", userID))
 		return h.responseInternalServerError(c)
 	}
 	if !result.Allowed {
@@ -126,21 +123,18 @@ func (h *PhoneAPIKeyHandler) store(c fiber.Ctx) error {
 
 	var request requests.PhoneAPIKeyStoreRequest
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateStore(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while updating phones [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while updating phones [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating phones")
 	}
 
 	phoneAPIKey, err := h.service.Create(ctx, h.userFromContext(c), request.Name)
 	if err != nil {
-		msg := fmt.Sprintf("cannot update phones with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot update phones with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -167,8 +161,7 @@ func (h *PhoneAPIKeyHandler) delete(c fiber.Ctx) error {
 
 	phoneAPIKeyID := c.Params("phoneAPIKeyID")
 	if errors := h.validator.ValidateUUID(phoneAPIKeyID, "phoneAPIKeyID"); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while deleting a phone API key with ID [%s]", spew.Sdump(errors), phoneAPIKeyID)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while deleting a phone API key with ID [%s]", spew.Sdump(errors), phoneAPIKeyID))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing event")
 	}
 
@@ -178,8 +171,7 @@ func (h *PhoneAPIKeyHandler) delete(c fiber.Ctx) error {
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete phone API key with ID [%s] for user with ID [%s]", phoneAPIKeyID, h.userIDFomContext(c))
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete phone API key with ID [%s] for user with ID [%s]", phoneAPIKeyID, h.userIDFomContext(c))))
 		return h.responseInternalServerError(c)
 	}
 
@@ -208,8 +200,7 @@ func (h *PhoneAPIKeyHandler) deletePhone(c fiber.Ctx) error {
 	phoneAPIKeyID := c.Params("phoneAPIKeyID")
 	phoneID := c.Params("phoneID")
 	if errors := h.mergeErrors(h.validator.ValidateUUID(phoneAPIKeyID, "phoneAPIKeyID"), h.validator.ValidateUUID(phoneID, "phoneID")); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while deleting a phone API key with ID [%s]", spew.Sdump(errors), phoneAPIKeyID)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while deleting a phone API key with ID [%s]", spew.Sdump(errors), phoneAPIKeyID))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing event")
 	}
 
@@ -219,8 +210,7 @@ func (h *PhoneAPIKeyHandler) deletePhone(c fiber.Ctx) error {
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot remove phone with ID [%s] from phone API key with ID [%s] for user with ID [%s]", phoneID, phoneAPIKeyID, h.userIDFomContext(c))
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot remove phone with ID [%s] from phone API key with ID [%s] for user with ID [%s]", phoneID, phoneAPIKeyID, h.userIDFomContext(c))))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/phone_api_key_handler_test.go
+++ b/api/pkg/handlers/phone_api_key_handler_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package handlers
 
 import (

--- a/api/pkg/handlers/phone_handler.go
+++ b/api/pkg/handlers/phone_handler.go
@@ -75,20 +75,20 @@ func (h *PhoneHandler) Index(c fiber.Ctx) error {
 	var request requests.PhoneIndex
 	if err := c.Bind().Query(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateIndex(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while fetching phones [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching phones")
 	}
 
 	phones, err := h.service.Index(ctx, h.userFromContext(c), request.ToIndexParams())
 	if err != nil {
 		msg := fmt.Sprintf("cannot index phones with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -118,20 +118,20 @@ func (h *PhoneHandler) Upsert(c fiber.Ctx) error {
 	var request requests.PhoneUpsert
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateUpsert(ctx, h.userIDFomContext(c), request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while updating phones [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating phones")
 	}
 
 	phone, err := h.service.Upsert(ctx, request.ToUpsertParams(h.userFromContext(c), c.OriginalURL(), c.Body()))
 	if err != nil {
 		msg := fmt.Sprintf("cannot update phones with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -161,7 +161,7 @@ func (h *PhoneHandler) Delete(c fiber.Ctx) error {
 	request := requests.PhoneDelete{PhoneID: c.Params("phoneID")}
 	if errors := h.validator.ValidateDelete(ctx, request); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while deleting phone [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while deleting phone")
 	}
 
@@ -171,7 +171,7 @@ func (h *PhoneHandler) Delete(c fiber.Ctx) error {
 	}
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete phones with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -201,20 +201,20 @@ func (h *PhoneHandler) UpsertFCMToken(c fiber.Ctx) error {
 	var request requests.PhoneFCMToken
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateFCMToken(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while updating phones [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating phones")
 	}
 
 	phone, err := h.service.UpsertFCMToken(ctx, request.ToPhoneFCMTokenParams(h.userFromContext(c), c.OriginalURL()))
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete phones with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/phone_handler.go
+++ b/api/pkg/handlers/phone_handler.go
@@ -74,21 +74,18 @@ func (h *PhoneHandler) Index(c fiber.Ctx) error {
 
 	var request requests.PhoneIndex
 	if err := c.Bind().Query(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateIndex(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while fetching phones [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while fetching phones [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching phones")
 	}
 
 	phones, err := h.service.Index(ctx, h.userFromContext(c), request.ToIndexParams())
 	if err != nil {
-		msg := fmt.Sprintf("cannot index phones with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot index phones with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -117,21 +114,18 @@ func (h *PhoneHandler) Upsert(c fiber.Ctx) error {
 
 	var request requests.PhoneUpsert
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateUpsert(ctx, h.userIDFomContext(c), request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while updating phones [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while updating phones [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating phones")
 	}
 
 	phone, err := h.service.Upsert(ctx, request.ToUpsertParams(h.userFromContext(c), c.OriginalURL(), c.Body()))
 	if err != nil {
-		msg := fmt.Sprintf("cannot update phones with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot update phones with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -160,8 +154,7 @@ func (h *PhoneHandler) Delete(c fiber.Ctx) error {
 
 	request := requests.PhoneDelete{PhoneID: c.Params("phoneID")}
 	if errors := h.validator.ValidateDelete(ctx, request); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while deleting phone [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while deleting phone [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while deleting phone")
 	}
 
@@ -170,8 +163,7 @@ func (h *PhoneHandler) Delete(c fiber.Ctx) error {
 		return h.responseNotFound(c, fmt.Sprintf("cannot find phone with ID [%s]", request.PhoneID))
 	}
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete phones with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot delete phones with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -200,21 +192,18 @@ func (h *PhoneHandler) UpsertFCMToken(c fiber.Ctx) error {
 
 	var request requests.PhoneFCMToken
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateFCMToken(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while updating phones [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while updating phones [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating phones")
 	}
 
 	phone, err := h.service.UpsertFCMToken(ctx, request.ToPhoneFCMTokenParams(h.userFromContext(c), c.OriginalURL()))
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete phones with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot delete phones with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/user_handler.go
+++ b/api/pkg/handlers/user_handler.go
@@ -72,7 +72,7 @@ func (h *UserHandler) Show(c fiber.Ctx) error {
 	user, err := h.service.Get(ctx, c.OriginalURL(), authUser)
 	if err != nil {
 		msg := fmt.Sprintf("cannot get user with ID [%s]", authUser.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -102,20 +102,20 @@ func (h *UserHandler) Update(c fiber.Ctx) error {
 	var request requests.UserUpdate
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateUpdate(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while updating user [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating user")
 	}
 
 	user, err := h.service.Update(ctx, c.OriginalURL(), h.userFromContext(c), request.ToUpdateParams())
 	if err != nil {
 		msg := fmt.Sprintf("cannot update user with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -139,7 +139,7 @@ func (h *UserHandler) Delete(c fiber.Ctx) error {
 
 	if err := h.service.Delete(ctx, c.OriginalURL(), h.userIDFomContext(c)); err != nil {
 		msg := fmt.Sprintf("cannot delete user user with ID [%s]", h.userIDFomContext(c))
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -168,14 +168,14 @@ func (h *UserHandler) UpdateNotifications(c fiber.Ctx) error {
 	var request requests.UserNotificationUpdate
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	user, err := h.service.UpdateNotificationSettings(ctx, h.userIDFomContext(c), request.ToUserNotificationUpdateParams())
 	if err != nil {
 		msg := fmt.Sprintf("cannot update notification for [%T] with ID [%s]", user, h.userIDFomContext(c))
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -204,7 +204,7 @@ func (h *UserHandler) subscriptionUpdateURL(c fiber.Ctx) error {
 	url, err := h.service.GetSubscriptionUpdateURL(ctx, authUser.ID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot get user with ID [%s]", authUser.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -233,7 +233,7 @@ func (h *UserHandler) cancelSubscription(c fiber.Ctx) error {
 	err := h.service.InitiateSubscriptionCancel(ctx, authUser.ID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot get user with ID [%s]", authUser.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -267,7 +267,7 @@ func (h *UserHandler) DeleteAPIKey(c fiber.Ctx) error {
 	user, err := h.service.RotateAPIKey(ctx, c.OriginalURL(), h.userIDFomContext(c))
 	if err != nil {
 		msg := fmt.Sprintf("cannot rotate the api key for [%T] with ID [%s]", user, h.userIDFomContext(c))
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -294,7 +294,7 @@ func (h *UserHandler) subscriptionPayments(c fiber.Ctx) error {
 	invoices, err := h.service.GetSubscriptionPayments(ctx, h.userIDFomContext(c))
 	if err != nil {
 		msg := fmt.Sprintf("cannot get current subscription invoices for user [%s]", h.userFromContext(c))
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -323,21 +323,21 @@ func (h *UserHandler) subscriptionInvoice(c fiber.Ctx) error {
 	var request requests.UserPaymentInvoice
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	request.SubscriptionInvoiceID = c.Params("subscriptionInvoiceID")
 	if errors := h.validator.ValidatePaymentInvoice(ctx, h.userIDFomContext(c), request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while validating subscription payment invoice request [%s]", spew.Sdump(errors), c.Body())
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while generating payment invoice")
 	}
 
 	reader, err := h.service.GenerateReceipt(ctx, request.UserInvoiceGenerateParams(h.userIDFomContext(c)))
 	if err != nil {
 		msg := fmt.Sprintf("cannot generate receipt for invoice ID [%s] and user [%s]", request.SubscriptionInvoiceID, h.userFromContext(c))
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -347,7 +347,7 @@ func (h *UserHandler) subscriptionInvoice(c fiber.Ctx) error {
 	data, err := io.ReadAll(reader)
 	if err != nil {
 		msg := fmt.Sprintf("cannot read invoice data with ID [%s] for user with ID [%s]", request.SubscriptionInvoiceID, h.userIDFomContext(c))
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/user_handler.go
+++ b/api/pkg/handlers/user_handler.go
@@ -71,8 +71,7 @@ func (h *UserHandler) Show(c fiber.Ctx) error {
 	authUser := h.userFromContext(c)
 	user, err := h.service.Get(ctx, c.OriginalURL(), authUser)
 	if err != nil {
-		msg := fmt.Sprintf("cannot get user with ID [%s]", authUser.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot get user with ID [%s]", authUser.ID))
 		return h.responseInternalServerError(c)
 	}
 
@@ -101,21 +100,18 @@ func (h *UserHandler) Update(c fiber.Ctx) error {
 
 	var request requests.UserUpdate
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateUpdate(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while updating user [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while updating user [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating user")
 	}
 
 	user, err := h.service.Update(ctx, c.OriginalURL(), h.userFromContext(c), request.ToUpdateParams())
 	if err != nil {
-		msg := fmt.Sprintf("cannot update user with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot update user with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -138,8 +134,7 @@ func (h *UserHandler) Delete(c fiber.Ctx) error {
 	defer span.End()
 
 	if err := h.service.Delete(ctx, c.OriginalURL(), h.userIDFomContext(c)); err != nil {
-		msg := fmt.Sprintf("cannot delete user user with ID [%s]", h.userIDFomContext(c))
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot delete user user with ID [%s]", h.userIDFomContext(c)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -167,15 +162,13 @@ func (h *UserHandler) UpdateNotifications(c fiber.Ctx) error {
 
 	var request requests.UserNotificationUpdate
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	user, err := h.service.UpdateNotificationSettings(ctx, h.userIDFomContext(c), request.ToUserNotificationUpdateParams())
 	if err != nil {
-		msg := fmt.Sprintf("cannot update notification for [%T] with ID [%s]", user, h.userIDFomContext(c))
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update notification for [%T] with ID [%s]", user, h.userIDFomContext(c))))
 		return h.responseInternalServerError(c)
 	}
 
@@ -203,8 +196,7 @@ func (h *UserHandler) subscriptionUpdateURL(c fiber.Ctx) error {
 
 	url, err := h.service.GetSubscriptionUpdateURL(ctx, authUser.ID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot get user with ID [%s]", authUser.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot get user with ID [%s]", authUser.ID))
 		return h.responseInternalServerError(c)
 	}
 
@@ -232,8 +224,7 @@ func (h *UserHandler) cancelSubscription(c fiber.Ctx) error {
 
 	err := h.service.InitiateSubscriptionCancel(ctx, authUser.ID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot get user with ID [%s]", authUser.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot get user with ID [%s]", authUser.ID))
 		return h.responseInternalServerError(c)
 	}
 
@@ -266,8 +257,7 @@ func (h *UserHandler) DeleteAPIKey(c fiber.Ctx) error {
 
 	user, err := h.service.RotateAPIKey(ctx, c.OriginalURL(), h.userIDFomContext(c))
 	if err != nil {
-		msg := fmt.Sprintf("cannot rotate the api key for [%T] with ID [%s]", user, h.userIDFomContext(c))
-		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(h.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot rotate the api key for [%T] with ID [%s]", user, h.userIDFomContext(c))))
 		return h.responseInternalServerError(c)
 	}
 
@@ -293,8 +283,7 @@ func (h *UserHandler) subscriptionPayments(c fiber.Ctx) error {
 
 	invoices, err := h.service.GetSubscriptionPayments(ctx, h.userIDFomContext(c))
 	if err != nil {
-		msg := fmt.Sprintf("cannot get current subscription invoices for user [%s]", h.userFromContext(c))
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot get current subscription invoices for user [%s]", h.userFromContext(c)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -322,22 +311,19 @@ func (h *UserHandler) subscriptionInvoice(c fiber.Ctx) error {
 
 	var request requests.UserPaymentInvoice
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into %T", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into %T", c.Body(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	request.SubscriptionInvoiceID = c.Params("subscriptionInvoiceID")
 	if errors := h.validator.ValidatePaymentInvoice(ctx, h.userIDFomContext(c), request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while validating subscription payment invoice request [%s]", spew.Sdump(errors), c.Body())
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while validating subscription payment invoice request [%s]", spew.Sdump(errors), c.Body()))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while generating payment invoice")
 	}
 
 	reader, err := h.service.GenerateReceipt(ctx, request.UserInvoiceGenerateParams(h.userIDFomContext(c)))
 	if err != nil {
-		msg := fmt.Sprintf("cannot generate receipt for invoice ID [%s] and user [%s]", request.SubscriptionInvoiceID, h.userFromContext(c))
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot generate receipt for invoice ID [%s] and user [%s]", request.SubscriptionInvoiceID, h.userFromContext(c)))
 		return h.responseInternalServerError(c)
 	}
 
@@ -346,8 +332,7 @@ func (h *UserHandler) subscriptionInvoice(c fiber.Ctx) error {
 
 	data, err := io.ReadAll(reader)
 	if err != nil {
-		msg := fmt.Sprintf("cannot read invoice data with ID [%s] for user with ID [%s]", request.SubscriptionInvoiceID, h.userIDFomContext(c))
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot read invoice data with ID [%s] for user with ID [%s]", request.SubscriptionInvoiceID, h.userIDFomContext(c)))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/webhook_handler.go
+++ b/api/pkg/handlers/webhook_handler.go
@@ -70,21 +70,18 @@ func (h *WebhookHandler) Index(c fiber.Ctx) error {
 
 	var request requests.WebhookIndex
 	if err := c.Bind().Query(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall URL [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall URL [%s] into %T", c.OriginalURL(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateIndex(ctx, request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while fetching webhooks [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while fetching webhooks [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching webhooks")
 	}
 
 	webhooks, err := h.service.Index(ctx, h.userIDFomContext(c), request.ToIndexParams())
 	if err != nil {
-		msg := fmt.Sprintf("cannot get webhooks with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot get webhooks with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -111,15 +108,13 @@ func (h *WebhookHandler) Delete(c fiber.Ctx) error {
 
 	webhookID := c.Params("webhookID")
 	if errors := h.validator.ValidateUUID(webhookID, "webhookID"); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while deleting webhook with ID [%s]", spew.Sdump(errors), webhookID)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while deleting webhook with ID [%s]", spew.Sdump(errors), webhookID))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while deleting webhook")
 	}
 
 	err := h.service.Delete(ctx, h.userIDFomContext(c), uuid.MustParse(webhookID))
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete webhook with ID [%+#v]", webhookID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot delete webhook with ID [%+#v]", webhookID))
 		return h.responseInternalServerError(c)
 	}
 
@@ -148,32 +143,29 @@ func (h *WebhookHandler) Store(c fiber.Ctx) error {
 
 	var request requests.WebhookStore
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall body [%s] into [%T]", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall body [%s] into [%T]", c.Body(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateStore(ctx, h.userIDFomContext(c), request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while storing webhook [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while storing webhook [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing webhook")
 	}
 
 	webhooks, err := h.service.Index(ctx, h.userIDFomContext(c), repositories.IndexParams{Skip: 0, Limit: 10})
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot index webhooks for user [%s]", h.userIDFomContext(c))))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot index webhooks for user [%s]", h.userIDFomContext(c)))
 		return h.responseInternalServerError(c)
 	}
 
 	if len(webhooks) == 10 {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] wants to create more than 5 webhooks", h.userIDFomContext(c))))
+		ctxLogger.Warn(stacktrace.NewError("user with ID [%s] wants to create more than 5 webhooks", h.userIDFomContext(c)))
 		return h.responsePaymentRequired(c, "You can't create more than 10 webhooks contact us to upgrade to our enterprise plan.")
 	}
 
 	webhook, err := h.service.Store(ctx, request.ToStoreParams(h.userFromContext(c)))
 	if err != nil {
-		msg := fmt.Sprintf("cannot store webhoook with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot store webhoook with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 
@@ -201,22 +193,19 @@ func (h *WebhookHandler) Update(c fiber.Ctx) error {
 
 	var request requests.WebhookUpdate
 	if err := c.Bind().Body(&request); err != nil {
-		msg := fmt.Sprintf("cannot marshall params [%s] into [%T]", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot marshall params [%s] into [%T]", c.Body(), request))
 		return h.responseBadRequest(c, err)
 	}
 
 	request.WebhookID = c.Params("webhookID")
 	if errors := h.validator.ValidateUpdate(ctx, h.userIDFomContext(c), request.Sanitize()); len(errors) != 0 {
-		msg := fmt.Sprintf("validation errors [%s], while updating user [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("validation errors [%s], while updating user [%+#v]", spew.Sdump(errors), request))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating webhook")
 	}
 
 	user, err := h.service.Update(ctx, request.ToUpdateParams(h.userFromContext(c)))
 	if err != nil {
-		msg := fmt.Sprintf("cannot update user with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot update user with params [%+#v]", request))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/webhook_handler.go
+++ b/api/pkg/handlers/webhook_handler.go
@@ -71,20 +71,20 @@ func (h *WebhookHandler) Index(c fiber.Ctx) error {
 	var request requests.WebhookIndex
 	if err := c.Bind().Query(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall URL [%s] into %T", c.OriginalURL(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateIndex(ctx, request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while fetching webhooks [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while fetching webhooks")
 	}
 
 	webhooks, err := h.service.Index(ctx, h.userIDFomContext(c), request.ToIndexParams())
 	if err != nil {
 		msg := fmt.Sprintf("cannot get webhooks with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -112,14 +112,14 @@ func (h *WebhookHandler) Delete(c fiber.Ctx) error {
 	webhookID := c.Params("webhookID")
 	if errors := h.validator.ValidateUUID(webhookID, "webhookID"); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while deleting webhook with ID [%s]", spew.Sdump(errors), webhookID)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while deleting webhook")
 	}
 
 	err := h.service.Delete(ctx, h.userIDFomContext(c), uuid.MustParse(webhookID))
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete webhook with ID [%+#v]", webhookID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -149,31 +149,31 @@ func (h *WebhookHandler) Store(c fiber.Ctx) error {
 	var request requests.WebhookStore
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall body [%s] into [%T]", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	if errors := h.validator.ValidateStore(ctx, h.userIDFomContext(c), request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while storing webhook [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while storing webhook")
 	}
 
 	webhooks, err := h.service.Index(ctx, h.userIDFomContext(c), repositories.IndexParams{Skip: 0, Limit: 10})
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot index webhooks for user [%s]", h.userIDFomContext(c))))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot index webhooks for user [%s]", h.userIDFomContext(c))))
 		return h.responseInternalServerError(c)
 	}
 
 	if len(webhooks) == 10 {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("user with ID [%s] wants to create more than 5 webhooks", h.userIDFomContext(c))))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("user with ID [%s] wants to create more than 5 webhooks", h.userIDFomContext(c))))
 		return h.responsePaymentRequired(c, "You can't create more than 10 webhooks contact us to upgrade to our enterprise plan.")
 	}
 
 	webhook, err := h.service.Store(ctx, request.ToStoreParams(h.userFromContext(c)))
 	if err != nil {
 		msg := fmt.Sprintf("cannot store webhoook with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 
@@ -202,21 +202,21 @@ func (h *WebhookHandler) Update(c fiber.Ctx) error {
 	var request requests.WebhookUpdate
 	if err := c.Bind().Body(&request); err != nil {
 		msg := fmt.Sprintf("cannot marshall params [%s] into [%T]", c.Body(), request)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return h.responseBadRequest(c, err)
 	}
 
 	request.WebhookID = c.Params("webhookID")
 	if errors := h.validator.ValidateUpdate(ctx, h.userIDFomContext(c), request.Sanitize()); len(errors) != 0 {
 		msg := fmt.Sprintf("validation errors [%s], while updating user [%+#v]", spew.Sdump(errors), request)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return h.responseUnprocessableEntity(c, errors, "validation errors while updating webhook")
 	}
 
 	user, err := h.service.Update(ctx, request.ToUpdateParams(h.userFromContext(c)))
 	if err != nil {
 		msg := fmt.Sprintf("cannot update user with params [%+#v]", request)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return h.responseInternalServerError(c)
 	}
 

--- a/api/pkg/handlers/webhook_handler.go
+++ b/api/pkg/handlers/webhook_handler.go
@@ -159,7 +159,7 @@ func (h *WebhookHandler) Store(c fiber.Ctx) error {
 	}
 
 	if len(webhooks) == 10 {
-		ctxLogger.Warn(stacktrace.NewError("user with ID [%s] wants to create more than 5 webhooks", h.userIDFomContext(c)))
+		ctxLogger.Warn(stacktrace.NewError("user with ID [%s] wants to create more than 10 webhooks", h.userIDFomContext(c)))
 		return h.responsePaymentRequired(c, "You can't create more than 10 webhooks contact us to upgrade to our enterprise plan.")
 	}
 

--- a/api/pkg/listeners/billing_listener.go
+++ b/api/pkg/listeners/billing_listener.go
@@ -46,13 +46,11 @@ func (listener *BillingListener) OnMessageAPISent(ctx context.Context, event clo
 
 	var payload events.MessageAPISentPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.RegisterSentMessage(ctx, payload.MessageID, payload.RequestReceivedAt, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot register sent message for event [%s] for event with ID [%s]", spew.Sdump(payload), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot register sent message for event [%s] for event with ID [%s]", spew.Sdump(payload), event.ID()))
 	}
 
 	return nil
@@ -65,13 +63,11 @@ func (listener *BillingListener) OnMessagePhoneReceived(ctx context.Context, eve
 
 	var payload events.MessagePhoneReceivedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.RegisterReceivedMessage(ctx, payload.MessageID, payload.Timestamp, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot register received message for event [%s] for event with ID [%s]", spew.Sdump(payload), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot register received message for event [%s] for event with ID [%s]", spew.Sdump(payload), event.ID()))
 	}
 
 	return nil
@@ -83,13 +79,11 @@ func (listener *BillingListener) onUserAccountDeleted(ctx context.Context, event
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot delete [entities.BillingUsage] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete [entities.BillingUsage] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/billing_listener.go
+++ b/api/pkg/listeners/billing_listener.go
@@ -47,12 +47,12 @@ func (listener *BillingListener) OnMessageAPISent(ctx context.Context, event clo
 	var payload events.MessageAPISentPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.RegisterSentMessage(ctx, payload.MessageID, payload.RequestReceivedAt, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot register sent message for event [%s] for event with ID [%s]", spew.Sdump(payload), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -66,12 +66,12 @@ func (listener *BillingListener) OnMessagePhoneReceived(ctx context.Context, eve
 	var payload events.MessagePhoneReceivedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.RegisterReceivedMessage(ctx, payload.MessageID, payload.Timestamp, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot register received message for event [%s] for event with ID [%s]", spew.Sdump(payload), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -84,12 +84,12 @@ func (listener *BillingListener) onUserAccountDeleted(ctx context.Context, event
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot delete [entities.BillingUsage] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/discord_listener.go
+++ b/api/pkg/listeners/discord_listener.go
@@ -43,13 +43,11 @@ func (listener *DiscordListener) OnMessagePhoneReceived(ctx context.Context, eve
 
 	var payload events.MessagePhoneReceivedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.HandleMessageReceived(ctx, payload.UserID, event); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -61,13 +59,11 @@ func (listener *DiscordListener) onUserAccountDeleted(ctx context.Context, event
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot delete [entities.Discord] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete [entities.Discord] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/discord_listener.go
+++ b/api/pkg/listeners/discord_listener.go
@@ -44,12 +44,12 @@ func (listener *DiscordListener) OnMessagePhoneReceived(ctx context.Context, eve
 	var payload events.MessagePhoneReceivedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.HandleMessageReceived(ctx, payload.UserID, event); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -62,12 +62,12 @@ func (listener *DiscordListener) onUserAccountDeleted(ctx context.Context, event
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot delete [entities.Discord] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/email_notification_listener.go
+++ b/api/pkg/listeners/email_notification_listener.go
@@ -46,12 +46,12 @@ func (listener *EmailNotificationListener) OnMessageSendExpired(ctx context.Cont
 	payload := new(events.MessageSendExpiredPayload)
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.NotifyMessageExpired(ctx, payload); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -65,12 +65,12 @@ func (listener *EmailNotificationListener) OnMessageSendFailed(ctx context.Conte
 	payload := new(events.MessageSendFailedPayload)
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.NotifyMessageFailed(ctx, payload); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -84,12 +84,12 @@ func (listener *EmailNotificationListener) OnWebhookSendFailed(ctx context.Conte
 	payload := new(events.WebhookSendFailedPayload)
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.NotifyWebhookSendFailed(ctx, payload); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -103,12 +103,12 @@ func (listener *EmailNotificationListener) OnDiscordSendFailed(ctx context.Conte
 	payload := new(events.DiscordSendFailedPayload)
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.NotifyDiscordSendFailed(ctx, payload); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/email_notification_listener.go
+++ b/api/pkg/listeners/email_notification_listener.go
@@ -45,13 +45,11 @@ func (listener *EmailNotificationListener) OnMessageSendExpired(ctx context.Cont
 
 	payload := new(events.MessageSendExpiredPayload)
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.NotifyMessageExpired(ctx, payload); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -64,13 +62,11 @@ func (listener *EmailNotificationListener) OnMessageSendFailed(ctx context.Conte
 
 	payload := new(events.MessageSendFailedPayload)
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.NotifyMessageFailed(ctx, payload); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -83,13 +79,11 @@ func (listener *EmailNotificationListener) OnWebhookSendFailed(ctx context.Conte
 
 	payload := new(events.WebhookSendFailedPayload)
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.NotifyWebhookSendFailed(ctx, payload); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -102,13 +96,11 @@ func (listener *EmailNotificationListener) OnDiscordSendFailed(ctx context.Conte
 
 	payload := new(events.DiscordSendFailedPayload)
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.NotifyDiscordSendFailed(ctx, payload); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/heartbeat_listener.go
+++ b/api/pkg/listeners/heartbeat_listener.go
@@ -49,7 +49,7 @@ func (listener *HeartbeatListener) onPhoneUpdated(ctx context.Context, event clo
 	var payload events.PhoneUpdatedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	storeParams := &services.HeartbeatMonitorStoreParams{
@@ -61,7 +61,7 @@ func (listener *HeartbeatListener) onPhoneUpdated(ctx context.Context, event clo
 
 	if _, err := listener.service.StoreMonitor(ctx, storeParams); err != nil {
 		msg := fmt.Sprintf("cannot store heartbeat monitor with params [%s] for event with ID [%s]", spew.Sdump(storeParams), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -75,12 +75,12 @@ func (listener *HeartbeatListener) onPhoneDeleted(ctx context.Context, event clo
 	var payload events.PhoneDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteMonitor(ctx, payload.UserID, payload.Owner); err != nil {
 		msg := fmt.Sprintf("cannot delete heartbeat monitor with userID [%s] and owner [%s] for event with ID [%s]", payload.UserID, payload.Owner, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -94,7 +94,7 @@ func (listener *HeartbeatListener) onPhoneHeartbeatCheck(ctx context.Context, ev
 	var payload events.PhoneHeartbeatCheckPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	monitorParams := &services.HeartbeatMonitorParams{
@@ -107,7 +107,7 @@ func (listener *HeartbeatListener) onPhoneHeartbeatCheck(ctx context.Context, ev
 
 	if err := listener.service.Monitor(ctx, monitorParams); err != nil {
 		msg := fmt.Sprintf("cannot monitor heartbeats for userID [%s] and owner [%s] for event with ID [%s]", payload.UserID, payload.Owner, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -121,12 +121,12 @@ func (listener *HeartbeatListener) onPhoneHeartbeatOffline(ctx context.Context, 
 	var payload events.PhoneHeartbeatOfflinePayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.UpdatePhoneOnline(ctx, payload.UserID, payload.MonitorID, false); err != nil {
 		msg := fmt.Sprintf("cannot delete heartbeat monitor with userID [%s] and owner [%s] for event with ID [%s]", payload.UserID, payload.Owner, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -139,12 +139,12 @@ func (listener *HeartbeatListener) onUserAccountDeleted(ctx context.Context, eve
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot delete [entities.Heartbeat] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/heartbeat_listener.go
+++ b/api/pkg/listeners/heartbeat_listener.go
@@ -48,8 +48,7 @@ func (listener *HeartbeatListener) onPhoneUpdated(ctx context.Context, event clo
 
 	var payload events.PhoneUpdatedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	storeParams := &services.HeartbeatMonitorStoreParams{
@@ -60,8 +59,7 @@ func (listener *HeartbeatListener) onPhoneUpdated(ctx context.Context, event clo
 	}
 
 	if _, err := listener.service.StoreMonitor(ctx, storeParams); err != nil {
-		msg := fmt.Sprintf("cannot store heartbeat monitor with params [%s] for event with ID [%s]", spew.Sdump(storeParams), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot store heartbeat monitor with params [%s] for event with ID [%s]", spew.Sdump(storeParams), event.ID()))
 	}
 
 	return nil
@@ -74,13 +72,11 @@ func (listener *HeartbeatListener) onPhoneDeleted(ctx context.Context, event clo
 
 	var payload events.PhoneDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteMonitor(ctx, payload.UserID, payload.Owner); err != nil {
-		msg := fmt.Sprintf("cannot delete heartbeat monitor with userID [%s] and owner [%s] for event with ID [%s]", payload.UserID, payload.Owner, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete heartbeat monitor with userID [%s] and owner [%s] for event with ID [%s]", payload.UserID, payload.Owner, event.ID()))
 	}
 
 	return nil
@@ -93,8 +89,7 @@ func (listener *HeartbeatListener) onPhoneHeartbeatCheck(ctx context.Context, ev
 
 	var payload events.PhoneHeartbeatCheckPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	monitorParams := &services.HeartbeatMonitorParams{
@@ -106,8 +101,7 @@ func (listener *HeartbeatListener) onPhoneHeartbeatCheck(ctx context.Context, ev
 	}
 
 	if err := listener.service.Monitor(ctx, monitorParams); err != nil {
-		msg := fmt.Sprintf("cannot monitor heartbeats for userID [%s] and owner [%s] for event with ID [%s]", payload.UserID, payload.Owner, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot monitor heartbeats for userID [%s] and owner [%s] for event with ID [%s]", payload.UserID, payload.Owner, event.ID()))
 	}
 
 	return nil
@@ -120,13 +114,11 @@ func (listener *HeartbeatListener) onPhoneHeartbeatOffline(ctx context.Context, 
 
 	var payload events.PhoneHeartbeatOfflinePayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.UpdatePhoneOnline(ctx, payload.UserID, payload.MonitorID, false); err != nil {
-		msg := fmt.Sprintf("cannot delete heartbeat monitor with userID [%s] and owner [%s] for event with ID [%s]", payload.UserID, payload.Owner, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete heartbeat monitor with userID [%s] and owner [%s] for event with ID [%s]", payload.UserID, payload.Owner, event.ID()))
 	}
 
 	return nil
@@ -138,13 +130,11 @@ func (listener *HeartbeatListener) onUserAccountDeleted(ctx context.Context, eve
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot delete [entities.Heartbeat] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete [entities.Heartbeat] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/integration_3cx_listener.go
+++ b/api/pkg/listeners/integration_3cx_listener.go
@@ -46,13 +46,11 @@ func (listener *Integration3CXListener) OnMessagePhoneReceived(ctx context.Conte
 
 	var payload events.MessagePhoneReceivedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -65,13 +63,11 @@ func (listener *Integration3CXListener) OnMessageSendFailed(ctx context.Context,
 
 	var payload events.MessageSendFailedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -84,13 +80,11 @@ func (listener *Integration3CXListener) OnMessagePhoneSent(ctx context.Context, 
 
 	var payload events.MessagePhoneSentPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -103,13 +97,11 @@ func (listener *Integration3CXListener) OnMessagePhoneDelivered(ctx context.Cont
 
 	var payload events.MessagePhoneDeliveredPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -121,13 +113,11 @@ func (listener *Integration3CXListener) onUserAccountDeleted(ctx context.Context
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot delete [entities.Integration3CX] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete [entities.Integration3CX] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/integration_3cx_listener.go
+++ b/api/pkg/listeners/integration_3cx_listener.go
@@ -47,12 +47,12 @@ func (listener *Integration3CXListener) OnMessagePhoneReceived(ctx context.Conte
 	var payload events.MessagePhoneReceivedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -66,12 +66,12 @@ func (listener *Integration3CXListener) OnMessageSendFailed(ctx context.Context,
 	var payload events.MessageSendFailedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -85,12 +85,12 @@ func (listener *Integration3CXListener) OnMessagePhoneSent(ctx context.Context, 
 	var payload events.MessagePhoneSentPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -104,12 +104,12 @@ func (listener *Integration3CXListener) OnMessagePhoneDelivered(ctx context.Cont
 	var payload events.MessagePhoneDeliveredPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -122,12 +122,12 @@ func (listener *Integration3CXListener) onUserAccountDeleted(ctx context.Context
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot delete [entities.Integration3CX] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/marketing_listener.go
+++ b/api/pkg/listeners/marketing_listener.go
@@ -43,12 +43,12 @@ func (listener *MarketingListener) onUserAccountCreated(ctx context.Context, eve
 	var payload events.UserAccountCreatedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.CreateContact(ctx, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot create [contact] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -61,12 +61,12 @@ func (listener *MarketingListener) onUserAccountDeleted(ctx context.Context, eve
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteContact(ctx, payload.UserEmail); err != nil {
 		msg := fmt.Sprintf("cannot delete [contact] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/marketing_listener.go
+++ b/api/pkg/listeners/marketing_listener.go
@@ -42,13 +42,11 @@ func (listener *MarketingListener) onUserAccountCreated(ctx context.Context, eve
 
 	var payload events.UserAccountCreatedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.CreateContact(ctx, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot create [contact] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create [contact] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil
@@ -60,13 +58,11 @@ func (listener *MarketingListener) onUserAccountDeleted(ctx context.Context, eve
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteContact(ctx, payload.UserEmail); err != nil {
-		msg := fmt.Sprintf("cannot delete [contact] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete [contact] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/message_listener.go
+++ b/api/pkg/listeners/message_listener.go
@@ -54,8 +54,7 @@ func (listener *MessageListener) OnMessagePhoneSending(ctx context.Context, even
 
 	var payload events.MessagePhoneSendingPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	handleParams := services.HandleMessageParams{
@@ -66,8 +65,7 @@ func (listener *MessageListener) OnMessagePhoneSending(ctx context.Context, even
 	}
 
 	if err := listener.service.HandleMessageSending(ctx, handleParams); err != nil {
-		msg := fmt.Sprintf("cannot handle sending for message with ID [%s] for event with ID [%s]", handleParams.ID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot handle sending for message with ID [%s] for event with ID [%s]", handleParams.ID, event.ID()))
 	}
 
 	return nil
@@ -80,8 +78,7 @@ func (listener *MessageListener) OnMessagePhoneSent(ctx context.Context, event c
 
 	var payload events.MessagePhoneSentPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	handleParams := services.HandleMessageParams{
@@ -92,8 +89,7 @@ func (listener *MessageListener) OnMessagePhoneSent(ctx context.Context, event c
 	}
 
 	if err := listener.service.HandleMessageSent(ctx, handleParams); err != nil {
-		msg := fmt.Sprintf("cannot handle [%s] for message with ID [%s] for event with ID [%s]", event.Type(), handleParams.ID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot handle [%s] for message with ID [%s] for event with ID [%s]", event.Type(), handleParams.ID, event.ID()))
 	}
 	return nil
 }
@@ -105,8 +101,7 @@ func (listener *MessageListener) OnMessagePhoneDelivered(ctx context.Context, ev
 
 	var payload events.MessagePhoneDeliveredPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	handleParams := services.HandleMessageParams{
@@ -116,8 +111,7 @@ func (listener *MessageListener) OnMessagePhoneDelivered(ctx context.Context, ev
 	}
 
 	if err := listener.service.HandleMessageDelivered(ctx, handleParams); err != nil {
-		msg := fmt.Sprintf("cannot handle [%s] for message with ID [%s] for event with ID [%s]", event.Type(), handleParams.ID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot handle [%s] for message with ID [%s] for event with ID [%s]", event.Type(), handleParams.ID, event.ID()))
 	}
 
 	return nil
@@ -130,8 +124,7 @@ func (listener *MessageListener) OnMessagePhoneFailed(ctx context.Context, event
 
 	var payload events.MessageSendFailedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	handleParams := services.HandleMessageFailedParams{
@@ -142,8 +135,7 @@ func (listener *MessageListener) OnMessagePhoneFailed(ctx context.Context, event
 	}
 
 	if err := listener.service.HandleMessageFailed(ctx, handleParams); err != nil {
-		msg := fmt.Sprintf("cannot handle [%s] for message with ID [%s] for event with ID [%s]", event.Type(), handleParams.ID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot handle [%s] for message with ID [%s] for event with ID [%s]", event.Type(), handleParams.ID, event.ID()))
 	}
 
 	return nil
@@ -156,14 +148,12 @@ func (listener *MessageListener) onMessageNotificationFailed(ctx context.Context
 
 	var payload events.MessageNotificationFailedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	message, err := listener.service.GetMessage(ctx, payload.UserID, payload.MessageID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load message with id [%s] and user id [%s]", payload.MessageID, payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load message with id [%s] and user id [%s]", payload.MessageID, payload.UserID))
 	}
 
 	storeParams := services.MessageStoreEventParams{
@@ -174,8 +164,7 @@ func (listener *MessageListener) onMessageNotificationFailed(ctx context.Context
 		Source:       event.Source(),
 	}
 	if _, err = listener.service.StoreEvent(ctx, message, storeParams); err != nil {
-		msg := fmt.Sprintf("cannot store message event [%s] for message with ID [%s]", storeParams.EventName, storeParams.MessageID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot store message event [%s] for message with ID [%s]", storeParams.EventName, storeParams.MessageID))
 	}
 
 	return nil
@@ -188,8 +177,7 @@ func (listener *MessageListener) onMessageNotificationSent(ctx context.Context, 
 
 	var payload events.MessageNotificationSentPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	checkParams := services.MessageScheduleExpirationParams{
@@ -201,8 +189,7 @@ func (listener *MessageListener) onMessageNotificationSent(ctx context.Context, 
 		MessageExpirationDuration: payload.MessageExpirationDuration,
 	}
 	if err := listener.service.ScheduleExpirationCheck(ctx, checkParams); err != nil {
-		msg := fmt.Sprintf("cannot exchedule expiration check for  ID [%s] and userID [%s]", checkParams.MessageID, checkParams.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot exchedule expiration check for  ID [%s] and userID [%s]", checkParams.MessageID, checkParams.UserID))
 	}
 
 	handleParams := services.HandleMessageParams{
@@ -212,8 +199,7 @@ func (listener *MessageListener) onMessageNotificationSent(ctx context.Context, 
 		Timestamp: payload.NotificationSentAt,
 	}
 	if err := listener.service.HandleMessageNotificationSent(ctx, handleParams); err != nil {
-		msg := fmt.Sprintf("cannot handle event [%s] for message [%s] and userID [%s]", event.Type(), checkParams.MessageID, checkParams.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot handle event [%s] for message [%s] and userID [%s]", event.Type(), checkParams.MessageID, checkParams.UserID))
 	}
 
 	return nil
@@ -226,8 +212,7 @@ func (listener *MessageListener) onMessageSendExpiredCheck(ctx context.Context, 
 
 	var payload events.MessageSendExpiredCheckPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	checkParams := services.MessageCheckExpired{
@@ -236,8 +221,7 @@ func (listener *MessageListener) onMessageSendExpiredCheck(ctx context.Context, 
 		Source:    event.Source(),
 	}
 	if err := listener.service.CheckExpired(ctx, checkParams); err != nil {
-		msg := fmt.Sprintf("cannot check expiration for message with ID [%s] and userID [%s]", checkParams.MessageID, checkParams.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot check expiration for message with ID [%s] and userID [%s]", checkParams.MessageID, checkParams.UserID))
 	}
 
 	return nil
@@ -250,8 +234,7 @@ func (listener *MessageListener) onMessageSendExpired(ctx context.Context, event
 
 	var payload events.MessageSendExpiredPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	expiredParams := services.HandleMessageParams{
@@ -261,8 +244,7 @@ func (listener *MessageListener) onMessageSendExpired(ctx context.Context, event
 		Timestamp: payload.Timestamp,
 	}
 	if err := listener.service.HandleMessageExpired(ctx, expiredParams); err != nil {
-		msg := fmt.Sprintf("cannot handle event [%s] for ID [%s] and userID [%s]", event.Type(), expiredParams.ID, expiredParams.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot handle event [%s] for ID [%s] and userID [%s]", event.Type(), expiredParams.ID, expiredParams.UserID))
 	}
 
 	return nil
@@ -275,8 +257,7 @@ func (listener *MessageListener) onMessageNotificationScheduled(ctx context.Cont
 
 	var payload events.MessageNotificationScheduledPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	expiredParams := services.HandleMessageParams{
@@ -286,8 +267,7 @@ func (listener *MessageListener) onMessageNotificationScheduled(ctx context.Cont
 		Timestamp: payload.ScheduledAt,
 	}
 	if err := listener.service.HandleMessageNotificationScheduled(ctx, expiredParams); err != nil {
-		msg := fmt.Sprintf("cannot handle event [%s] for ID [%s] and userID [%s]", event.Type(), expiredParams.ID, expiredParams.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot handle event [%s] for ID [%s] and userID [%s]", event.Type(), expiredParams.ID, expiredParams.UserID))
 	}
 
 	return nil
@@ -300,13 +280,11 @@ func (listener *MessageListener) onMessageThreadAPIDeleted(ctx context.Context, 
 
 	var payload events.MessageThreadAPIDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteByOwnerAndContact(ctx, payload.UserID, payload.Owner, payload.Contact); err != nil {
-		msg := fmt.Sprintf("cannot handle [%s] event with ID [%s] and userID [%s]", event.Type(), event.ID(), payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot handle [%s] event with ID [%s] and userID [%s]", event.Type(), event.ID(), payload.UserID))
 	}
 
 	return nil
@@ -319,13 +297,11 @@ func (listener *MessageListener) onMessageCallMissed(ctx context.Context, event 
 
 	payload := new(events.MessageCallMissedPayload)
 	if err := event.DataAs(payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.RespondToMissedCall(ctx, event.Source(), payload); err != nil {
-		msg := fmt.Sprintf("cannot handle [%s] event with ID [%s] and userID [%s]", event.Type(), event.ID(), payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot handle [%s] event with ID [%s] and userID [%s]", event.Type(), event.ID(), payload.UserID))
 	}
 
 	return nil
@@ -337,13 +313,11 @@ func (listener *MessageListener) onUserAccountDeleted(ctx context.Context, event
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot delete [entities.Message] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete [entities.Message] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/message_listener.go
+++ b/api/pkg/listeners/message_listener.go
@@ -55,7 +55,7 @@ func (listener *MessageListener) OnMessagePhoneSending(ctx context.Context, even
 	var payload events.MessagePhoneSendingPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	handleParams := services.HandleMessageParams{
@@ -67,7 +67,7 @@ func (listener *MessageListener) OnMessagePhoneSending(ctx context.Context, even
 
 	if err := listener.service.HandleMessageSending(ctx, handleParams); err != nil {
 		msg := fmt.Sprintf("cannot handle sending for message with ID [%s] for event with ID [%s]", handleParams.ID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -81,7 +81,7 @@ func (listener *MessageListener) OnMessagePhoneSent(ctx context.Context, event c
 	var payload events.MessagePhoneSentPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	handleParams := services.HandleMessageParams{
@@ -93,7 +93,7 @@ func (listener *MessageListener) OnMessagePhoneSent(ctx context.Context, event c
 
 	if err := listener.service.HandleMessageSent(ctx, handleParams); err != nil {
 		msg := fmt.Sprintf("cannot handle [%s] for message with ID [%s] for event with ID [%s]", event.Type(), handleParams.ID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	return nil
 }
@@ -106,7 +106,7 @@ func (listener *MessageListener) OnMessagePhoneDelivered(ctx context.Context, ev
 	var payload events.MessagePhoneDeliveredPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	handleParams := services.HandleMessageParams{
@@ -117,7 +117,7 @@ func (listener *MessageListener) OnMessagePhoneDelivered(ctx context.Context, ev
 
 	if err := listener.service.HandleMessageDelivered(ctx, handleParams); err != nil {
 		msg := fmt.Sprintf("cannot handle [%s] for message with ID [%s] for event with ID [%s]", event.Type(), handleParams.ID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -131,7 +131,7 @@ func (listener *MessageListener) OnMessagePhoneFailed(ctx context.Context, event
 	var payload events.MessageSendFailedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	handleParams := services.HandleMessageFailedParams{
@@ -143,7 +143,7 @@ func (listener *MessageListener) OnMessagePhoneFailed(ctx context.Context, event
 
 	if err := listener.service.HandleMessageFailed(ctx, handleParams); err != nil {
 		msg := fmt.Sprintf("cannot handle [%s] for message with ID [%s] for event with ID [%s]", event.Type(), handleParams.ID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -157,13 +157,13 @@ func (listener *MessageListener) onMessageNotificationFailed(ctx context.Context
 	var payload events.MessageNotificationFailedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	message, err := listener.service.GetMessage(ctx, payload.UserID, payload.MessageID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load message with id [%s] and user id [%s]", payload.MessageID, payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	storeParams := services.MessageStoreEventParams{
@@ -175,7 +175,7 @@ func (listener *MessageListener) onMessageNotificationFailed(ctx context.Context
 	}
 	if _, err = listener.service.StoreEvent(ctx, message, storeParams); err != nil {
 		msg := fmt.Sprintf("cannot store message event [%s] for message with ID [%s]", storeParams.EventName, storeParams.MessageID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -189,7 +189,7 @@ func (listener *MessageListener) onMessageNotificationSent(ctx context.Context, 
 	var payload events.MessageNotificationSentPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	checkParams := services.MessageScheduleExpirationParams{
@@ -202,7 +202,7 @@ func (listener *MessageListener) onMessageNotificationSent(ctx context.Context, 
 	}
 	if err := listener.service.ScheduleExpirationCheck(ctx, checkParams); err != nil {
 		msg := fmt.Sprintf("cannot exchedule expiration check for  ID [%s] and userID [%s]", checkParams.MessageID, checkParams.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	handleParams := services.HandleMessageParams{
@@ -213,7 +213,7 @@ func (listener *MessageListener) onMessageNotificationSent(ctx context.Context, 
 	}
 	if err := listener.service.HandleMessageNotificationSent(ctx, handleParams); err != nil {
 		msg := fmt.Sprintf("cannot handle event [%s] for message [%s] and userID [%s]", event.Type(), checkParams.MessageID, checkParams.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -227,7 +227,7 @@ func (listener *MessageListener) onMessageSendExpiredCheck(ctx context.Context, 
 	var payload events.MessageSendExpiredCheckPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	checkParams := services.MessageCheckExpired{
@@ -237,7 +237,7 @@ func (listener *MessageListener) onMessageSendExpiredCheck(ctx context.Context, 
 	}
 	if err := listener.service.CheckExpired(ctx, checkParams); err != nil {
 		msg := fmt.Sprintf("cannot check expiration for message with ID [%s] and userID [%s]", checkParams.MessageID, checkParams.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -251,7 +251,7 @@ func (listener *MessageListener) onMessageSendExpired(ctx context.Context, event
 	var payload events.MessageSendExpiredPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	expiredParams := services.HandleMessageParams{
@@ -262,7 +262,7 @@ func (listener *MessageListener) onMessageSendExpired(ctx context.Context, event
 	}
 	if err := listener.service.HandleMessageExpired(ctx, expiredParams); err != nil {
 		msg := fmt.Sprintf("cannot handle event [%s] for ID [%s] and userID [%s]", event.Type(), expiredParams.ID, expiredParams.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -276,7 +276,7 @@ func (listener *MessageListener) onMessageNotificationScheduled(ctx context.Cont
 	var payload events.MessageNotificationScheduledPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	expiredParams := services.HandleMessageParams{
@@ -287,7 +287,7 @@ func (listener *MessageListener) onMessageNotificationScheduled(ctx context.Cont
 	}
 	if err := listener.service.HandleMessageNotificationScheduled(ctx, expiredParams); err != nil {
 		msg := fmt.Sprintf("cannot handle event [%s] for ID [%s] and userID [%s]", event.Type(), expiredParams.ID, expiredParams.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -301,12 +301,12 @@ func (listener *MessageListener) onMessageThreadAPIDeleted(ctx context.Context, 
 	var payload events.MessageThreadAPIDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteByOwnerAndContact(ctx, payload.UserID, payload.Owner, payload.Contact); err != nil {
 		msg := fmt.Sprintf("cannot handle [%s] event with ID [%s] and userID [%s]", event.Type(), event.ID(), payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -320,12 +320,12 @@ func (listener *MessageListener) onMessageCallMissed(ctx context.Context, event 
 	payload := new(events.MessageCallMissedPayload)
 	if err := event.DataAs(payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.RespondToMissedCall(ctx, event.Source(), payload); err != nil {
 		msg := fmt.Sprintf("cannot handle [%s] event with ID [%s] and userID [%s]", event.Type(), event.ID(), payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -338,12 +338,12 @@ func (listener *MessageListener) onUserAccountDeleted(ctx context.Context, event
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot delete [entities.Message] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/message_send_schedule_listener.go
+++ b/api/pkg/listeners/message_send_schedule_listener.go
@@ -45,12 +45,11 @@ func (listener *MessageSendScheduleListener) onUserAccountDeleted(
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot delete [entities.MessageSendSchedule] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete [entities.MessageSendSchedule] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/message_send_schedule_listener.go
+++ b/api/pkg/listeners/message_send_schedule_listener.go
@@ -45,12 +45,12 @@ func (listener *MessageSendScheduleListener) onUserAccountDeleted(
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot delete [entities.MessageSendSchedule] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/message_thread_listener.go
+++ b/api/pkg/listeners/message_thread_listener.go
@@ -53,8 +53,7 @@ func (listener *MessageThreadListener) OnMessageAPISent(ctx context.Context, eve
 
 	var payload events.MessageAPISentPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -68,8 +67,7 @@ func (listener *MessageThreadListener) OnMessageAPISent(ctx context.Context, eve
 	}
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
-		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID()))
 	}
 
 	return nil
@@ -82,13 +80,11 @@ func (listener *MessageThreadListener) onMessageDeleted(ctx context.Context, eve
 
 	payload := new(events.MessageAPIDeletedPayload)
 	if err := event.DataAs(payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.UpdateAfterDeletedMessage(ctx, payload); err != nil {
-		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", payload.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update thread for message with ID [%s] for event with ID [%s]", payload.MessageID, event.ID()))
 	}
 
 	return nil
@@ -101,8 +97,7 @@ func (listener *MessageThreadListener) OnMessagePhoneSending(ctx context.Context
 
 	var payload events.MessagePhoneSendingPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -116,8 +111,7 @@ func (listener *MessageThreadListener) OnMessagePhoneSending(ctx context.Context
 	}
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
-		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID()))
 	}
 
 	return nil
@@ -130,8 +124,7 @@ func (listener *MessageThreadListener) OnMessagePhoneSent(ctx context.Context, e
 
 	var payload events.MessagePhoneSentPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -145,8 +138,7 @@ func (listener *MessageThreadListener) OnMessagePhoneSent(ctx context.Context, e
 	}
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
-		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID()))
 	}
 
 	return nil
@@ -159,8 +151,7 @@ func (listener *MessageThreadListener) OnMessagePhoneDelivered(ctx context.Conte
 
 	var payload events.MessagePhoneDeliveredPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -174,8 +165,7 @@ func (listener *MessageThreadListener) OnMessagePhoneDelivered(ctx context.Conte
 	}
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
-		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID()))
 	}
 
 	return nil
@@ -188,8 +178,7 @@ func (listener *MessageThreadListener) OnMessagePhoneFailed(ctx context.Context,
 
 	var payload events.MessageSendFailedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T] for event [%s]", event.Data(), payload, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T] for event [%s]", event.Data(), payload, event.ID()))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -203,8 +192,7 @@ func (listener *MessageThreadListener) OnMessagePhoneFailed(ctx context.Context,
 	}
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
-		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID()))
 	}
 
 	return nil
@@ -217,8 +205,7 @@ func (listener *MessageThreadListener) OnMessagePhoneReceived(ctx context.Contex
 
 	var payload events.MessagePhoneReceivedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -232,8 +219,7 @@ func (listener *MessageThreadListener) OnMessagePhoneReceived(ctx context.Contex
 	}
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
-		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID()))
 	}
 
 	return nil
@@ -246,8 +232,7 @@ func (listener *MessageThreadListener) onMessageNotificationScheduled(ctx contex
 
 	var payload events.MessageNotificationScheduledPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -261,8 +246,7 @@ func (listener *MessageThreadListener) onMessageNotificationScheduled(ctx contex
 	}
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
-		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID()))
 	}
 
 	return nil
@@ -275,8 +259,7 @@ func (listener *MessageThreadListener) onMessageExpired(ctx context.Context, eve
 
 	var payload events.MessageSendExpiredPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -290,8 +273,7 @@ func (listener *MessageThreadListener) onMessageExpired(ctx context.Context, eve
 	}
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
-		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID()))
 	}
 
 	return nil
@@ -303,13 +285,11 @@ func (listener *MessageThreadListener) onUserAccountDeleted(ctx context.Context,
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot delete [entities.MessageThread] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete [entities.MessageThread] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/message_thread_listener.go
+++ b/api/pkg/listeners/message_thread_listener.go
@@ -54,7 +54,7 @@ func (listener *MessageThreadListener) OnMessageAPISent(ctx context.Context, eve
 	var payload events.MessageAPISentPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -69,7 +69,7 @@ func (listener *MessageThreadListener) OnMessageAPISent(ctx context.Context, eve
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
 		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -83,12 +83,12 @@ func (listener *MessageThreadListener) onMessageDeleted(ctx context.Context, eve
 	payload := new(events.MessageAPIDeletedPayload)
 	if err := event.DataAs(payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.UpdateAfterDeletedMessage(ctx, payload); err != nil {
 		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", payload.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -102,7 +102,7 @@ func (listener *MessageThreadListener) OnMessagePhoneSending(ctx context.Context
 	var payload events.MessagePhoneSendingPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -117,7 +117,7 @@ func (listener *MessageThreadListener) OnMessagePhoneSending(ctx context.Context
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
 		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -131,7 +131,7 @@ func (listener *MessageThreadListener) OnMessagePhoneSent(ctx context.Context, e
 	var payload events.MessagePhoneSentPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -146,7 +146,7 @@ func (listener *MessageThreadListener) OnMessagePhoneSent(ctx context.Context, e
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
 		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -160,7 +160,7 @@ func (listener *MessageThreadListener) OnMessagePhoneDelivered(ctx context.Conte
 	var payload events.MessagePhoneDeliveredPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -175,7 +175,7 @@ func (listener *MessageThreadListener) OnMessagePhoneDelivered(ctx context.Conte
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
 		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -189,7 +189,7 @@ func (listener *MessageThreadListener) OnMessagePhoneFailed(ctx context.Context,
 	var payload events.MessageSendFailedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T] for event [%s]", event.Data(), payload, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -204,7 +204,7 @@ func (listener *MessageThreadListener) OnMessagePhoneFailed(ctx context.Context,
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
 		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -218,7 +218,7 @@ func (listener *MessageThreadListener) OnMessagePhoneReceived(ctx context.Contex
 	var payload events.MessagePhoneReceivedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -233,7 +233,7 @@ func (listener *MessageThreadListener) OnMessagePhoneReceived(ctx context.Contex
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
 		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -247,7 +247,7 @@ func (listener *MessageThreadListener) onMessageNotificationScheduled(ctx contex
 	var payload events.MessageNotificationScheduledPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -262,7 +262,7 @@ func (listener *MessageThreadListener) onMessageNotificationScheduled(ctx contex
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
 		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -276,7 +276,7 @@ func (listener *MessageThreadListener) onMessageExpired(ctx context.Context, eve
 	var payload events.MessageSendExpiredPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	updateParams := services.MessageThreadUpdateParams{
@@ -291,7 +291,7 @@ func (listener *MessageThreadListener) onMessageExpired(ctx context.Context, eve
 
 	if err := listener.service.UpdateThread(ctx, updateParams); err != nil {
 		msg := fmt.Sprintf("cannot update thread for message with ID [%s] for event with ID [%s]", updateParams.MessageID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -304,12 +304,12 @@ func (listener *MessageThreadListener) onUserAccountDeleted(ctx context.Context,
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot delete [entities.MessageThread] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/phone_api_key_listener.go
+++ b/api/pkg/listeners/phone_api_key_listener.go
@@ -48,8 +48,7 @@ func (listener *PhoneAPIKeyListener) onPhoneUpdated(ctx context.Context, event c
 
 	var payload events.PhoneUpdatedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if payload.PhoneAPIKeyID == nil {
@@ -58,8 +57,7 @@ func (listener *PhoneAPIKeyListener) onPhoneUpdated(ctx context.Context, event c
 	}
 
 	if err := listener.service.AddPhone(ctx, payload.UserID, *payload.PhoneAPIKeyID, payload.PhoneID); err != nil {
-		msg := fmt.Sprintf("cannot store heartbeat monitor with params [%s] for event with ID [%s]", spew.Sdump(payload), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot store heartbeat monitor with params [%s] for event with ID [%s]", spew.Sdump(payload), event.ID()))
 	}
 
 	return nil
@@ -72,13 +70,11 @@ func (listener *PhoneAPIKeyListener) onPhoneDeleted(ctx context.Context, event c
 
 	var payload events.PhoneDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.RemovePhoneByID(ctx, payload.UserID, payload.PhoneID, payload.Owner); err != nil {
-		msg := fmt.Sprintf("cannot remove phone with ID [%s] from phone api key for [%s] event with ID [%s]", payload.PhoneID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot remove phone with ID [%s] from phone api key for [%s] event with ID [%s]", payload.PhoneID, event.Type(), event.ID()))
 	}
 
 	return nil
@@ -91,13 +87,11 @@ func (listener *PhoneAPIKeyListener) onUserAccountDeleted(ctx context.Context, e
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s] for [%s] event with ID [%s]", entities.PhoneAPIKey{}, payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [%T] for user with ID [%s] for [%s] event with ID [%s]", entities.PhoneAPIKey{}, payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/phone_api_key_listener.go
+++ b/api/pkg/listeners/phone_api_key_listener.go
@@ -49,17 +49,17 @@ func (listener *PhoneAPIKeyListener) onPhoneUpdated(ctx context.Context, event c
 	var payload events.PhoneUpdatedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if payload.PhoneAPIKeyID == nil {
-		ctxLogger.Info(fmt.Sprintf("phone API Key does not exist for [%s] event with ID [%s] and phone with ID [%s] for user [%S]", event.Type(), event.ID(), payload.PhoneID, payload.UserID))
+		ctxLogger.Info(fmt.Sprintf("phone API Key does not exist for [%s] event with ID [%s] and phone with ID [%s] for user [%s]", event.Type(), event.ID(), payload.PhoneID, payload.UserID))
 		return nil
 	}
 
 	if err := listener.service.AddPhone(ctx, payload.UserID, *payload.PhoneAPIKeyID, payload.PhoneID); err != nil {
 		msg := fmt.Sprintf("cannot store heartbeat monitor with params [%s] for event with ID [%s]", spew.Sdump(payload), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -73,12 +73,12 @@ func (listener *PhoneAPIKeyListener) onPhoneDeleted(ctx context.Context, event c
 	var payload events.PhoneDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.RemovePhoneByID(ctx, payload.UserID, payload.PhoneID, payload.Owner); err != nil {
 		msg := fmt.Sprintf("cannot remove phone with ID [%s] from phone api key for [%s] event with ID [%s]", payload.PhoneID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -92,12 +92,12 @@ func (listener *PhoneAPIKeyListener) onUserAccountDeleted(ctx context.Context, e
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s] for [%s] event with ID [%s]", entities.PhoneAPIKey{}, payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/phone_listener.go
+++ b/api/pkg/listeners/phone_listener.go
@@ -44,13 +44,11 @@ func (listener *PhoneListener) onMessageSendScheduleDeleted(ctx context.Context,
 
 	var payload events.MessageSendScheduleDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.NullifyScheduleID(ctx, payload.UserID, payload.ScheduleID); err != nil {
-		msg := fmt.Sprintf("cannot nullify schedule ID [%s] for user [%s] on [%s] event with ID [%s]", payload.ScheduleID, payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot nullify schedule ID [%s] for user [%s] on [%s] event with ID [%s]", payload.ScheduleID, payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil
@@ -63,13 +61,11 @@ func (listener *PhoneListener) onUserAccountDeleted(ctx context.Context, event c
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot delete all [entities.Phone] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [entities.Phone] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/phone_listener.go
+++ b/api/pkg/listeners/phone_listener.go
@@ -45,12 +45,12 @@ func (listener *PhoneListener) onMessageSendScheduleDeleted(ctx context.Context,
 	var payload events.MessageSendScheduleDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.NullifyScheduleID(ctx, payload.UserID, payload.ScheduleID); err != nil {
 		msg := fmt.Sprintf("cannot nullify schedule ID [%s] for user [%s] on [%s] event with ID [%s]", payload.ScheduleID, payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -64,12 +64,12 @@ func (listener *PhoneListener) onUserAccountDeleted(ctx context.Context, event c
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot delete all [entities.Phone] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/phone_notification_listener.go
+++ b/api/pkg/listeners/phone_notification_listener.go
@@ -50,7 +50,7 @@ func (listener *PhoneNotificationListener) onMessageAPISent(ctx context.Context,
 	var payload events.MessageAPISentPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	sendParams := &services.PhoneNotificationScheduleParams{
@@ -68,7 +68,7 @@ func (listener *PhoneNotificationListener) onMessageAPISent(ctx context.Context,
 
 	if err := listener.service.Schedule(ctx, sendParams); err != nil {
 		msg := fmt.Sprintf("cannot send notification with params [%s] for event with ID [%s]", spew.Sdump(sendParams), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -82,7 +82,7 @@ func (listener *PhoneNotificationListener) onMessageSendRetry(ctx context.Contex
 	var payload events.MessageSendRetryPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	sendParams := &services.PhoneNotificationScheduleParams{
@@ -98,7 +98,7 @@ func (listener *PhoneNotificationListener) onMessageSendRetry(ctx context.Contex
 
 	if err := listener.service.Schedule(ctx, sendParams); err != nil {
 		msg := fmt.Sprintf("cannot send notification with params [%s] for event with ID [%s]", spew.Sdump(sendParams), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -112,12 +112,12 @@ func (listener *PhoneNotificationListener) onPhoneHeartbeatMissed(ctx context.Co
 	payload := new(events.PhoneHeartbeatMissedPayload)
 	if err := event.DataAs(payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.SendHeartbeatFCM(ctx, payload); err != nil {
 		msg := fmt.Sprintf("cannot schedule send heartbeat FCM with params [%s] for event with ID [%s]", spew.Sdump(payload), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -131,7 +131,7 @@ func (listener *PhoneNotificationListener) onMessageNotificationSend(ctx context
 	var payload events.MessageNotificationSendPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	scheduleParams := &services.PhoneNotificationSendParams{
@@ -145,7 +145,7 @@ func (listener *PhoneNotificationListener) onMessageNotificationSend(ctx context
 
 	if err := listener.service.Send(ctx, scheduleParams); err != nil {
 		msg := fmt.Sprintf("cannot schedule notification with params [%s] for event with ID [%s]", spew.Sdump(scheduleParams), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -158,12 +158,12 @@ func (listener *PhoneNotificationListener) onUserAccountDeleted(ctx context.Cont
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot delete [entities.Phone] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -177,12 +177,12 @@ func (listener *PhoneNotificationListener) onMessageAPIDeleted(ctx context.Conte
 	var payload events.MessageAPIDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteByMessageID(ctx, payload.UserID, payload.MessageID); err != nil {
 		msg := fmt.Sprintf("cannot delete [entities.PhoneNotification] for user [%s] and message [%s] on [%s] event with ID [%s]", payload.UserID, payload.MessageID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/phone_notification_listener.go
+++ b/api/pkg/listeners/phone_notification_listener.go
@@ -49,8 +49,7 @@ func (listener *PhoneNotificationListener) onMessageAPISent(ctx context.Context,
 
 	var payload events.MessageAPISentPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	sendParams := &services.PhoneNotificationScheduleParams{
@@ -67,8 +66,7 @@ func (listener *PhoneNotificationListener) onMessageAPISent(ctx context.Context,
 	}
 
 	if err := listener.service.Schedule(ctx, sendParams); err != nil {
-		msg := fmt.Sprintf("cannot send notification with params [%s] for event with ID [%s]", spew.Sdump(sendParams), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot send notification with params [%s] for event with ID [%s]", spew.Sdump(sendParams), event.ID()))
 	}
 
 	return nil
@@ -81,8 +79,7 @@ func (listener *PhoneNotificationListener) onMessageSendRetry(ctx context.Contex
 
 	var payload events.MessageSendRetryPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	sendParams := &services.PhoneNotificationScheduleParams{
@@ -97,8 +94,7 @@ func (listener *PhoneNotificationListener) onMessageSendRetry(ctx context.Contex
 	}
 
 	if err := listener.service.Schedule(ctx, sendParams); err != nil {
-		msg := fmt.Sprintf("cannot send notification with params [%s] for event with ID [%s]", spew.Sdump(sendParams), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot send notification with params [%s] for event with ID [%s]", spew.Sdump(sendParams), event.ID()))
 	}
 
 	return nil
@@ -111,13 +107,11 @@ func (listener *PhoneNotificationListener) onPhoneHeartbeatMissed(ctx context.Co
 
 	payload := new(events.PhoneHeartbeatMissedPayload)
 	if err := event.DataAs(payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.SendHeartbeatFCM(ctx, payload); err != nil {
-		msg := fmt.Sprintf("cannot schedule send heartbeat FCM with params [%s] for event with ID [%s]", spew.Sdump(payload), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot schedule send heartbeat FCM with params [%s] for event with ID [%s]", spew.Sdump(payload), event.ID()))
 	}
 
 	return nil
@@ -130,8 +124,7 @@ func (listener *PhoneNotificationListener) onMessageNotificationSend(ctx context
 
 	var payload events.MessageNotificationSendPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	scheduleParams := &services.PhoneNotificationSendParams{
@@ -144,8 +137,7 @@ func (listener *PhoneNotificationListener) onMessageNotificationSend(ctx context
 	}
 
 	if err := listener.service.Send(ctx, scheduleParams); err != nil {
-		msg := fmt.Sprintf("cannot schedule notification with params [%s] for event with ID [%s]", spew.Sdump(scheduleParams), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot schedule notification with params [%s] for event with ID [%s]", spew.Sdump(scheduleParams), event.ID()))
 	}
 
 	return nil
@@ -157,13 +149,11 @@ func (listener *PhoneNotificationListener) onUserAccountDeleted(ctx context.Cont
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot delete [entities.Phone] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete [entities.Phone] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil
@@ -176,13 +166,11 @@ func (listener *PhoneNotificationListener) onMessageAPIDeleted(ctx context.Conte
 
 	var payload events.MessageAPIDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteByMessageID(ctx, payload.UserID, payload.MessageID); err != nil {
-		msg := fmt.Sprintf("cannot delete [entities.PhoneNotification] for user [%s] and message [%s] on [%s] event with ID [%s]", payload.UserID, payload.MessageID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete [entities.PhoneNotification] for user [%s] and message [%s] on [%s] event with ID [%s]", payload.UserID, payload.MessageID, event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/user_listener.go
+++ b/api/pkg/listeners/user_listener.go
@@ -50,8 +50,7 @@ func (listener *UserListener) onPhoneHeartbeatDead(ctx context.Context, event cl
 
 	var payload events.PhoneHeartbeatOfflinePayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	sendParams := &services.UserSendPhoneDeadEmailParams{
@@ -62,8 +61,7 @@ func (listener *UserListener) onPhoneHeartbeatDead(ctx context.Context, event cl
 	}
 
 	if err := listener.service.SendPhoneDeadEmail(ctx, sendParams); err != nil {
-		msg := fmt.Sprintf("cannot send notification with params [%s] for event with ID [%s]", spew.Sdump(sendParams), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot send notification with params [%s] for event with ID [%s]", spew.Sdump(sendParams), event.ID()))
 	}
 
 	return nil
@@ -76,13 +74,11 @@ func (listener *UserListener) onUserAPIKeyRotated(ctx context.Context, event clo
 
 	payload := new(events.UserAPIKeyRotatedPayload)
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.SendAPIKeyRotatedEmail(ctx, payload); err != nil {
-		msg := fmt.Sprintf("cannot send notification with params [%s] for event with ID [%s]", spew.Sdump(payload), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot send notification with params [%s] for event with ID [%s]", spew.Sdump(payload), event.ID()))
 	}
 
 	return nil
@@ -95,13 +91,11 @@ func (listener *UserListener) OnUserSubscriptionCreated(ctx context.Context, eve
 
 	var payload events.UserSubscriptionCreatedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.StartSubscription(ctx, &payload); err != nil {
-		msg := fmt.Sprintf("cannot start subscription for user with ID [%s] for event with ID [%s]", payload.UserID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot start subscription for user with ID [%s] for event with ID [%s]", payload.UserID, event.ID()))
 	}
 
 	return nil
@@ -114,13 +108,11 @@ func (listener *UserListener) OnUserSubscriptionCancelled(ctx context.Context, e
 
 	var payload events.UserSubscriptionCancelledPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.CancelSubscription(ctx, &payload); err != nil {
-		msg := fmt.Sprintf("cannot cancell subscription for user with ID [%s] for event with ID [%s]", payload.UserID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot cancell subscription for user with ID [%s] for event with ID [%s]", payload.UserID, event.ID()))
 	}
 
 	return nil
@@ -133,13 +125,11 @@ func (listener *UserListener) OnUserSubscriptionExpired(ctx context.Context, eve
 
 	var payload events.UserSubscriptionExpiredPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.ExpireSubscription(ctx, &payload); err != nil {
-		msg := fmt.Sprintf("cannot expire subscription for user with ID [%s] for event with ID [%s]", payload.UserID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot expire subscription for user with ID [%s] for event with ID [%s]", payload.UserID, event.ID()))
 	}
 
 	return nil
@@ -152,13 +142,11 @@ func (listener *UserListener) OnUserSubscriptionUpdated(ctx context.Context, eve
 
 	var payload events.UserSubscriptionUpdatedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.UpdateSubscription(ctx, &payload); err != nil {
-		msg := fmt.Sprintf("cannot expire subscription for user with ID [%s] for event with ID [%s]", payload.UserID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot expire subscription for user with ID [%s] for event with ID [%s]", payload.UserID, event.ID()))
 	}
 
 	return nil
@@ -170,13 +158,11 @@ func (listener *UserListener) onUserAccountDeleted(ctx context.Context, event cl
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteAuthUser(ctx, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot delete [entities.AuthUser] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete [entities.AuthUser] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/user_listener.go
+++ b/api/pkg/listeners/user_listener.go
@@ -51,7 +51,7 @@ func (listener *UserListener) onPhoneHeartbeatDead(ctx context.Context, event cl
 	var payload events.PhoneHeartbeatOfflinePayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	sendParams := &services.UserSendPhoneDeadEmailParams{
@@ -63,7 +63,7 @@ func (listener *UserListener) onPhoneHeartbeatDead(ctx context.Context, event cl
 
 	if err := listener.service.SendPhoneDeadEmail(ctx, sendParams); err != nil {
 		msg := fmt.Sprintf("cannot send notification with params [%s] for event with ID [%s]", spew.Sdump(sendParams), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -77,12 +77,12 @@ func (listener *UserListener) onUserAPIKeyRotated(ctx context.Context, event clo
 	payload := new(events.UserAPIKeyRotatedPayload)
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.SendAPIKeyRotatedEmail(ctx, payload); err != nil {
 		msg := fmt.Sprintf("cannot send notification with params [%s] for event with ID [%s]", spew.Sdump(payload), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -96,12 +96,12 @@ func (listener *UserListener) OnUserSubscriptionCreated(ctx context.Context, eve
 	var payload events.UserSubscriptionCreatedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.StartSubscription(ctx, &payload); err != nil {
 		msg := fmt.Sprintf("cannot start subscription for user with ID [%s] for event with ID [%s]", payload.UserID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -115,12 +115,12 @@ func (listener *UserListener) OnUserSubscriptionCancelled(ctx context.Context, e
 	var payload events.UserSubscriptionCancelledPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.CancelSubscription(ctx, &payload); err != nil {
 		msg := fmt.Sprintf("cannot cancell subscription for user with ID [%s] for event with ID [%s]", payload.UserID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -134,12 +134,12 @@ func (listener *UserListener) OnUserSubscriptionExpired(ctx context.Context, eve
 	var payload events.UserSubscriptionExpiredPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.ExpireSubscription(ctx, &payload); err != nil {
 		msg := fmt.Sprintf("cannot expire subscription for user with ID [%s] for event with ID [%s]", payload.UserID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -153,12 +153,12 @@ func (listener *UserListener) OnUserSubscriptionUpdated(ctx context.Context, eve
 	var payload events.UserSubscriptionUpdatedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.UpdateSubscription(ctx, &payload); err != nil {
 		msg := fmt.Sprintf("cannot expire subscription for user with ID [%s] for event with ID [%s]", payload.UserID, event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -171,12 +171,12 @@ func (listener *UserListener) onUserAccountDeleted(ctx context.Context, event cl
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteAuthUser(ctx, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot delete [entities.AuthUser] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/webhook_listener.go
+++ b/api/pkg/listeners/webhook_listener.go
@@ -50,13 +50,11 @@ func (listener *WebhookListener) OnMessagePhoneReceived(ctx context.Context, eve
 
 	var payload events.MessagePhoneReceivedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -69,13 +67,11 @@ func (listener *WebhookListener) OnMessageSendExpired(ctx context.Context, event
 
 	var payload events.MessageSendExpiredPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -88,13 +84,11 @@ func (listener *WebhookListener) OnMessageSendFailed(ctx context.Context, event 
 
 	var payload events.MessageSendFailedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -107,13 +101,11 @@ func (listener *WebhookListener) OnMessagePhoneSent(ctx context.Context, event c
 
 	var payload events.MessagePhoneSentPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -126,13 +118,11 @@ func (listener *WebhookListener) OnMessagePhoneDelivered(ctx context.Context, ev
 
 	var payload events.MessagePhoneDeliveredPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -145,13 +135,11 @@ func (listener *WebhookListener) onPhoneHeartbeatOffline(ctx context.Context, ev
 
 	var payload events.PhoneHeartbeatOfflinePayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -164,13 +152,11 @@ func (listener *WebhookListener) onPhoneHeartbeatOnline(ctx context.Context, eve
 
 	var payload events.PhoneHeartbeatOnlinePayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -183,13 +169,11 @@ func (listener *WebhookListener) onMessageCallMissed(ctx context.Context, event 
 
 	var payload events.MessageCallMissedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
-		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot process [%s] event with ID [%s]", event.Type(), event.ID()))
 	}
 
 	return nil
@@ -201,13 +185,11 @@ func (listener *WebhookListener) onUserAccountDeleted(ctx context.Context, event
 
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
-		msg := fmt.Sprintf("cannot delete [entities.Webhook] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete [entities.Webhook] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
 	}
 
 	return nil

--- a/api/pkg/listeners/webhook_listener.go
+++ b/api/pkg/listeners/webhook_listener.go
@@ -51,12 +51,12 @@ func (listener *WebhookListener) OnMessagePhoneReceived(ctx context.Context, eve
 	var payload events.MessagePhoneReceivedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -70,12 +70,12 @@ func (listener *WebhookListener) OnMessageSendExpired(ctx context.Context, event
 	var payload events.MessageSendExpiredPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -89,12 +89,12 @@ func (listener *WebhookListener) OnMessageSendFailed(ctx context.Context, event 
 	var payload events.MessageSendFailedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -108,12 +108,12 @@ func (listener *WebhookListener) OnMessagePhoneSent(ctx context.Context, event c
 	var payload events.MessagePhoneSentPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -127,12 +127,12 @@ func (listener *WebhookListener) OnMessagePhoneDelivered(ctx context.Context, ev
 	var payload events.MessagePhoneDeliveredPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -146,12 +146,12 @@ func (listener *WebhookListener) onPhoneHeartbeatOffline(ctx context.Context, ev
 	var payload events.PhoneHeartbeatOfflinePayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -165,12 +165,12 @@ func (listener *WebhookListener) onPhoneHeartbeatOnline(ctx context.Context, eve
 	var payload events.PhoneHeartbeatOnlinePayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -184,12 +184,12 @@ func (listener *WebhookListener) onMessageCallMissed(ctx context.Context, event 
 	var payload events.MessageCallMissedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.Send(ctx, payload.UserID, event, payload.Owner); err != nil {
 		msg := fmt.Sprintf("cannot process [%s] event with ID [%s]", event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -202,12 +202,12 @@ func (listener *WebhookListener) onUserAccountDeleted(ctx context.Context, event
 	var payload events.UserAccountDeletedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
 		msg := fmt.Sprintf("cannot delete [entities.Webhook] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID())
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/websocket_listener.go
+++ b/api/pkg/listeners/websocket_listener.go
@@ -47,12 +47,12 @@ func (listener *WebsocketListener) onMessagePhoneSent(ctx context.Context, event
 	var payload events.MessagePhoneSentPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.client.Trigger(payload.UserID.String(), event.Type(), event.ID()); err != nil {
 		msg := fmt.Sprintf("cannot trigger websocket [%s] event with ID [%s] for user with ID [%s]", event.Type(), event.ID(), payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -66,12 +66,12 @@ func (listener *WebsocketListener) onMessagePhoneReceived(ctx context.Context, e
 	var payload events.MessagePhoneReceivedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.client.Trigger(payload.UserID.String(), event.Type(), event.ID()); err != nil {
 		msg := fmt.Sprintf("cannot trigger websocket [%s] event with ID [%s] for user with ID [%s]", event.Type(), event.ID(), payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -85,12 +85,12 @@ func (listener *WebsocketListener) onMessagePhoneFailed(ctx context.Context, eve
 	var payload events.MessageSendFailedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.client.Trigger(payload.UserID.String(), event.Type(), event.ID()); err != nil {
 		msg := fmt.Sprintf("cannot trigger websocket [%s] event with ID [%s] for user with ID [%s]", event.Type(), event.ID(), payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -104,12 +104,12 @@ func (listener *WebsocketListener) onPhoneUpdated(ctx context.Context, event clo
 	var payload events.PhoneUpdatedPayload
 	if err := event.DataAs(&payload); err != nil {
 		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := listener.client.Trigger(payload.UserID.String(), event.Type(), event.ID()); err != nil {
 		msg := fmt.Sprintf("cannot trigger websocket [%s] event with ID [%s] for user with ID [%s]", event.Type(), event.ID(), payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/listeners/websocket_listener.go
+++ b/api/pkg/listeners/websocket_listener.go
@@ -46,13 +46,11 @@ func (listener *WebsocketListener) onMessagePhoneSent(ctx context.Context, event
 
 	var payload events.MessagePhoneSentPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.client.Trigger(payload.UserID.String(), event.Type(), event.ID()); err != nil {
-		msg := fmt.Sprintf("cannot trigger websocket [%s] event with ID [%s] for user with ID [%s]", event.Type(), event.ID(), payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot trigger websocket [%s] event with ID [%s] for user with ID [%s]", event.Type(), event.ID(), payload.UserID))
 	}
 
 	return nil
@@ -65,13 +63,11 @@ func (listener *WebsocketListener) onMessagePhoneReceived(ctx context.Context, e
 
 	var payload events.MessagePhoneReceivedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.client.Trigger(payload.UserID.String(), event.Type(), event.ID()); err != nil {
-		msg := fmt.Sprintf("cannot trigger websocket [%s] event with ID [%s] for user with ID [%s]", event.Type(), event.ID(), payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot trigger websocket [%s] event with ID [%s] for user with ID [%s]", event.Type(), event.ID(), payload.UserID))
 	}
 
 	return nil
@@ -84,13 +80,11 @@ func (listener *WebsocketListener) onMessagePhoneFailed(ctx context.Context, eve
 
 	var payload events.MessageSendFailedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.client.Trigger(payload.UserID.String(), event.Type(), event.ID()); err != nil {
-		msg := fmt.Sprintf("cannot trigger websocket [%s] event with ID [%s] for user with ID [%s]", event.Type(), event.ID(), payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot trigger websocket [%s] event with ID [%s] for user with ID [%s]", event.Type(), event.ID(), payload.UserID))
 	}
 
 	return nil
@@ -103,13 +97,11 @@ func (listener *WebsocketListener) onPhoneUpdated(ctx context.Context, event clo
 
 	var payload events.PhoneUpdatedPayload
 	if err := event.DataAs(&payload); err != nil {
-		msg := fmt.Sprintf("cannot decode [%s] into [%T]", event.Data(), payload)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode [%s] into [%T]", event.Data(), payload))
 	}
 
 	if err := listener.client.Trigger(payload.UserID.String(), event.Type(), event.ID()); err != nil {
-		msg := fmt.Sprintf("cannot trigger websocket [%s] event with ID [%s] for user with ID [%s]", event.Type(), event.ID(), payload.UserID)
-		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot trigger websocket [%s] event with ID [%s] for user with ID [%s]", event.Type(), event.ID(), payload.UserID))
 	}
 
 	return nil

--- a/api/pkg/middlewares/api_key_auth_middleware.go
+++ b/api/pkg/middlewares/api_key_auth_middleware.go
@@ -28,7 +28,7 @@ func APIKeyAuth(logger telemetry.Logger, tracer telemetry.Tracer, userRepository
 
 		authUser, err := userRepository.LoadAuthContext(ctx, apiKey)
 		if err != nil {
-			ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load user with api key [%s]", apiKey)))
+			ctxLogger.Error(stacktrace.Propagate(err, "cannot load user with api key [%s]", apiKey))
 			return c.Next()
 		}
 

--- a/api/pkg/middlewares/api_key_auth_middleware.go
+++ b/api/pkg/middlewares/api_key_auth_middleware.go
@@ -28,7 +28,7 @@ func APIKeyAuth(logger telemetry.Logger, tracer telemetry.Tracer, userRepository
 
 		authUser, err := userRepository.LoadAuthContext(ctx, apiKey)
 		if err != nil {
-			ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot load user with api key [%s]", apiKey)))
+			ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load user with api key [%s]", apiKey)))
 			return c.Next()
 		}
 

--- a/api/pkg/middlewares/bearer_api_key_auth_middleware.go
+++ b/api/pkg/middlewares/bearer_api_key_auth_middleware.go
@@ -26,7 +26,7 @@ func BearerAPIKeyAuth(logger telemetry.Logger, tracer telemetry.Tracer, userRepo
 
 		authUser, err := userRepository.LoadAuthContext(ctx, apiKey)
 		if err != nil {
-			ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load user with api key [%s] using header [%s]", apiKey, c.Get(authHeaderBearer))))
+			ctxLogger.Error(stacktrace.Propagate(err, "cannot load user with api key [%s] using header [%s]", apiKey, c.Get(authHeaderBearer)))
 			return c.Next()
 		}
 

--- a/api/pkg/middlewares/bearer_api_key_auth_middleware.go
+++ b/api/pkg/middlewares/bearer_api_key_auth_middleware.go
@@ -26,7 +26,7 @@ func BearerAPIKeyAuth(logger telemetry.Logger, tracer telemetry.Tracer, userRepo
 
 		authUser, err := userRepository.LoadAuthContext(ctx, apiKey)
 		if err != nil {
-			ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot load user with api key [%s] using header [%s]", apiKey, c.Get(authHeaderBearer))))
+			ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load user with api key [%s] using header [%s]", apiKey, c.Get(authHeaderBearer))))
 			return c.Next()
 		}
 

--- a/api/pkg/middlewares/bearer_auth_middleware.go
+++ b/api/pkg/middlewares/bearer_auth_middleware.go
@@ -33,8 +33,7 @@ func BearerAuth(logger telemetry.Logger, tracer telemetry.Tracer, authClient *au
 
 		token, err := authClient.VerifyIDToken(context.Background(), authToken)
 		if err != nil {
-			msg := fmt.Sprintf("invalid firebase id token [%s]", authToken)
-			ctxLogger.Warn(tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+			ctxLogger.Warn(tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "invalid firebase id token [%s]", authToken)))
 			return c.Next()
 		}
 

--- a/api/pkg/middlewares/bearer_auth_middleware.go
+++ b/api/pkg/middlewares/bearer_auth_middleware.go
@@ -34,7 +34,7 @@ func BearerAuth(logger telemetry.Logger, tracer telemetry.Tracer, authClient *au
 		token, err := authClient.VerifyIDToken(context.Background(), authToken)
 		if err != nil {
 			msg := fmt.Sprintf("invalid firebase id token [%s]", authToken)
-			ctxLogger.Warn(tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+			ctxLogger.Warn(tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 			return c.Next()
 		}
 

--- a/api/pkg/middlewares/http_request_logger_middleware.go
+++ b/api/pkg/middlewares/http_request_logger_middleware.go
@@ -24,7 +24,7 @@ func HTTPRequestLogger(tracer telemetry.Tracer, logger telemetry.Logger) fiber.H
 		statusCode := c.Response().StatusCode()
 		span.AddEvent(fmt.Sprintf("finished handling request with traceID: [%s], statusCode: [%d]", span.SpanContext().TraceID().String(), statusCode))
 		if statusCode >= 300 && len(c.Request().Body()) > 0 && !slices.Contains([]int{401, 402}, statusCode) {
-			ctxLogger.WithString("client.version", c.Get(clientVersionHeader)).Warn(stacktrace.NewError("%s", fmt.Sprintf("http.status [%d], body [%s]", statusCode, string(c.Request().Body()))))
+			ctxLogger.WithString("client.version", c.Get(clientVersionHeader)).Warn(stacktrace.NewError("http.status [%d], body [%s]", statusCode, string(c.Request().Body())))
 		}
 
 		return response

--- a/api/pkg/middlewares/http_request_logger_middleware.go
+++ b/api/pkg/middlewares/http_request_logger_middleware.go
@@ -24,7 +24,7 @@ func HTTPRequestLogger(tracer telemetry.Tracer, logger telemetry.Logger) fiber.H
 		statusCode := c.Response().StatusCode()
 		span.AddEvent(fmt.Sprintf("finished handling request with traceID: [%s], statusCode: [%d]", span.SpanContext().TraceID().String(), statusCode))
 		if statusCode >= 300 && len(c.Request().Body()) > 0 && !slices.Contains([]int{401, 402}, statusCode) {
-			ctxLogger.WithString("client.version", c.Get(clientVersionHeader)).Warn(stacktrace.NewError(fmt.Sprintf("http.status [%d], body [%s]", statusCode, string(c.Request().Body()))))
+			ctxLogger.WithString("client.version", c.Get(clientVersionHeader)).Warn(stacktrace.NewError("%s", fmt.Sprintf("http.status [%d], body [%s]", statusCode, string(c.Request().Body()))))
 		}
 
 		return response

--- a/api/pkg/middlewares/phone_api_key_auth_middleware.go
+++ b/api/pkg/middlewares/phone_api_key_auth_middleware.go
@@ -26,7 +26,7 @@ func PhoneAPIKeyAuth(logger telemetry.Logger, tracer telemetry.Tracer, repositor
 
 		authUser, err := repository.LoadAuthContext(ctx, apiKey)
 		if err != nil {
-			ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load user with phone api key [%s]", apiKey)))
+			ctxLogger.Error(stacktrace.Propagate(err, "cannot load user with phone api key [%s]", apiKey))
 			return c.Next()
 		}
 

--- a/api/pkg/middlewares/phone_api_key_auth_middleware.go
+++ b/api/pkg/middlewares/phone_api_key_auth_middleware.go
@@ -26,7 +26,7 @@ func PhoneAPIKeyAuth(logger telemetry.Logger, tracer telemetry.Tracer, repositor
 
 		authUser, err := repository.LoadAuthContext(ctx, apiKey)
 		if err != nil {
-			ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot load user with phone api key [%s]", apiKey)))
+			ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load user with phone api key [%s]", apiKey)))
 			return c.Next()
 		}
 

--- a/api/pkg/repositories/google_cloud_storage_attachment_repository.go
+++ b/api/pkg/repositories/google_cloud_storage_attachment_repository.go
@@ -43,11 +43,11 @@ func (s *GoogleCloudStorageAttachmentRepository) Upload(ctx context.Context, pat
 	writer.ContentType = contentType
 
 	if _, err := writer.Write(data); err != nil {
-		return s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot write attachment to GCS path [%s]", path)))
+		return s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot write attachment to GCS path [%s]", path))
 	}
 
 	if err := writer.Close(); err != nil {
-		return s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot close GCS writer for path [%s]", path)))
+		return s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot close GCS writer for path [%s]", path))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("uploaded attachment to GCS path [%s/%s] with size [%d]", s.bucket, path, len(data)))
@@ -61,17 +61,16 @@ func (s *GoogleCloudStorageAttachmentRepository) Download(ctx context.Context, p
 
 	reader, err := s.client.Bucket(s.bucket).Object(path).NewReader(ctx)
 	if err != nil {
-		msg := fmt.Sprintf("cannot open GCS reader for path [%s]", path)
 		if errors.Is(err, storage.ErrObjectNotExist) {
-			return nil, s.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+			return nil, s.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "cannot open GCS reader for path [%s]", path))
 		}
-		return nil, s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot open GCS reader for path [%s]", path))
 	}
 	defer reader.Close()
 
 	data, err := io.ReadAll(reader)
 	if err != nil {
-		return nil, s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot read attachment from GCS path [%s]", path)))
+		return nil, s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot read attachment from GCS path [%s]", path))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("downloaded attachment from GCS path [%s/%s] with size [%d]", s.bucket, path, len(data)))
@@ -84,7 +83,7 @@ func (s *GoogleCloudStorageAttachmentRepository) Delete(ctx context.Context, pat
 	defer span.End()
 
 	if err := s.client.Bucket(s.bucket).Object(path).Delete(ctx); err != nil {
-		return s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot delete GCS object at path [%s]", path)))
+		return s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete GCS object at path [%s]", path))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted attachment from GCS path [%s/%s]", s.bucket, path))

--- a/api/pkg/repositories/google_cloud_storage_attachment_repository.go
+++ b/api/pkg/repositories/google_cloud_storage_attachment_repository.go
@@ -43,11 +43,11 @@ func (s *GoogleCloudStorageAttachmentRepository) Upload(ctx context.Context, pat
 	writer.ContentType = contentType
 
 	if _, err := writer.Write(data); err != nil {
-		return s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, fmt.Sprintf("cannot write attachment to GCS path [%s]", path)))
+		return s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot write attachment to GCS path [%s]", path)))
 	}
 
 	if err := writer.Close(); err != nil {
-		return s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, fmt.Sprintf("cannot close GCS writer for path [%s]", path)))
+		return s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot close GCS writer for path [%s]", path)))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("uploaded attachment to GCS path [%s/%s] with size [%d]", s.bucket, path, len(data)))
@@ -63,15 +63,15 @@ func (s *GoogleCloudStorageAttachmentRepository) Download(ctx context.Context, p
 	if err != nil {
 		msg := fmt.Sprintf("cannot open GCS reader for path [%s]", path)
 		if errors.Is(err, storage.ErrObjectNotExist) {
-			return nil, s.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+			return nil, s.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 		}
-		return nil, s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	defer reader.Close()
 
 	data, err := io.ReadAll(reader)
 	if err != nil {
-		return nil, s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, fmt.Sprintf("cannot read attachment from GCS path [%s]", path)))
+		return nil, s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot read attachment from GCS path [%s]", path)))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("downloaded attachment from GCS path [%s/%s] with size [%d]", s.bucket, path, len(data)))
@@ -84,7 +84,7 @@ func (s *GoogleCloudStorageAttachmentRepository) Delete(ctx context.Context, pat
 	defer span.End()
 
 	if err := s.client.Bucket(s.bucket).Object(path).Delete(ctx); err != nil {
-		return s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, fmt.Sprintf("cannot delete GCS object at path [%s]", path)))
+		return s.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot delete GCS object at path [%s]", path)))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted attachment from GCS path [%s/%s]", s.bucket, path))

--- a/api/pkg/repositories/gorm_billing_usage_repository.go
+++ b/api/pkg/repositories/gorm_billing_usage_repository.go
@@ -40,8 +40,7 @@ func (repository *gormBillingUsageRepository) DeleteAllForUser(ctx context.Conte
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.BillingUsage{}).Error; err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.BillingUsage{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [%T] for user with ID [%s]", &entities.BillingUsage{}, userID))
 	}
 
 	return nil
@@ -52,7 +51,8 @@ func (repository *gormBillingUsageRepository) RegisterSentMessage(ctx context.Co
 	ctx, span := repository.tracer.Start(ctx)
 	defer span.End()
 
-	return crdbgorm.ExecuteTx(ctx, repository.db, nil,
+	return crdbgorm.ExecuteTx(
+		ctx, repository.db, nil,
 		func(tx *gorm.DB) error {
 			result := tx.WithContext(ctx).
 				Model(&entities.BillingUsage{}).
@@ -78,7 +78,8 @@ func (repository *gormBillingUsageRepository) RegisterReceivedMessage(ctx contex
 	ctx, span := repository.tracer.Start(ctx)
 	defer span.End()
 
-	return crdbgorm.ExecuteTx(ctx, repository.db, nil,
+	return crdbgorm.ExecuteTx(
+		ctx, repository.db, nil,
 		func(tx *gorm.DB) error {
 			result := tx.WithContext(ctx).
 				Model(&entities.BillingUsage{}).
@@ -107,7 +108,8 @@ func (repository *gormBillingUsageRepository) GetCurrent(ctx context.Context, us
 	timestamp := time.Now().UTC()
 
 	var usage entities.BillingUsage
-	err := crdbgorm.ExecuteTx(ctx, repository.db, nil,
+	err := crdbgorm.ExecuteTx(
+		ctx, repository.db, nil,
 		func(tx *gorm.DB) error {
 			result := tx.WithContext(ctx).
 				Where("user_id = ?", userID).
@@ -131,7 +133,7 @@ func (repository *gormBillingUsageRepository) GetCurrent(ctx context.Context, us
 		},
 	)
 	if err != nil {
-		return &usage, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load billing usage for user [%s]", userID))
+		return &usage, stacktrace.Propagate(err, "cannot load billing usage for user [%s]", userID)
 	}
 
 	return &usage, nil
@@ -154,8 +156,7 @@ func (repository *gormBillingUsageRepository) GetHistory(ctx context.Context, us
 		Find(&usages).
 		Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot fetch billing usage history for userID [%s] and params [%+#v]", userID, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch billing usage history for userID [%s] and params [%+#v]", userID, params))
 	}
 
 	return usages, nil
@@ -166,7 +167,7 @@ func (repository *gormBillingUsageRepository) GetHistory(ctx context.Context, us
 func (repository *gormBillingUsageRepository) createBillingUsageForUser(ctx context.Context, tx *gorm.DB, userID entities.UserID, timestamp time.Time, sent uint, received uint) (*entities.BillingUsage, error) {
 	user := new(entities.User)
 	if err := tx.WithContext(ctx).First(user, userID).Error; err != nil {
-		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load user [%s] to compute billing cycle", userID))
+		return nil, stacktrace.Propagate(err, "cannot load user [%s] to compute billing cycle", userID)
 	}
 
 	start, end := computeBillingCycle(timestamp, user.GetBillingAnchorDay())

--- a/api/pkg/repositories/gorm_billing_usage_repository.go
+++ b/api/pkg/repositories/gorm_billing_usage_repository.go
@@ -41,7 +41,7 @@ func (repository *gormBillingUsageRepository) DeleteAllForUser(ctx context.Conte
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.BillingUsage{}).Error; err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.BillingUsage{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -131,7 +131,7 @@ func (repository *gormBillingUsageRepository) GetCurrent(ctx context.Context, us
 		},
 	)
 	if err != nil {
-		return &usage, stacktrace.Propagate(err, fmt.Sprintf("cannot load billing usage for user [%s]", userID))
+		return &usage, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load billing usage for user [%s]", userID))
 	}
 
 	return &usage, nil
@@ -155,7 +155,7 @@ func (repository *gormBillingUsageRepository) GetHistory(ctx context.Context, us
 		Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot fetch billing usage history for userID [%s] and params [%+#v]", userID, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return usages, nil
@@ -166,7 +166,7 @@ func (repository *gormBillingUsageRepository) GetHistory(ctx context.Context, us
 func (repository *gormBillingUsageRepository) createBillingUsageForUser(ctx context.Context, tx *gorm.DB, userID entities.UserID, timestamp time.Time, sent uint, received uint) (*entities.BillingUsage, error) {
 	user := new(entities.User)
 	if err := tx.WithContext(ctx).First(user, userID).Error; err != nil {
-		return nil, stacktrace.Propagate(err, fmt.Sprintf("cannot load user [%s] to compute billing cycle", userID))
+		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load user [%s] to compute billing cycle", userID))
 	}
 
 	start, end := computeBillingCycle(timestamp, user.GetBillingAnchorDay())

--- a/api/pkg/repositories/gorm_discord_repository.go
+++ b/api/pkg/repositories/gorm_discord_repository.go
@@ -37,8 +37,7 @@ func (repository *gormDiscordRepository) DeleteAllForUser(ctx context.Context, u
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.Discord{}).Error; err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Discord{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [%T] for user with ID [%s]", &entities.Discord{}, userID))
 	}
 
 	return nil
@@ -49,8 +48,7 @@ func (repository *gormDiscordRepository) Save(ctx context.Context, Discord *enti
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Save(Discord).Error; err != nil {
-		msg := fmt.Sprintf("cannot update discord integration with ID [%s]", Discord.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update discord integration with ID [%s]", Discord.ID))
 	}
 
 	return nil
@@ -69,8 +67,7 @@ func (repository *gormDiscordRepository) Index(ctx context.Context, userID entit
 
 	discords := make([]*entities.Discord, 0)
 	if err := query.Order("created_at DESC").Limit(params.Limit).Offset(params.Skip).Find(&discords).Error; err != nil {
-		msg := fmt.Sprintf("cannot fetch discord integrations for user [%s] and params [%+#v]", userID, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch discord integrations for user [%s] and params [%+#v]", userID, params))
 	}
 
 	return discords, nil
@@ -88,8 +85,7 @@ func (repository *gormDiscordRepository) FetchHavingIncomingChannel(ctx context.
 		Where("incoming_channel_id != ?", "").
 		Find(&discords).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot load discord integrations for user with ID [%s] having a valid [incoming_channel_id]", userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load discord integrations for user with ID [%s] having a valid [incoming_channel_id]", userID))
 	}
 
 	return discords, nil
@@ -102,13 +98,11 @@ func (repository *gormDiscordRepository) Load(ctx context.Context, userID entiti
 	discord := new(entities.Discord)
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", discordID).First(&discord).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("discord integration with ID [%s] for user [%s] does not exist", discordID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "discord integration with ID [%s] for user [%s] does not exist", discordID, userID))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load discord integration with ID [%s] for user [%s]", discordID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load discord integration with ID [%s] for user [%s]", discordID, userID))
 	}
 
 	return discord, nil
@@ -121,13 +115,11 @@ func (repository *gormDiscordRepository) FindByServerID(ctx context.Context, ser
 	discord := new(entities.Discord)
 	err := repository.db.WithContext(ctx).Where("server_id = ?", serverID).First(&discord).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("discord integration with server ID [%s] does not exist", serverID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "discord integration with server ID [%s] does not exist", serverID))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load discord integration with serverID [%s]", serverID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load discord integration with serverID [%s]", serverID))
 	}
 
 	return discord, nil
@@ -142,8 +134,7 @@ func (repository *gormDiscordRepository) Delete(ctx context.Context, userID enti
 		Where("id = ?", discordID).
 		Delete(&entities.Discord{}).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete discord integration with ID [%s] and userID [%s]", discordID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete discord integration with ID [%s] and userID [%s]", discordID, userID))
 	}
 
 	return nil

--- a/api/pkg/repositories/gorm_discord_repository.go
+++ b/api/pkg/repositories/gorm_discord_repository.go
@@ -38,7 +38,7 @@ func (repository *gormDiscordRepository) DeleteAllForUser(ctx context.Context, u
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.Discord{}).Error; err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Discord{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -50,7 +50,7 @@ func (repository *gormDiscordRepository) Save(ctx context.Context, Discord *enti
 
 	if err := repository.db.WithContext(ctx).Save(Discord).Error; err != nil {
 		msg := fmt.Sprintf("cannot update discord integration with ID [%s]", Discord.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -70,7 +70,7 @@ func (repository *gormDiscordRepository) Index(ctx context.Context, userID entit
 	discords := make([]*entities.Discord, 0)
 	if err := query.Order("created_at DESC").Limit(params.Limit).Offset(params.Skip).Find(&discords).Error; err != nil {
 		msg := fmt.Sprintf("cannot fetch discord integrations for user [%s] and params [%+#v]", userID, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return discords, nil
@@ -89,7 +89,7 @@ func (repository *gormDiscordRepository) FetchHavingIncomingChannel(ctx context.
 		Find(&discords).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot load discord integrations for user with ID [%s] having a valid [incoming_channel_id]", userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return discords, nil
@@ -103,12 +103,12 @@ func (repository *gormDiscordRepository) Load(ctx context.Context, userID entiti
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", discordID).First(&discord).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("discord integration with ID [%s] for user [%s] does not exist", discordID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load discord integration with ID [%s] for user [%s]", discordID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return discord, nil
@@ -122,12 +122,12 @@ func (repository *gormDiscordRepository) FindByServerID(ctx context.Context, ser
 	err := repository.db.WithContext(ctx).Where("server_id = ?", serverID).First(&discord).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("discord integration with server ID [%s] does not exist", serverID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load discord integration with serverID [%s]", serverID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return discord, nil
@@ -143,7 +143,7 @@ func (repository *gormDiscordRepository) Delete(ctx context.Context, userID enti
 		Delete(&entities.Discord{}).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete discord integration with ID [%s] and userID [%s]", discordID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/repositories/gorm_heartbeat_monitor_repository.go
+++ b/api/pkg/repositories/gorm_heartbeat_monitor_repository.go
@@ -40,8 +40,7 @@ func (repository *gormHeartbeatMonitorRepository) DeleteAllForUser(ctx context.C
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.HeartbeatMonitor{}).Error; err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.HeartbeatMonitor{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [%T] for user with ID [%s]", &entities.HeartbeatMonitor{}, userID))
 	}
 	return nil
 }
@@ -63,8 +62,7 @@ func (repository *gormHeartbeatMonitorRepository) UpdatePhoneOnline(ctx context.
 			"updated_at":   time.Now().UTC(),
 		}).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot update heartbeat monitor ID [%s] for user [%s]", monitorID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update heartbeat monitor ID [%s] for user [%s]", monitorID, userID))
 	}
 	return nil
 }
@@ -85,8 +83,7 @@ func (repository *gormHeartbeatMonitorRepository) UpdateQueueID(ctx context.Cont
 			"updated_at": time.Now().UTC(),
 		}).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot update heartbeat monitor ID [%s]", monitorID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update heartbeat monitor ID [%s]", monitorID))
 	}
 	return nil
 }
@@ -103,8 +100,7 @@ func (repository *gormHeartbeatMonitorRepository) Delete(ctx context.Context, us
 		Where("owner = ?", owner).
 		Delete(&entities.HeartbeatMonitor{}).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete heartbeat monitor with owner [%s] and userID [%s]", owner, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete heartbeat monitor with owner [%s] and userID [%s]", owner, userID))
 	}
 
 	return nil
@@ -121,8 +117,7 @@ func (repository *gormHeartbeatMonitorRepository) Index(ctx context.Context, use
 	query := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("owner = ?", owner)
 	heartbeats := new([]entities.Heartbeat)
 	if err := query.Order("timestamp DESC").Limit(params.Limit).Offset(params.Skip).Find(&heartbeats).Error; err != nil {
-		msg := fmt.Sprintf("cannot fetch heartbeats with owner [%s] and params [%+#v]", owner, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch heartbeats with owner [%s] and params [%+#v]", owner, params))
 	}
 
 	return heartbeats, nil
@@ -137,8 +132,7 @@ func (repository *gormHeartbeatMonitorRepository) Store(ctx context.Context, hea
 	defer cancel()
 
 	if err := repository.db.WithContext(ctx).Create(heartbeatMonitor).Error; err != nil {
-		msg := fmt.Sprintf("cannot save heartbeatMonitor monitor with ID [%s]", heartbeatMonitor.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save heartbeatMonitor monitor with ID [%s]", heartbeatMonitor.ID))
 	}
 
 	return nil
@@ -158,13 +152,11 @@ func (repository *gormHeartbeatMonitorRepository) Load(ctx context.Context, user
 		Where("owner = ?", owner).
 		First(&phone).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("heartbeat monitor with userID [%s] and owner [%s] does not exist", userID, owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "heartbeat monitor with userID [%s] and owner [%s] does not exist", userID, owner))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load heartbeat monitor with userID [%s] and owner [%s]", userID, owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load heartbeat monitor with userID [%s] and owner [%s]", userID, owner))
 	}
 
 	return phone, nil
@@ -186,8 +178,7 @@ func (repository *gormHeartbeatMonitorRepository) Exists(ctx context.Context, us
 		Where("id = ?", monitorID).
 		Find(&exists).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot check if heartbeat monitor exists with userID [%s] and montior ID [%s]", userID, monitorID)
-		return exists, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return exists, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot check if heartbeat monitor exists with userID [%s] and montior ID [%s]", userID, monitorID))
 	}
 
 	return exists, nil

--- a/api/pkg/repositories/gorm_heartbeat_monitor_repository.go
+++ b/api/pkg/repositories/gorm_heartbeat_monitor_repository.go
@@ -41,7 +41,7 @@ func (repository *gormHeartbeatMonitorRepository) DeleteAllForUser(ctx context.C
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.HeartbeatMonitor{}).Error; err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.HeartbeatMonitor{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	return nil
 }
@@ -64,7 +64,7 @@ func (repository *gormHeartbeatMonitorRepository) UpdatePhoneOnline(ctx context.
 		}).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot update heartbeat monitor ID [%s] for user [%s]", monitorID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	return nil
 }
@@ -86,7 +86,7 @@ func (repository *gormHeartbeatMonitorRepository) UpdateQueueID(ctx context.Cont
 		}).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot update heartbeat monitor ID [%s]", monitorID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	return nil
 }
@@ -104,7 +104,7 @@ func (repository *gormHeartbeatMonitorRepository) Delete(ctx context.Context, us
 		Delete(&entities.HeartbeatMonitor{}).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete heartbeat monitor with owner [%s] and userID [%s]", owner, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -122,7 +122,7 @@ func (repository *gormHeartbeatMonitorRepository) Index(ctx context.Context, use
 	heartbeats := new([]entities.Heartbeat)
 	if err := query.Order("timestamp DESC").Limit(params.Limit).Offset(params.Skip).Find(&heartbeats).Error; err != nil {
 		msg := fmt.Sprintf("cannot fetch heartbeats with owner [%s] and params [%+#v]", owner, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return heartbeats, nil
@@ -138,7 +138,7 @@ func (repository *gormHeartbeatMonitorRepository) Store(ctx context.Context, hea
 
 	if err := repository.db.WithContext(ctx).Create(heartbeatMonitor).Error; err != nil {
 		msg := fmt.Sprintf("cannot save heartbeatMonitor monitor with ID [%s]", heartbeatMonitor.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -159,12 +159,12 @@ func (repository *gormHeartbeatMonitorRepository) Load(ctx context.Context, user
 		First(&phone).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("heartbeat monitor with userID [%s] and owner [%s] does not exist", userID, owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load heartbeat monitor with userID [%s] and owner [%s]", userID, owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return phone, nil
@@ -187,7 +187,7 @@ func (repository *gormHeartbeatMonitorRepository) Exists(ctx context.Context, us
 		Find(&exists).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot check if heartbeat monitor exists with userID [%s] and montior ID [%s]", userID, monitorID)
-		return exists, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return exists, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return exists, nil

--- a/api/pkg/repositories/gorm_heartbeat_repository.go
+++ b/api/pkg/repositories/gorm_heartbeat_repository.go
@@ -38,8 +38,7 @@ func (repository *gormHeartbeatRepository) DeleteAllForUser(ctx context.Context,
 
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.Heartbeat{}).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Heartbeat{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [%T] for user with ID [%s]", &entities.Heartbeat{}, userID))
 	}
 
 	return nil
@@ -59,13 +58,11 @@ func (repository *gormHeartbeatRepository) Last(ctx context.Context, userID enti
 		Order("timestamp DESC").
 		First(&heartbeat).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("heartbeat with userID [%s] and owner [%s] does not exist", userID, owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "heartbeat with userID [%s] and owner [%s] does not exist", userID, owner))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load heartbeat with userID [%s] and owner [%s]", userID, owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load heartbeat with userID [%s] and owner [%s]", userID, owner))
 	}
 
 	return heartbeat, nil
@@ -88,8 +85,7 @@ func (repository *gormHeartbeatRepository) Index(ctx context.Context, userID ent
 	heartbeats := new([]entities.Heartbeat)
 	err := query.Order("timestamp DESC").Limit(params.Limit).Offset(params.Skip).Find(&heartbeats).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot fetch heartbeats with owner [%s] and params [%+#v]", owner, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch heartbeats with owner [%s] and params [%+#v]", owner, params))
 	}
 
 	return heartbeats, nil
@@ -104,8 +100,7 @@ func (repository *gormHeartbeatRepository) Store(ctx context.Context, heartbeat 
 	defer cancel()
 
 	if err := repository.db.WithContext(ctx).Create(heartbeat).Error; err != nil {
-		msg := fmt.Sprintf("cannot save heartbeat with ID [%s]", heartbeat.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save heartbeat with ID [%s]", heartbeat.ID))
 	}
 
 	return nil

--- a/api/pkg/repositories/gorm_heartbeat_repository.go
+++ b/api/pkg/repositories/gorm_heartbeat_repository.go
@@ -39,7 +39,7 @@ func (repository *gormHeartbeatRepository) DeleteAllForUser(ctx context.Context,
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.Heartbeat{}).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Heartbeat{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -60,12 +60,12 @@ func (repository *gormHeartbeatRepository) Last(ctx context.Context, userID enti
 		First(&heartbeat).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("heartbeat with userID [%s] and owner [%s] does not exist", userID, owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load heartbeat with userID [%s] and owner [%s]", userID, owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return heartbeat, nil
@@ -89,7 +89,7 @@ func (repository *gormHeartbeatRepository) Index(ctx context.Context, userID ent
 	err := query.Order("timestamp DESC").Limit(params.Limit).Offset(params.Skip).Find(&heartbeats).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot fetch heartbeats with owner [%s] and params [%+#v]", owner, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return heartbeats, nil
@@ -105,7 +105,7 @@ func (repository *gormHeartbeatRepository) Store(ctx context.Context, heartbeat 
 
 	if err := repository.db.WithContext(ctx).Create(heartbeat).Error; err != nil {
 		msg := fmt.Sprintf("cannot save heartbeat with ID [%s]", heartbeat.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/repositories/gorm_integration_3cx_repository.go
+++ b/api/pkg/repositories/gorm_integration_3cx_repository.go
@@ -37,7 +37,7 @@ func (repository *gormIntegration3CxRepository) DeleteAllForUser(ctx context.Con
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.Integration3CX{}).Error; err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Integration3CX{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -52,12 +52,12 @@ func (repository *gormIntegration3CxRepository) Load(ctx context.Context, userID
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).First(&integration).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("[3cx] integration for user [%s] does not exist", userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load [3cx] integration for user [%s]", userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return integration, nil
@@ -70,7 +70,7 @@ func (repository *gormIntegration3CxRepository) Save(ctx context.Context, integr
 
 	if err := repository.db.WithContext(ctx).Save(integration).Error; err != nil {
 		msg := fmt.Sprintf("cannot save [%T] with ID [%s]", integration, integration.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/repositories/gorm_integration_3cx_repository.go
+++ b/api/pkg/repositories/gorm_integration_3cx_repository.go
@@ -36,8 +36,7 @@ func (repository *gormIntegration3CxRepository) DeleteAllForUser(ctx context.Con
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.Integration3CX{}).Error; err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Integration3CX{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [%T] for user with ID [%s]", &entities.Integration3CX{}, userID))
 	}
 
 	return nil
@@ -51,13 +50,11 @@ func (repository *gormIntegration3CxRepository) Load(ctx context.Context, userID
 	integration := new(entities.Integration3CX)
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).First(&integration).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("[3cx] integration for user [%s] does not exist", userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "[3cx] integration for user [%s] does not exist", userID))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load [3cx] integration for user [%s]", userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load [3cx] integration for user [%s]", userID))
 	}
 
 	return integration, nil
@@ -69,8 +66,7 @@ func (repository *gormIntegration3CxRepository) Save(ctx context.Context, integr
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Save(integration).Error; err != nil {
-		msg := fmt.Sprintf("cannot save [%T] with ID [%s]", integration, integration.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save [%T] with ID [%s]", integration, integration.ID))
 	}
 
 	return nil

--- a/api/pkg/repositories/gorm_message_repository.go
+++ b/api/pkg/repositories/gorm_message_repository.go
@@ -41,7 +41,7 @@ func (repository *gormMessageRepository) DeleteAllForUser(ctx context.Context, u
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.Message{}).Error; err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Message{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -60,7 +60,7 @@ func (repository *gormMessageRepository) DeleteByOwnerAndContact(ctx context.Con
 		Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete messages between owner [%s] and contact [%s] for user with ID [%s]", owner, contact, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -74,7 +74,7 @@ func (repository *gormMessageRepository) Delete(ctx context.Context, userID enti
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", messageID).Delete(&entities.Message{}).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete message with ID [%s] for user with ID [%s]", messageID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -98,7 +98,7 @@ func (repository *gormMessageRepository) Index(ctx context.Context, userID entit
 	messages := new([]entities.Message)
 	if err := query.Order("order_timestamp DESC").Limit(params.Limit).Offset(params.Skip).Find(&messages).Error; err != nil {
 		msg := fmt.Sprintf("cannot fetch messges with owner [%s] and contact [%s] and params [%+#v]", owner, contact, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return messages, nil
@@ -119,12 +119,12 @@ func (repository *gormMessageRepository) LastMessage(ctx context.Context, userID
 	err := query.Order("order_timestamp DESC").First(&message).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("cannot get last message for [%s] with owner [%s] and contact [%s]", userID, owner, contact)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot get last message for [%s] with owner [%s] and contact [%s]", userID, owner, contact)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return message, nil
@@ -170,7 +170,7 @@ func (repository *gormMessageRepository) Search(ctx context.Context, userID enti
 		Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot search messages with for user [%s] params [%+#v]", userID, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return messages, nil
@@ -201,7 +201,7 @@ func (repository *gormMessageRepository) GetBulkMessages(ctx context.Context, us
 	`, userID, limit).Scan(&orders).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot fetch bulk message orders for user [%s]", userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return orders, nil
@@ -214,7 +214,7 @@ func (repository *gormMessageRepository) Store(ctx context.Context, message *ent
 
 	if err := repository.db.WithContext(ctx).Create(message).Error; err != nil {
 		msg := fmt.Sprintf("cannot save message with ID [%s]", message.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -229,12 +229,12 @@ func (repository *gormMessageRepository) Load(ctx context.Context, userID entiti
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", messageID).First(message).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("message with ID [%s] and userID [%s] does not exist", messageID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load message with ID [%s]", messageID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return message, nil
@@ -247,7 +247,7 @@ func (repository *gormMessageRepository) Update(ctx context.Context, message *en
 
 	if err := repository.db.WithContext(ctx).Save(message).Error; err != nil {
 		msg := fmt.Sprintf("cannot update message with ID [%s]", message.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -276,17 +276,17 @@ func (repository *gormMessageRepository) GetOutstanding(ctx context.Context, use
 	)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("outstanding message with ID [%s] and userID [%s] does not exist", messageID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot fetch outstanding message with userID [%s] and messageID [%s]", userID, messageID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if message == nil || message.ID == uuid.Nil {
 		msg := fmt.Sprintf("outstanding message with ID [%s] and userID [%s] does not exist", messageID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.NewErrorWithCode(ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.NewErrorWithCode(ErrCodeNotFound, "%s", msg))
 	}
 
 	return message, nil

--- a/api/pkg/repositories/gorm_message_repository.go
+++ b/api/pkg/repositories/gorm_message_repository.go
@@ -40,8 +40,7 @@ func (repository *gormMessageRepository) DeleteAllForUser(ctx context.Context, u
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.Message{}).Error; err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Message{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [%T] for user with ID [%s]", &entities.Message{}, userID))
 	}
 
 	return nil
@@ -59,8 +58,7 @@ func (repository *gormMessageRepository) DeleteByOwnerAndContact(ctx context.Con
 		Delete(&entities.Message{}).
 		Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete messages between owner [%s] and contact [%s] for user with ID [%s]", owner, contact, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete messages between owner [%s] and contact [%s] for user with ID [%s]", owner, contact, userID))
 	}
 
 	return nil
@@ -73,8 +71,7 @@ func (repository *gormMessageRepository) Delete(ctx context.Context, userID enti
 
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", messageID).Delete(&entities.Message{}).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete message with ID [%s] for user with ID [%s]", messageID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete message with ID [%s] for user with ID [%s]", messageID, userID))
 	}
 
 	return nil
@@ -97,8 +94,7 @@ func (repository *gormMessageRepository) Index(ctx context.Context, userID entit
 
 	messages := new([]entities.Message)
 	if err := query.Order("order_timestamp DESC").Limit(params.Limit).Offset(params.Skip).Find(&messages).Error; err != nil {
-		msg := fmt.Sprintf("cannot fetch messges with owner [%s] and contact [%s] and params [%+#v]", owner, contact, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch messges with owner [%s] and contact [%s] and params [%+#v]", owner, contact, params))
 	}
 
 	return messages, nil
@@ -118,13 +114,11 @@ func (repository *gormMessageRepository) LastMessage(ctx context.Context, userID
 
 	err := query.Order("order_timestamp DESC").First(&message).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("cannot get last message for [%s] with owner [%s] and contact [%s]", userID, owner, contact)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "cannot get last message for [%s] with owner [%s] and contact [%s]", userID, owner, contact))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot get last message for [%s] with owner [%s] and contact [%s]", userID, owner, contact)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot get last message for [%s] with owner [%s] and contact [%s]", userID, owner, contact))
 	}
 
 	return message, nil
@@ -169,8 +163,7 @@ func (repository *gormMessageRepository) Search(ctx context.Context, userID enti
 		Find(&messages).
 		Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot search messages with for user [%s] params [%+#v]", userID, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot search messages with for user [%s] params [%+#v]", userID, params))
 	}
 
 	return messages, nil
@@ -200,8 +193,7 @@ func (repository *gormMessageRepository) GetBulkMessages(ctx context.Context, us
 		LIMIT ?
 	`, userID, limit).Scan(&orders).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot fetch bulk message orders for user [%s]", userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch bulk message orders for user [%s]", userID))
 	}
 
 	return orders, nil
@@ -213,8 +205,7 @@ func (repository *gormMessageRepository) Store(ctx context.Context, message *ent
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Create(message).Error; err != nil {
-		msg := fmt.Sprintf("cannot save message with ID [%s]", message.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save message with ID [%s]", message.ID))
 	}
 
 	return nil
@@ -228,13 +219,11 @@ func (repository *gormMessageRepository) Load(ctx context.Context, userID entiti
 	message := new(entities.Message)
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", messageID).First(message).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("message with ID [%s] and userID [%s] does not exist", messageID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "message with ID [%s] and userID [%s] does not exist", messageID, userID))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load message with ID [%s]", messageID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load message with ID [%s]", messageID))
 	}
 
 	return message, nil
@@ -246,8 +235,7 @@ func (repository *gormMessageRepository) Update(ctx context.Context, message *en
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Save(message).Error; err != nil {
-		msg := fmt.Sprintf("cannot update message with ID [%s]", message.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update message with ID [%s]", message.ID))
 	}
 
 	return nil
@@ -259,7 +247,8 @@ func (repository *gormMessageRepository) GetOutstanding(ctx context.Context, use
 	defer span.End()
 
 	message := new(entities.Message)
-	err := crdbgorm.ExecuteTx(ctx, repository.db, nil,
+	err := crdbgorm.ExecuteTx(
+		ctx, repository.db, nil,
 		func(tx *gorm.DB) error {
 			query := tx.WithContext(ctx).Model(message).
 				Clauses(clause.Returning{}).
@@ -275,18 +264,15 @@ func (repository *gormMessageRepository) GetOutstanding(ctx context.Context, use
 		},
 	)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("outstanding message with ID [%s] and userID [%s] does not exist", messageID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "outstanding message with ID [%s] and userID [%s] does not exist", messageID, userID))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot fetch outstanding message with userID [%s] and messageID [%s]", userID, messageID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch outstanding message with userID [%s] and messageID [%s]", userID, messageID))
 	}
 
 	if message == nil || message.ID == uuid.Nil {
-		msg := fmt.Sprintf("outstanding message with ID [%s] and userID [%s] does not exist", messageID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.NewErrorWithCode(ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.NewErrorWithCode(ErrCodeNotFound, "outstanding message with ID [%s] and userID [%s] does not exist", messageID, userID))
 	}
 
 	return message, nil

--- a/api/pkg/repositories/gorm_message_thread_repository.go
+++ b/api/pkg/repositories/gorm_message_thread_repository.go
@@ -41,7 +41,7 @@ func (repository *gormMessageThreadRepository) DeleteAllForUser(ctx context.Cont
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.MessageThread{}).Error; err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.MessageThread{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -55,7 +55,7 @@ func (repository *gormMessageThreadRepository) Delete(ctx context.Context, userI
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", messageThreadID).Delete(&entities.MessageThread{}).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete message thread with ID [%s] for user with ID [%s]", messageThreadID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -76,7 +76,7 @@ func (repository *gormMessageThreadRepository) UpdateAfterDeletedMessage(ctx con
 		}).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot update thread after message is deleted with userID [%s] and messageID [%s]", userID, messageID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -89,7 +89,7 @@ func (repository *gormMessageThreadRepository) Store(ctx context.Context, thread
 
 	if err := repository.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(thread).Error; err != nil {
 		msg := fmt.Sprintf("cannot save message thread with ID [%s]", thread.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -102,7 +102,7 @@ func (repository *gormMessageThreadRepository) Update(ctx context.Context, threa
 
 	if err := repository.db.WithContext(ctx).Save(thread).Error; err != nil {
 		msg := fmt.Sprintf("cannot update message thread thread with ID [%s]", thread.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -124,12 +124,12 @@ func (repository *gormMessageThreadRepository) LoadByOwnerContact(ctx context.Co
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("thread with owner [%s] and contact [%s] does not exist", owner, contact)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load thread with owner [%s] and contact [%s]", owner, contact)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return thread, nil
@@ -150,12 +150,12 @@ func (repository *gormMessageThreadRepository) Load(ctx context.Context, userID 
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("thread with id [%s] not found", ID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("thread with id [%s]", ID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return thread, nil
@@ -189,7 +189,7 @@ func (repository *gormMessageThreadRepository) Index(ctx context.Context, userID
 	threads := new([]entities.MessageThread)
 	if err := query.Order("order_timestamp DESC").Limit(params.Limit).Offset(params.Skip).Find(&threads).Error; err != nil {
 		msg := fmt.Sprintf("cannot fetch message threads with owner [%s] and params [%+#v]", owner, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return threads, nil

--- a/api/pkg/repositories/gorm_message_thread_repository.go
+++ b/api/pkg/repositories/gorm_message_thread_repository.go
@@ -40,8 +40,7 @@ func (repository *gormMessageThreadRepository) DeleteAllForUser(ctx context.Cont
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.MessageThread{}).Error; err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.MessageThread{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [%T] for user with ID [%s]", &entities.MessageThread{}, userID))
 	}
 
 	return nil
@@ -54,8 +53,7 @@ func (repository *gormMessageThreadRepository) Delete(ctx context.Context, userI
 
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", messageThreadID).Delete(&entities.MessageThread{}).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete message thread with ID [%s] for user with ID [%s]", messageThreadID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete message thread with ID [%s] for user with ID [%s]", messageThreadID, userID))
 	}
 
 	return nil
@@ -75,8 +73,7 @@ func (repository *gormMessageThreadRepository) UpdateAfterDeletedMessage(ctx con
 			"status":               entities.MessageStatusDeleted,
 		}).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot update thread after message is deleted with userID [%s] and messageID [%s]", userID, messageID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update thread after message is deleted with userID [%s] and messageID [%s]", userID, messageID))
 	}
 
 	return nil
@@ -88,8 +85,7 @@ func (repository *gormMessageThreadRepository) Store(ctx context.Context, thread
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(thread).Error; err != nil {
-		msg := fmt.Sprintf("cannot save message thread with ID [%s]", thread.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save message thread with ID [%s]", thread.ID))
 	}
 
 	return nil
@@ -101,8 +97,7 @@ func (repository *gormMessageThreadRepository) Update(ctx context.Context, threa
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Save(thread).Error; err != nil {
-		msg := fmt.Sprintf("cannot update message thread thread with ID [%s]", thread.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update message thread thread with ID [%s]", thread.ID))
 	}
 
 	return nil
@@ -123,13 +118,11 @@ func (repository *gormMessageThreadRepository) LoadByOwnerContact(ctx context.Co
 		First(thread).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("thread with owner [%s] and contact [%s] does not exist", owner, contact)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "thread with owner [%s] and contact [%s] does not exist", owner, contact))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load thread with owner [%s] and contact [%s]", owner, contact)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load thread with owner [%s] and contact [%s]", owner, contact))
 	}
 
 	return thread, nil
@@ -149,13 +142,11 @@ func (repository *gormMessageThreadRepository) Load(ctx context.Context, userID 
 		First(thread).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("thread with id [%s] not found", ID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "thread with id [%s] not found", ID))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("thread with id [%s]", ID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "thread with id [%s]", ID))
 	}
 
 	return thread, nil
@@ -188,8 +179,7 @@ func (repository *gormMessageThreadRepository) Index(ctx context.Context, userID
 
 	threads := new([]entities.MessageThread)
 	if err := query.Order("order_timestamp DESC").Limit(params.Limit).Offset(params.Skip).Find(&threads).Error; err != nil {
-		msg := fmt.Sprintf("cannot fetch message threads with owner [%s] and params [%+#v]", owner, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch message threads with owner [%s] and params [%+#v]", owner, params))
 	}
 
 	return threads, nil

--- a/api/pkg/repositories/gorm_phone_api_key_repository.go
+++ b/api/pkg/repositories/gorm_phone_api_key_repository.go
@@ -54,7 +54,7 @@ WHERE user_id = ? AND array_position(phone_ids, ?) IS NOT NULL;
 		Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot remove phone with ID [%s] and number [%s] for user with ID [%s] ", phoneID, phoneNumber, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	repository.cache.Clear()
@@ -87,12 +87,12 @@ func (repository *gormPhoneAPIKeyRepository) Load(ctx context.Context, userID en
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", phoneAPIKeyID).First(&phoneAPIKey).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("[%T] with ID [%s] for user with ID [%s] does not exist", phoneAPIKey, phoneAPIKeyID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load [%T] with ID [%s] for user with ID [%s]", phoneAPIKey, phoneAPIKeyID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return phoneAPIKey, nil
@@ -104,7 +104,7 @@ func (repository *gormPhoneAPIKeyRepository) Create(ctx context.Context, phoneAP
 
 	if err := repository.db.WithContext(ctx).Create(phoneAPIKey).Error; err != nil {
 		msg := fmt.Sprintf("cannot save phone API key with ID [%s] for user with ID [%s]", phoneAPIKey.ID, phoneAPIKey.UserID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -122,12 +122,12 @@ func (repository *gormPhoneAPIKeyRepository) LoadAuthContext(ctx context.Context
 	err := repository.db.WithContext(ctx).Where("api_key = ?", apiKey).First(phoneAPIKey).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("phone api key [%s] does not exist", apiKey)
-		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load phone api key [%s]", apiKey)
-		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	authUser := entities.AuthContext{
@@ -139,7 +139,7 @@ func (repository *gormPhoneAPIKeyRepository) LoadAuthContext(ctx context.Context
 
 	if result := repository.cache.SetWithTTL(apiKey, authUser, 1, 15*time.Second); !result {
 		msg := fmt.Sprintf("cannot cache [%T] with ID [%s] and result [%t]", authUser, phoneAPIKey.ID, result)
-		ctxLogger.Error(repository.tracer.WrapErrorSpan(span, stacktrace.NewError(msg)))
+		ctxLogger.Error(repository.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg)))
 	}
 
 	return authUser, nil
@@ -158,7 +158,7 @@ func (repository *gormPhoneAPIKeyRepository) Index(ctx context.Context, userID e
 	phoneAPIKeys := new([]*entities.PhoneAPIKey)
 	if err := query.Order("created_at DESC").Limit(params.Limit).Offset(params.Skip).Find(phoneAPIKeys).Error; err != nil {
 		msg := fmt.Sprintf("cannot fetch phone API Keys with userID [%s] and params [%+#v]", userID, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return *phoneAPIKeys, nil
@@ -171,7 +171,7 @@ func (repository *gormPhoneAPIKeyRepository) Delete(ctx context.Context, phoneAP
 	err := repository.db.WithContext(ctx).Delete(phoneAPIKey).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete phone API key with ID [%s] and userID [%s]", phoneAPIKey.ID, phoneAPIKey.UserID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	repository.cache.Del(phoneAPIKey.APIKey)
 
@@ -194,7 +194,7 @@ WHERE  user_id  = ?;
 			Error
 		if err != nil {
 			msg := fmt.Sprintf("cannot remove phone with ID [%s] from API Key with ID [%s] for user with ID [%s]", phone.ID, phoneAPIKey.ID, phone.UserID)
-			return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+			return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 		}
 
 		query = `
@@ -208,14 +208,14 @@ WHERE array_position(phone_ids, ?) IS NULL AND id = ?;
 			Error
 		if err != nil {
 			msg := fmt.Sprintf("cannot add [%T] with ID [%s] from API Key with ID [%s] for user with ID [%s]", phone, phone.ID, phoneAPIKey.ID, phone.UserID)
-			return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+			return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 		}
 
 		return nil
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot add [%T] with ID [%s] from API Key with ID [%s] for user with ID [%s]", phone, phone.ID, phoneAPIKey.ID, phone.UserID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	repository.cache.Clear()
 	return nil
@@ -236,7 +236,7 @@ WHERE id = ?;
 		Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot remove phone with ID [%s] from phone API key with ID [%s]", phone.ID, phoneAPIKey.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -248,7 +248,7 @@ func (repository *gormPhoneAPIKeyRepository) DeleteAllForUser(ctx context.Contex
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.PhoneAPIKey{}).Error; err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.PhoneAPIKey{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/repositories/gorm_phone_api_key_repository.go
+++ b/api/pkg/repositories/gorm_phone_api_key_repository.go
@@ -53,8 +53,7 @@ WHERE user_id = ? AND array_position(phone_ids, ?) IS NOT NULL;
 		Exec(query, phoneID, phoneNumber, userID, phoneID).
 		Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot remove phone with ID [%s] and number [%s] for user with ID [%s] ", phoneID, phoneNumber, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot remove phone with ID [%s] and number [%s] for user with ID [%s] ", phoneID, phoneNumber, userID))
 	}
 
 	repository.cache.Clear()
@@ -86,13 +85,11 @@ func (repository *gormPhoneAPIKeyRepository) Load(ctx context.Context, userID en
 	phoneAPIKey := new(entities.PhoneAPIKey)
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", phoneAPIKeyID).First(&phoneAPIKey).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("[%T] with ID [%s] for user with ID [%s] does not exist", phoneAPIKey, phoneAPIKeyID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "[%T] with ID [%s] for user with ID [%s] does not exist", phoneAPIKey, phoneAPIKeyID, userID))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load [%T] with ID [%s] for user with ID [%s]", phoneAPIKey, phoneAPIKeyID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load [%T] with ID [%s] for user with ID [%s]", phoneAPIKey, phoneAPIKeyID, userID))
 	}
 
 	return phoneAPIKey, nil
@@ -103,8 +100,7 @@ func (repository *gormPhoneAPIKeyRepository) Create(ctx context.Context, phoneAP
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Create(phoneAPIKey).Error; err != nil {
-		msg := fmt.Sprintf("cannot save phone API key with ID [%s] for user with ID [%s]", phoneAPIKey.ID, phoneAPIKey.UserID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save phone API key with ID [%s] for user with ID [%s]", phoneAPIKey.ID, phoneAPIKey.UserID))
 	}
 
 	return nil
@@ -121,13 +117,11 @@ func (repository *gormPhoneAPIKeyRepository) LoadAuthContext(ctx context.Context
 	phoneAPIKey := new(entities.PhoneAPIKey)
 	err := repository.db.WithContext(ctx).Where("api_key = ?", apiKey).First(phoneAPIKey).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("phone api key [%s] does not exist", apiKey)
-		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "phone api key [%s] does not exist", apiKey))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load phone api key [%s]", apiKey)
-		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load phone api key [%s]", apiKey))
 	}
 
 	authUser := entities.AuthContext{
@@ -138,8 +132,7 @@ func (repository *gormPhoneAPIKeyRepository) LoadAuthContext(ctx context.Context
 	}
 
 	if result := repository.cache.SetWithTTL(apiKey, authUser, 1, 15*time.Second); !result {
-		msg := fmt.Sprintf("cannot cache [%T] with ID [%s] and result [%t]", authUser, phoneAPIKey.ID, result)
-		ctxLogger.Error(repository.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg)))
+		ctxLogger.Error(repository.tracer.WrapErrorSpan(span, stacktrace.NewError("cannot cache [%T] with ID [%s] and result [%t]", authUser, phoneAPIKey.ID, result)))
 	}
 
 	return authUser, nil
@@ -157,8 +150,7 @@ func (repository *gormPhoneAPIKeyRepository) Index(ctx context.Context, userID e
 
 	phoneAPIKeys := new([]*entities.PhoneAPIKey)
 	if err := query.Order("created_at DESC").Limit(params.Limit).Offset(params.Skip).Find(phoneAPIKeys).Error; err != nil {
-		msg := fmt.Sprintf("cannot fetch phone API Keys with userID [%s] and params [%+#v]", userID, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch phone API Keys with userID [%s] and params [%+#v]", userID, params))
 	}
 
 	return *phoneAPIKeys, nil
@@ -170,8 +162,7 @@ func (repository *gormPhoneAPIKeyRepository) Delete(ctx context.Context, phoneAP
 
 	err := repository.db.WithContext(ctx).Delete(phoneAPIKey).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete phone API key with ID [%s] and userID [%s]", phoneAPIKey.ID, phoneAPIKey.UserID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete phone API key with ID [%s] and userID [%s]", phoneAPIKey.ID, phoneAPIKey.UserID))
 	}
 	repository.cache.Del(phoneAPIKey.APIKey)
 
@@ -193,8 +184,7 @@ WHERE  user_id  = ?;
 			Exec(query, phone.ID, phone.PhoneNumber, phone.UserID).
 			Error
 		if err != nil {
-			msg := fmt.Sprintf("cannot remove phone with ID [%s] from API Key with ID [%s] for user with ID [%s]", phone.ID, phoneAPIKey.ID, phone.UserID)
-			return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+			return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot remove phone with ID [%s] from API Key with ID [%s] for user with ID [%s]", phone.ID, phoneAPIKey.ID, phone.UserID))
 		}
 
 		query = `
@@ -207,15 +197,13 @@ WHERE array_position(phone_ids, ?) IS NULL AND id = ?;
 			Exec(query, phone.ID, phone.PhoneNumber, phone.ID, phoneAPIKey.ID).
 			Error
 		if err != nil {
-			msg := fmt.Sprintf("cannot add [%T] with ID [%s] from API Key with ID [%s] for user with ID [%s]", phone, phone.ID, phoneAPIKey.ID, phone.UserID)
-			return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+			return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot add [%T] with ID [%s] from API Key with ID [%s] for user with ID [%s]", phone, phone.ID, phoneAPIKey.ID, phone.UserID))
 		}
 
 		return nil
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot add [%T] with ID [%s] from API Key with ID [%s] for user with ID [%s]", phone, phone.ID, phoneAPIKey.ID, phone.UserID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot add [%T] with ID [%s] from API Key with ID [%s] for user with ID [%s]", phone, phone.ID, phoneAPIKey.ID, phone.UserID))
 	}
 	repository.cache.Clear()
 	return nil
@@ -235,8 +223,7 @@ WHERE id = ?;
 		Exec(query, phone.ID, phone.PhoneNumber, phoneAPIKey.ID).
 		Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot remove phone with ID [%s] from phone API key with ID [%s]", phone.ID, phoneAPIKey.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot remove phone with ID [%s] from phone API key with ID [%s]", phone.ID, phoneAPIKey.ID))
 	}
 
 	return nil
@@ -247,8 +234,7 @@ func (repository *gormPhoneAPIKeyRepository) DeleteAllForUser(ctx context.Contex
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.PhoneAPIKey{}).Error; err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.PhoneAPIKey{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [%T] for user with ID [%s]", &entities.PhoneAPIKey{}, userID))
 	}
 
 	return nil

--- a/api/pkg/repositories/gorm_phone_notification_repository.go
+++ b/api/pkg/repositories/gorm_phone_notification_repository.go
@@ -71,7 +71,7 @@ func (repository *gormPhoneNotificationRepository) DeleteByMessageID(ctx context
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete [%T] for user [%s] and message with ID [%s]", &entities.PhoneNotification{}, userID, messageID)
 		return repository.tracer.WrapErrorSpan(span,
-			stacktrace.Propagate(err, msg),
+			stacktrace.Propagate(err, "%s", msg),
 		)
 	}
 

--- a/api/pkg/repositories/gorm_phone_notification_repository.go
+++ b/api/pkg/repositories/gorm_phone_notification_repository.go
@@ -69,9 +69,9 @@ func (repository *gormPhoneNotificationRepository) DeleteByMessageID(ctx context
 		Where("user_id = ? AND message_id = ?", userID, messageID).
 		Delete(&entities.PhoneNotification{}).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete [%T] for user [%s] and message with ID [%s]", &entities.PhoneNotification{}, userID, messageID)
-		return repository.tracer.WrapErrorSpan(span,
-			stacktrace.Propagate(err, "%s", msg),
+		return repository.tracer.WrapErrorSpan(
+			span,
+			stacktrace.Propagate(err, "cannot delete [%T] for user [%s] and message with ID [%s]", &entities.PhoneNotification{}, userID, messageID),
 		)
 	}
 

--- a/api/pkg/repositories/gorm_phone_repository.go
+++ b/api/pkg/repositories/gorm_phone_repository.go
@@ -42,8 +42,7 @@ func (repository *gormPhoneRepository) DeleteAllForUser(ctx context.Context, use
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.Phone{}).Error; err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Phone{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [%T] for user with ID [%s]", &entities.Phone{}, userID))
 	}
 
 	repository.cache.Clear()
@@ -61,8 +60,7 @@ func (repository *gormPhoneRepository) NullifyScheduleID(ctx context.Context, us
 		Where("message_send_schedule_id = ?", scheduleID).
 		Update("message_send_schedule_id", nil).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot nullify message_send_schedule_id [%s] for user [%s]", scheduleID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot nullify message_send_schedule_id [%s] for user [%s]", scheduleID, userID))
 	}
 
 	repository.cache.Clear()
@@ -80,13 +78,11 @@ func (repository *gormPhoneRepository) LoadByID(ctx context.Context, userID enti
 		Where("id = ?", phoneID).
 		First(&phone).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("phone with ID [%s] does not exist", phoneID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "phone with ID [%s] does not exist", phoneID))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load phone with ID [%s]", phoneID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load phone with ID [%s]", phoneID))
 	}
 
 	return phone, nil
@@ -102,8 +98,7 @@ func (repository *gormPhoneRepository) Delete(ctx context.Context, userID entiti
 		Where("id = ?", phoneID).
 		Delete(&entities.Phone{}).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete phone with ID [%s] and userID [%s]", phoneID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete phone with ID [%s] and userID [%s]", phoneID, userID))
 	}
 
 	repository.cache.Clear()
@@ -120,16 +115,14 @@ func (repository *gormPhoneRepository) Save(ctx context.Context, phone *entities
 		ctxLogger.Info(fmt.Sprintf("phone with user [%s] and number[%s] already exists", phone.UserID, phone.PhoneNumber))
 		loadedPhone, err := repository.Load(ctx, phone.UserID, phone.PhoneNumber)
 		if err != nil {
-			msg := fmt.Sprintf("cannot load phone for user [%s] and number [%s]", phone.UserID, phone.PhoneNumber)
-			return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+			return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load phone for user [%s] and number [%s]", phone.UserID, phone.PhoneNumber))
 		}
 		*phone = *loadedPhone
 		return nil
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot save phone with ID [%s]", phone.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save phone with ID [%s]", phone.ID))
 	}
 
 	repository.cache.Del(repository.getCacheKey(phone.UserID, phone.PhoneNumber))
@@ -148,18 +141,15 @@ func (repository *gormPhoneRepository) Load(ctx context.Context, userID entities
 	phone := new(entities.Phone)
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("phone_number = ?", phoneNumber).First(phone).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("phone with userID [%s] and phoneNumber [%s] does not exist", userID, phoneNumber)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "phone with userID [%s] and phoneNumber [%s] does not exist", userID, phoneNumber))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load phone phone with userID [%s] and phoneNumber [%s]", userID, phoneNumber)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load phone phone with userID [%s] and phoneNumber [%s]", userID, phoneNumber))
 	}
 
 	if result := repository.cache.SetWithTTL(repository.getCacheKey(userID, phoneNumber), phone, 1, 30*time.Minute); !result {
-		msg := fmt.Sprintf("cannot cache [%T] with ID [%s] and result [%t]", phone, phone.ID, result)
-		ctxLogger.Error(repository.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg)))
+		ctxLogger.Error(repository.tracer.WrapErrorSpan(span, stacktrace.NewError("cannot cache [%T] with ID [%s] and result [%t]", phone, phone.ID, result)))
 	}
 
 	return phone, nil
@@ -177,8 +167,7 @@ func (repository *gormPhoneRepository) Index(ctx context.Context, userID entitie
 
 	phones := new([]entities.Phone)
 	if err := query.Order("created_at DESC").Limit(params.Limit).Offset(params.Skip).Find(&phones).Error; err != nil {
-		msg := fmt.Sprintf("cannot fetch phones with userID [%s] and params [%+#v]", userID, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch phones with userID [%s] and params [%+#v]", userID, params))
 	}
 
 	return phones, nil

--- a/api/pkg/repositories/gorm_phone_repository.go
+++ b/api/pkg/repositories/gorm_phone_repository.go
@@ -43,7 +43,7 @@ func (repository *gormPhoneRepository) DeleteAllForUser(ctx context.Context, use
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.Phone{}).Error; err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Phone{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	repository.cache.Clear()
@@ -62,7 +62,7 @@ func (repository *gormPhoneRepository) NullifyScheduleID(ctx context.Context, us
 		Update("message_send_schedule_id", nil).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot nullify message_send_schedule_id [%s] for user [%s]", scheduleID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	repository.cache.Clear()
@@ -81,12 +81,12 @@ func (repository *gormPhoneRepository) LoadByID(ctx context.Context, userID enti
 		First(&phone).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("phone with ID [%s] does not exist", phoneID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load phone with ID [%s]", phoneID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return phone, nil
@@ -103,7 +103,7 @@ func (repository *gormPhoneRepository) Delete(ctx context.Context, userID entiti
 		Delete(&entities.Phone{}).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete phone with ID [%s] and userID [%s]", phoneID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	repository.cache.Clear()
@@ -121,7 +121,7 @@ func (repository *gormPhoneRepository) Save(ctx context.Context, phone *entities
 		loadedPhone, err := repository.Load(ctx, phone.UserID, phone.PhoneNumber)
 		if err != nil {
 			msg := fmt.Sprintf("cannot load phone for user [%s] and number [%s]", phone.UserID, phone.PhoneNumber)
-			return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+			return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 		}
 		*phone = *loadedPhone
 		return nil
@@ -129,7 +129,7 @@ func (repository *gormPhoneRepository) Save(ctx context.Context, phone *entities
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot save phone with ID [%s]", phone.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	repository.cache.Del(repository.getCacheKey(phone.UserID, phone.PhoneNumber))
@@ -149,17 +149,17 @@ func (repository *gormPhoneRepository) Load(ctx context.Context, userID entities
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("phone_number = ?", phoneNumber).First(phone).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("phone with userID [%s] and phoneNumber [%s] does not exist", userID, phoneNumber)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load phone phone with userID [%s] and phoneNumber [%s]", userID, phoneNumber)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if result := repository.cache.SetWithTTL(repository.getCacheKey(userID, phoneNumber), phone, 1, 30*time.Minute); !result {
 		msg := fmt.Sprintf("cannot cache [%T] with ID [%s] and result [%t]", phone, phone.ID, result)
-		ctxLogger.Error(repository.tracer.WrapErrorSpan(span, stacktrace.NewError(msg)))
+		ctxLogger.Error(repository.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg)))
 	}
 
 	return phone, nil
@@ -178,7 +178,7 @@ func (repository *gormPhoneRepository) Index(ctx context.Context, userID entitie
 	phones := new([]entities.Phone)
 	if err := query.Order("created_at DESC").Limit(params.Limit).Offset(params.Skip).Find(&phones).Error; err != nil {
 		msg := fmt.Sprintf("cannot fetch phones with userID [%s] and params [%+#v]", userID, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return phones, nil

--- a/api/pkg/repositories/gorm_user_repository.go
+++ b/api/pkg/repositories/gorm_user_repository.go
@@ -196,7 +196,7 @@ func (repository *gormUserRepository) Load(ctx context.Context, userID entities.
 	user := new(entities.User)
 	err := repository.db.WithContext(ctx).First(user, userID).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "user with ID [%s] does not exist", user.ID))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "user with ID [%s] does not exist", userID))
 	}
 
 	if err != nil {

--- a/api/pkg/repositories/gorm_user_repository.go
+++ b/api/pkg/repositories/gorm_user_repository.go
@@ -49,7 +49,7 @@ func (repository *gormUserRepository) Delete(ctx context.Context, user *entities
 
 	if err := repository.db.WithContext(ctx).Delete(user).Error; err != nil {
 		msg := fmt.Sprintf("cannot delete user with ID [%s]", user.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -61,7 +61,7 @@ func (repository *gormUserRepository) RotateAPIKey(ctx context.Context, userID e
 
 	apiKey, err := repository.generateAPIKey(64)
 	if err != nil {
-		return nil, stacktrace.Propagate(err, fmt.Sprintf("cannot generate apiKey for user [%s]", userID))
+		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot generate apiKey for user [%s]", userID))
 	}
 
 	user := new(entities.User)
@@ -80,7 +80,7 @@ func (repository *gormUserRepository) RotateAPIKey(ctx context.Context, userID e
 	)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("user with ID [%s] does not exist", userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err == nil && oldAPIKey != "" {
@@ -104,12 +104,12 @@ func (repository *gormUserRepository) LoadBySubscriptionID(ctx context.Context, 
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("user with subscriptionID [%s] does not exist", subscriptionID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with subscription ID [%s]", subscriptionID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return user, nil
@@ -126,12 +126,12 @@ func (repository *gormUserRepository) LoadByEmail(ctx context.Context, email str
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("user with email [%s] does not exist", email)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with email ID [%s]", email)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return user, nil
@@ -143,7 +143,7 @@ func (repository *gormUserRepository) Store(ctx context.Context, user *entities.
 
 	if err := repository.db.WithContext(ctx).Create(user).Error; err != nil {
 		msg := fmt.Sprintf("cannot save user with ID [%s]", user.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -155,7 +155,7 @@ func (repository *gormUserRepository) Update(ctx context.Context, user *entities
 
 	if err := repository.db.WithContext(ctx).Save(user).Error; err != nil {
 		msg := fmt.Sprintf("cannot update user with ID [%s]", user.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -167,7 +167,7 @@ func (repository *gormUserRepository) LoadAuthContext(ctx context.Context, apiKe
 
 	if authUser, found := repository.cache.Get(apiKey); found {
 		if authUser.IsNoop() {
-			return authUser, repository.tracer.WrapErrorSpan(span, stacktrace.NewError(fmt.Sprintf("user with api key [%s] does not exist", apiKey)))
+			return authUser, repository.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", fmt.Sprintf("user with api key [%s] does not exist", apiKey)))
 		}
 		return authUser, nil
 	}
@@ -177,12 +177,12 @@ func (repository *gormUserRepository) LoadAuthContext(ctx context.Context, apiKe
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		repository.cache.SetWithTTL(apiKey, entities.AuthContext{}, 1, 2*time.Hour)
 		msg := fmt.Sprintf("user with api key [%s] does not exist", apiKey)
-		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with api key [%s]", apiKey)
-		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	authUser := entities.AuthContext{
@@ -192,7 +192,7 @@ func (repository *gormUserRepository) LoadAuthContext(ctx context.Context, apiKe
 
 	if result := repository.cache.SetWithTTL(apiKey, authUser, 1, 2*time.Hour); !result {
 		msg := fmt.Sprintf("cannot cache [%T] with ID [%s] and result [%t]", authUser, user.ID, result)
-		ctxLogger.Error(repository.tracer.WrapErrorSpan(span, stacktrace.NewError(msg)))
+		ctxLogger.Error(repository.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg)))
 	}
 
 	return authUser, nil
@@ -206,12 +206,12 @@ func (repository *gormUserRepository) Load(ctx context.Context, userID entities.
 	err := repository.db.WithContext(ctx).First(user, userID).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("user with ID [%s] does not exist", user.ID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with ID [%s]", userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return user, nil
@@ -228,7 +228,7 @@ func (repository *gormUserRepository) LoadOrStore(ctx context.Context, authUser 
 
 	apiKey, err := repository.generateAPIKey(64)
 	if err != nil {
-		return nil, false, stacktrace.Propagate(err, fmt.Sprintf("cannot generate apiKey for user [%s]", authUser.ID))
+		return nil, false, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot generate apiKey for user [%s]", authUser.ID))
 	}
 
 	user = &entities.User{
@@ -253,7 +253,7 @@ func (repository *gormUserRepository) LoadOrStore(ctx context.Context, authUser 
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create user from auth user [%+#v]", authUser)
-		return user, isNew, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return user, isNew, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return user, isNew, nil
@@ -267,7 +267,7 @@ func (repository *gormUserRepository) generateRandomBytes(n int) ([]byte, error)
 	b := make([]byte, n)
 	// Note that err == nil only if we read len(b) bytes.
 	if _, err := rand.Read(b); err != nil {
-		return nil, stacktrace.Propagate(err, fmt.Sprintf("cannot generate [%d] random bytes", n))
+		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot generate [%d] random bytes", n))
 	}
 
 	return b, nil

--- a/api/pkg/repositories/gorm_user_repository.go
+++ b/api/pkg/repositories/gorm_user_repository.go
@@ -48,8 +48,7 @@ func (repository *gormUserRepository) Delete(ctx context.Context, user *entities
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Delete(user).Error; err != nil {
-		msg := fmt.Sprintf("cannot delete user with ID [%s]", user.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete user with ID [%s]", user.ID))
 	}
 
 	return nil
@@ -61,12 +60,13 @@ func (repository *gormUserRepository) RotateAPIKey(ctx context.Context, userID e
 
 	apiKey, err := repository.generateAPIKey(64)
 	if err != nil {
-		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot generate apiKey for user [%s]", userID))
+		return nil, stacktrace.Propagate(err, "cannot generate apiKey for user [%s]", userID)
 	}
 
 	user := new(entities.User)
 	var oldAPIKey string
-	err = crdbgorm.ExecuteTx(ctx, repository.db, nil,
+	err = crdbgorm.ExecuteTx(
+		ctx, repository.db, nil,
 		func(tx *gorm.DB) error {
 			if err := tx.WithContext(ctx).Where("id = ?", userID).First(user).Error; err != nil {
 				return err
@@ -79,8 +79,7 @@ func (repository *gormUserRepository) RotateAPIKey(ctx context.Context, userID e
 		},
 	)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("user with ID [%s] does not exist", userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "user with ID [%s] does not exist", userID))
 	}
 
 	if err == nil && oldAPIKey != "" {
@@ -103,13 +102,11 @@ func (repository *gormUserRepository) LoadBySubscriptionID(ctx context.Context, 
 		First(user).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("user with subscriptionID [%s] does not exist", subscriptionID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "user with subscriptionID [%s] does not exist", subscriptionID))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with subscription ID [%s]", subscriptionID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load user with subscription ID [%s]", subscriptionID))
 	}
 
 	return user, nil
@@ -125,13 +122,11 @@ func (repository *gormUserRepository) LoadByEmail(ctx context.Context, email str
 		First(user).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("user with email [%s] does not exist", email)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "user with email [%s] does not exist", email))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with email ID [%s]", email)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load user with email ID [%s]", email))
 	}
 
 	return user, nil
@@ -142,8 +137,7 @@ func (repository *gormUserRepository) Store(ctx context.Context, user *entities.
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Create(user).Error; err != nil {
-		msg := fmt.Sprintf("cannot save user with ID [%s]", user.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save user with ID [%s]", user.ID))
 	}
 
 	return nil
@@ -154,8 +148,7 @@ func (repository *gormUserRepository) Update(ctx context.Context, user *entities
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Save(user).Error; err != nil {
-		msg := fmt.Sprintf("cannot update user with ID [%s]", user.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update user with ID [%s]", user.ID))
 	}
 
 	return nil
@@ -167,7 +160,7 @@ func (repository *gormUserRepository) LoadAuthContext(ctx context.Context, apiKe
 
 	if authUser, found := repository.cache.Get(apiKey); found {
 		if authUser.IsNoop() {
-			return authUser, repository.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", fmt.Sprintf("user with api key [%s] does not exist", apiKey)))
+			return authUser, repository.tracer.WrapErrorSpan(span, stacktrace.NewError("user with api key [%s] does not exist", apiKey))
 		}
 		return authUser, nil
 	}
@@ -176,13 +169,12 @@ func (repository *gormUserRepository) LoadAuthContext(ctx context.Context, apiKe
 	err := repository.db.WithContext(ctx).Where("api_key = ?", apiKey).First(user).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		repository.cache.SetWithTTL(apiKey, entities.AuthContext{}, 1, 2*time.Hour)
-		msg := fmt.Sprintf("user with api key [%s] does not exist", apiKey)
-		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+
+		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "user with api key [%s] does not exist", apiKey))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with api key [%s]", apiKey)
-		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return entities.AuthContext{}, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load user with api key [%s]", apiKey))
 	}
 
 	authUser := entities.AuthContext{
@@ -191,8 +183,7 @@ func (repository *gormUserRepository) LoadAuthContext(ctx context.Context, apiKe
 	}
 
 	if result := repository.cache.SetWithTTL(apiKey, authUser, 1, 2*time.Hour); !result {
-		msg := fmt.Sprintf("cannot cache [%T] with ID [%s] and result [%t]", authUser, user.ID, result)
-		ctxLogger.Error(repository.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg)))
+		ctxLogger.Error(repository.tracer.WrapErrorSpan(span, stacktrace.NewError("cannot cache [%T] with ID [%s] and result [%t]", authUser, user.ID, result)))
 	}
 
 	return authUser, nil
@@ -205,13 +196,11 @@ func (repository *gormUserRepository) Load(ctx context.Context, userID entities.
 	user := new(entities.User)
 	err := repository.db.WithContext(ctx).First(user, userID).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("user with ID [%s] does not exist", user.ID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "user with ID [%s] does not exist", user.ID))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with ID [%s]", userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load user with ID [%s]", userID))
 	}
 
 	return user, nil
@@ -228,7 +217,7 @@ func (repository *gormUserRepository) LoadOrStore(ctx context.Context, authUser 
 
 	apiKey, err := repository.generateAPIKey(64)
 	if err != nil {
-		return nil, false, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot generate apiKey for user [%s]", authUser.ID))
+		return nil, false, stacktrace.Propagate(err, "cannot generate apiKey for user [%s]", authUser.ID)
 	}
 
 	user = &entities.User{
@@ -252,8 +241,7 @@ func (repository *gormUserRepository) LoadOrStore(ctx context.Context, authUser 
 		return result.Error
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create user from auth user [%+#v]", authUser)
-		return user, isNew, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return user, isNew, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create user from auth user [%+#v]", authUser))
 	}
 
 	return user, isNew, nil
@@ -267,7 +255,7 @@ func (repository *gormUserRepository) generateRandomBytes(n int) ([]byte, error)
 	b := make([]byte, n)
 	// Note that err == nil only if we read len(b) bytes.
 	if _, err := rand.Read(b); err != nil {
-		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot generate [%d] random bytes", n))
+		return nil, stacktrace.Propagate(err, "cannot generate [%d] random bytes", n)
 	}
 
 	return b, nil

--- a/api/pkg/repositories/gorm_webhook_repository.go
+++ b/api/pkg/repositories/gorm_webhook_repository.go
@@ -37,8 +37,7 @@ func (repository *gormWebhookRepository) DeleteAllForUser(ctx context.Context, u
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.Webhook{}).Error; err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Webhook{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [%T] for user with ID [%s]", &entities.Webhook{}, userID))
 	}
 
 	return nil
@@ -49,8 +48,7 @@ func (repository *gormWebhookRepository) Save(ctx context.Context, webhook *enti
 	defer span.End()
 
 	if err := repository.db.WithContext(ctx).Save(webhook).Error; err != nil {
-		msg := fmt.Sprintf("cannot update webhook with ID [%s]", webhook.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update webhook with ID [%s]", webhook.ID))
 	}
 
 	return nil
@@ -69,8 +67,7 @@ func (repository *gormWebhookRepository) Index(ctx context.Context, userID entit
 
 	webhooks := make([]*entities.Webhook, 0)
 	if err := query.Order("created_at DESC").Limit(params.Limit).Offset(params.Skip).Find(&webhooks).Error; err != nil {
-		msg := fmt.Sprintf("cannot fetch webhooks for user [%s] and params [%+#v]", userID, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch webhooks for user [%s] and params [%+#v]", userID, params))
 	}
 
 	return webhooks, nil
@@ -86,8 +83,7 @@ func (repository *gormWebhookRepository) LoadByEvent(ctx context.Context, userID
 		Scan(&webhooks).
 		Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot load webhooks for user with ID [%s] and event [%s]", userID, event)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load webhooks for user with ID [%s] and event [%s]", userID, event))
 	}
 
 	return webhooks, nil
@@ -100,13 +96,11 @@ func (repository *gormWebhookRepository) Load(ctx context.Context, userID entiti
 	webhook := new(entities.Webhook)
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", webhookID).First(&webhook).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		msg := fmt.Sprintf("webhook with ID [%s] for user [%s] does not exist", webhookID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "webhook with ID [%s] for user [%s] does not exist", webhookID, userID))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load webhook with ID [%s] for user [%s]", webhookID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load webhook with ID [%s] for user [%s]", webhookID, userID))
 	}
 
 	return webhook, nil
@@ -121,8 +115,7 @@ func (repository *gormWebhookRepository) Delete(ctx context.Context, userID enti
 		Where("id = ?", webhookID).
 		Delete(&entities.Webhook{}).Error
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete webhook with ID [%s] and userID [%s]", webhookID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete webhook with ID [%s] and userID [%s]", webhookID, userID))
 	}
 
 	return nil

--- a/api/pkg/repositories/gorm_webhook_repository.go
+++ b/api/pkg/repositories/gorm_webhook_repository.go
@@ -38,7 +38,7 @@ func (repository *gormWebhookRepository) DeleteAllForUser(ctx context.Context, u
 
 	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.Webhook{}).Error; err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Webhook{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -50,7 +50,7 @@ func (repository *gormWebhookRepository) Save(ctx context.Context, webhook *enti
 
 	if err := repository.db.WithContext(ctx).Save(webhook).Error; err != nil {
 		msg := fmt.Sprintf("cannot update webhook with ID [%s]", webhook.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -70,7 +70,7 @@ func (repository *gormWebhookRepository) Index(ctx context.Context, userID entit
 	webhooks := make([]*entities.Webhook, 0)
 	if err := query.Order("created_at DESC").Limit(params.Limit).Offset(params.Skip).Find(&webhooks).Error; err != nil {
 		msg := fmt.Sprintf("cannot fetch webhooks for user [%s] and params [%+#v]", userID, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return webhooks, nil
@@ -87,7 +87,7 @@ func (repository *gormWebhookRepository) LoadByEvent(ctx context.Context, userID
 		Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot load webhooks for user with ID [%s] and event [%s]", userID, event)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return webhooks, nil
@@ -101,12 +101,12 @@ func (repository *gormWebhookRepository) Load(ctx context.Context, userID entiti
 	err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Where("id = ?", webhookID).First(&webhook).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		msg := fmt.Sprintf("webhook with ID [%s] for user [%s] does not exist", webhookID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load webhook with ID [%s] for user [%s]", webhookID, userID)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return webhook, nil
@@ -122,7 +122,7 @@ func (repository *gormWebhookRepository) Delete(ctx context.Context, userID enti
 		Delete(&entities.Webhook{}).Error
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete webhook with ID [%s] and userID [%s]", webhookID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/repositories/memory_attachment_repository.go
+++ b/api/pkg/repositories/memory_attachment_repository.go
@@ -44,7 +44,7 @@ func (s *MemoryAttachmentRepository) Download(ctx context.Context, path string) 
 
 	value, ok := s.data.Load(path)
 	if !ok {
-		return nil, s.tracer.WrapErrorSpan(span, stacktrace.NewErrorWithCode(ErrCodeNotFound, fmt.Sprintf("attachment not found at path [%s]", path)))
+		return nil, s.tracer.WrapErrorSpan(span, stacktrace.NewErrorWithCode(ErrCodeNotFound, "%s", fmt.Sprintf("attachment not found at path [%s]", path)))
 	}
 	return value.([]byte), nil
 }

--- a/api/pkg/repositories/memory_attachment_repository.go
+++ b/api/pkg/repositories/memory_attachment_repository.go
@@ -44,7 +44,7 @@ func (s *MemoryAttachmentRepository) Download(ctx context.Context, path string) 
 
 	value, ok := s.data.Load(path)
 	if !ok {
-		return nil, s.tracer.WrapErrorSpan(span, stacktrace.NewErrorWithCode(ErrCodeNotFound, "%s", fmt.Sprintf("attachment not found at path [%s]", path)))
+		return nil, s.tracer.WrapErrorSpan(span, stacktrace.NewErrorWithCode(ErrCodeNotFound, "attachment not found at path [%s]", path))
 	}
 	return value.([]byte), nil
 }

--- a/api/pkg/repositories/mongo_heartbeat_monitor_repository.go
+++ b/api/pkg/repositories/mongo_heartbeat_monitor_repository.go
@@ -43,8 +43,7 @@ func (repository *mongoHeartbeatMonitorRepository) Store(ctx context.Context, mo
 
 	_, err := repository.collection.InsertOne(ctx, monitor)
 	if err != nil {
-		msg := fmt.Sprintf("cannot save heartbeat monitor with ID [%s]", monitor.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save heartbeat monitor with ID [%s]", monitor.ID))
 	}
 
 	return nil
@@ -65,12 +64,10 @@ func (repository *mongoHeartbeatMonitorRepository) Load(ctx context.Context, use
 	var monitor entities.HeartbeatMonitor
 	err := repository.collection.FindOne(ctx, filter).Decode(&monitor)
 	if err == mongo.ErrNoDocuments {
-		msg := fmt.Sprintf("heartbeat monitor with userID [%s] and owner [%s] does not exist", userID, phoneNumber)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "heartbeat monitor with userID [%s] and owner [%s] does not exist", userID, phoneNumber))
 	}
 	if err != nil {
-		msg := fmt.Sprintf("cannot load heartbeat monitor with userID [%s] and owner [%s]", userID, phoneNumber)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load heartbeat monitor with userID [%s] and owner [%s]", userID, phoneNumber))
 	}
 
 	return &monitor, nil
@@ -90,8 +87,7 @@ func (repository *mongoHeartbeatMonitorRepository) Exists(ctx context.Context, u
 
 	count, err := repository.collection.CountDocuments(ctx, filter)
 	if err != nil {
-		msg := fmt.Sprintf("cannot check if heartbeat monitor exists with userID [%s] and monitor ID [%s]", userID, monitorID)
-		return false, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return false, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot check if heartbeat monitor exists with userID [%s] and monitor ID [%s]", userID, monitorID))
 	}
 
 	return count > 0, nil
@@ -112,8 +108,7 @@ func (repository *mongoHeartbeatMonitorRepository) UpdateQueueID(ctx context.Con
 
 	_, err := repository.collection.UpdateOne(ctx, filter, update)
 	if err != nil {
-		msg := fmt.Sprintf("cannot update heartbeat monitor ID [%s]", monitorID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update heartbeat monitor ID [%s]", monitorID))
 	}
 
 	return nil
@@ -133,8 +128,7 @@ func (repository *mongoHeartbeatMonitorRepository) Delete(ctx context.Context, u
 
 	_, err := repository.collection.DeleteMany(ctx, filter)
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete heartbeat monitor with owner [%s] and userID [%s]", phoneNumber, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete heartbeat monitor with owner [%s] and userID [%s]", phoneNumber, userID))
 	}
 
 	return nil
@@ -158,8 +152,7 @@ func (repository *mongoHeartbeatMonitorRepository) UpdatePhoneOnline(ctx context
 
 	_, err := repository.collection.UpdateOne(ctx, filter, update)
 	if err != nil {
-		msg := fmt.Sprintf("cannot update heartbeat monitor ID [%s] for user [%s]", monitorID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update heartbeat monitor ID [%s] for user [%s]", monitorID, userID))
 	}
 
 	return nil
@@ -174,8 +167,7 @@ func (repository *mongoHeartbeatMonitorRepository) DeleteAllForUser(ctx context.
 
 	_, err := repository.collection.DeleteMany(ctx, bson.D{{Key: "user_id", Value: string(userID)}})
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.HeartbeatMonitor{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [%T] for user with ID [%s]", &entities.HeartbeatMonitor{}, userID))
 	}
 
 	return nil

--- a/api/pkg/repositories/mongo_heartbeat_monitor_repository.go
+++ b/api/pkg/repositories/mongo_heartbeat_monitor_repository.go
@@ -44,7 +44,7 @@ func (repository *mongoHeartbeatMonitorRepository) Store(ctx context.Context, mo
 	_, err := repository.collection.InsertOne(ctx, monitor)
 	if err != nil {
 		msg := fmt.Sprintf("cannot save heartbeat monitor with ID [%s]", monitor.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -58,19 +58,19 @@ func (repository *mongoHeartbeatMonitorRepository) Load(ctx context.Context, use
 	defer cancel()
 
 	filter := bson.D{
-		{"user_id", string(userID)},
-		{"owner", phoneNumber},
+		{Key: "user_id", Value: string(userID)},
+		{Key: "owner", Value: phoneNumber},
 	}
 
 	var monitor entities.HeartbeatMonitor
 	err := repository.collection.FindOne(ctx, filter).Decode(&monitor)
 	if err == mongo.ErrNoDocuments {
 		msg := fmt.Sprintf("heartbeat monitor with userID [%s] and owner [%s] does not exist", userID, phoneNumber)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 	if err != nil {
 		msg := fmt.Sprintf("cannot load heartbeat monitor with userID [%s] and owner [%s]", userID, phoneNumber)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return &monitor, nil
@@ -84,14 +84,14 @@ func (repository *mongoHeartbeatMonitorRepository) Exists(ctx context.Context, u
 	defer cancel()
 
 	filter := bson.D{
-		{"user_id", string(userID)},
-		{"_id", monitorID.String()},
+		{Key: "user_id", Value: string(userID)},
+		{Key: "_id", Value: monitorID.String()},
 	}
 
 	count, err := repository.collection.CountDocuments(ctx, filter)
 	if err != nil {
 		msg := fmt.Sprintf("cannot check if heartbeat monitor exists with userID [%s] and monitor ID [%s]", userID, monitorID)
-		return false, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return false, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return count > 0, nil
@@ -104,16 +104,16 @@ func (repository *mongoHeartbeatMonitorRepository) UpdateQueueID(ctx context.Con
 	ctx, cancel := context.WithTimeout(ctx, dbOperationDuration)
 	defer cancel()
 
-	filter := bson.D{{"_id", monitorID.String()}}
-	update := bson.D{{"$set", bson.D{
-		{"queue_id", queueID},
-		{"updated_at", time.Now().UTC()},
+	filter := bson.D{{Key: "_id", Value: monitorID.String()}}
+	update := bson.D{{Key: "$set", Value: bson.D{
+		{Key: "queue_id", Value: queueID},
+		{Key: "updated_at", Value: time.Now().UTC()},
 	}}}
 
 	_, err := repository.collection.UpdateOne(ctx, filter, update)
 	if err != nil {
 		msg := fmt.Sprintf("cannot update heartbeat monitor ID [%s]", monitorID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -127,14 +127,14 @@ func (repository *mongoHeartbeatMonitorRepository) Delete(ctx context.Context, u
 	defer cancel()
 
 	filter := bson.D{
-		{"user_id", string(userID)},
-		{"owner", phoneNumber},
+		{Key: "user_id", Value: string(userID)},
+		{Key: "owner", Value: phoneNumber},
 	}
 
 	_, err := repository.collection.DeleteMany(ctx, filter)
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete heartbeat monitor with owner [%s] and userID [%s]", phoneNumber, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -148,18 +148,18 @@ func (repository *mongoHeartbeatMonitorRepository) UpdatePhoneOnline(ctx context
 	defer cancel()
 
 	filter := bson.D{
-		{"_id", monitorID.String()},
-		{"user_id", string(userID)},
+		{Key: "_id", Value: monitorID.String()},
+		{Key: "user_id", Value: string(userID)},
 	}
-	update := bson.D{{"$set", bson.D{
-		{"phone_online", online},
-		{"updated_at", time.Now().UTC()},
+	update := bson.D{{Key: "$set", Value: bson.D{
+		{Key: "phone_online", Value: online},
+		{Key: "updated_at", Value: time.Now().UTC()},
 	}}}
 
 	_, err := repository.collection.UpdateOne(ctx, filter, update)
 	if err != nil {
 		msg := fmt.Sprintf("cannot update heartbeat monitor ID [%s] for user [%s]", monitorID, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -172,10 +172,10 @@ func (repository *mongoHeartbeatMonitorRepository) DeleteAllForUser(ctx context.
 	ctx, cancel := context.WithTimeout(ctx, dbOperationDuration)
 	defer cancel()
 
-	_, err := repository.collection.DeleteMany(ctx, bson.D{{"user_id", string(userID)}})
+	_, err := repository.collection.DeleteMany(ctx, bson.D{{Key: "user_id", Value: string(userID)}})
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.HeartbeatMonitor{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/repositories/mongo_heartbeat_repository.go
+++ b/api/pkg/repositories/mongo_heartbeat_repository.go
@@ -43,7 +43,7 @@ func (repository *mongoHeartbeatRepository) Store(ctx context.Context, heartbeat
 	_, err := repository.collection.InsertOne(ctx, heartbeat)
 	if err != nil {
 		msg := fmt.Sprintf("cannot save heartbeat with ID [%s]", heartbeat.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -57,30 +57,30 @@ func (repository *mongoHeartbeatRepository) Index(ctx context.Context, userID en
 	defer cancel()
 
 	filter := bson.D{
-		{"user_id", string(userID)},
-		{"owner", owner},
+		{Key: "user_id", Value: string(userID)},
+		{Key: "owner", Value: owner},
 	}
 
 	if len(params.Query) > 0 {
-		filter = append(filter, bson.E{"version", bson.D{{"$regex", params.Query}, {"$options", "i"}}})
+		filter = append(filter, bson.E{Key: "version", Value: bson.D{{Key: "$regex", Value: params.Query}, {Key: "$options", Value: "i"}}})
 	}
 
 	opts := options.Find().
-		SetSort(bson.D{{"timestamp", -1}}).
+		SetSort(bson.D{{Key: "timestamp", Value: -1}}).
 		SetSkip(int64(params.Skip)).
 		SetLimit(int64(params.Limit))
 
 	cursor, err := repository.collection.Find(ctx, filter, opts)
 	if err != nil {
 		msg := fmt.Sprintf("cannot fetch heartbeats with owner [%s] and params [%+#v]", owner, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	defer cursor.Close(ctx)
 
 	var heartbeats []entities.Heartbeat
 	if err = cursor.All(ctx, &heartbeats); err != nil {
 		msg := fmt.Sprintf("cannot decode heartbeats for owner [%s]", owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if heartbeats == nil {
@@ -98,21 +98,21 @@ func (repository *mongoHeartbeatRepository) Last(ctx context.Context, userID ent
 	defer cancel()
 
 	filter := bson.D{
-		{"user_id", string(userID)},
-		{"owner", owner},
+		{Key: "user_id", Value: string(userID)},
+		{Key: "owner", Value: owner},
 	}
 
-	opts := options.FindOne().SetSort(bson.D{{"timestamp", -1}})
+	opts := options.FindOne().SetSort(bson.D{{Key: "timestamp", Value: -1}})
 
 	var heartbeat entities.Heartbeat
 	err := repository.collection.FindOne(ctx, filter, opts).Decode(&heartbeat)
 	if err == mongo.ErrNoDocuments {
 		msg := fmt.Sprintf("heartbeat with userID [%s] and owner [%s] does not exist", userID, owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
 	}
 	if err != nil {
 		msg := fmt.Sprintf("cannot load heartbeat with userID [%s] and owner [%s]", userID, owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return &heartbeat, nil
@@ -125,10 +125,10 @@ func (repository *mongoHeartbeatRepository) DeleteAllForUser(ctx context.Context
 	ctx, cancel := context.WithTimeout(ctx, dbOperationDuration)
 	defer cancel()
 
-	_, err := repository.collection.DeleteMany(ctx, bson.D{{"user_id", string(userID)}})
+	_, err := repository.collection.DeleteMany(ctx, bson.D{{Key: "user_id", Value: string(userID)}})
 	if err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Heartbeat{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil

--- a/api/pkg/repositories/mongo_heartbeat_repository.go
+++ b/api/pkg/repositories/mongo_heartbeat_repository.go
@@ -42,8 +42,7 @@ func (repository *mongoHeartbeatRepository) Store(ctx context.Context, heartbeat
 
 	_, err := repository.collection.InsertOne(ctx, heartbeat)
 	if err != nil {
-		msg := fmt.Sprintf("cannot save heartbeat with ID [%s]", heartbeat.ID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save heartbeat with ID [%s]", heartbeat.ID))
 	}
 
 	return nil
@@ -72,15 +71,13 @@ func (repository *mongoHeartbeatRepository) Index(ctx context.Context, userID en
 
 	cursor, err := repository.collection.Find(ctx, filter, opts)
 	if err != nil {
-		msg := fmt.Sprintf("cannot fetch heartbeats with owner [%s] and params [%+#v]", owner, params)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch heartbeats with owner [%s] and params [%+#v]", owner, params))
 	}
 	defer cursor.Close(ctx)
 
 	var heartbeats []entities.Heartbeat
 	if err = cursor.All(ctx, &heartbeats); err != nil {
-		msg := fmt.Sprintf("cannot decode heartbeats for owner [%s]", owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot decode heartbeats for owner [%s]", owner))
 	}
 
 	if heartbeats == nil {
@@ -107,12 +104,10 @@ func (repository *mongoHeartbeatRepository) Last(ctx context.Context, userID ent
 	var heartbeat entities.Heartbeat
 	err := repository.collection.FindOne(ctx, filter, opts).Decode(&heartbeat)
 	if err == mongo.ErrNoDocuments {
-		msg := fmt.Sprintf("heartbeat with userID [%s] and owner [%s] does not exist", userID, owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, ErrCodeNotFound, "heartbeat with userID [%s] and owner [%s] does not exist", userID, owner))
 	}
 	if err != nil {
-		msg := fmt.Sprintf("cannot load heartbeat with userID [%s] and owner [%s]", userID, owner)
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load heartbeat with userID [%s] and owner [%s]", userID, owner))
 	}
 
 	return &heartbeat, nil
@@ -127,8 +122,7 @@ func (repository *mongoHeartbeatRepository) DeleteAllForUser(ctx context.Context
 
 	_, err := repository.collection.DeleteMany(ctx, bson.D{{Key: "user_id", Value: string(userID)}})
 	if err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user with ID [%s]", &entities.Heartbeat{}, userID)
-		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete all [%T] for user with ID [%s]", &entities.Heartbeat{}, userID))
 	}
 
 	return nil

--- a/api/pkg/repositories/mongodb.go
+++ b/api/pkg/repositories/mongodb.go
@@ -2,7 +2,6 @@ package repositories
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"reflect"
 	"time"
@@ -92,7 +91,7 @@ func NewMongoDB(uri string) (*mongo.Database, error) {
 func parseMongoDBName(uri string) (string, error) {
 	parsed, err := url.Parse(uri)
 	if err != nil {
-		return "", stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot parse MongoDB URI [%s]", uri))
+		return "", stacktrace.Propagate(err, "cannot parse MongoDB URI [%s]", uri)
 	}
 
 	appName := parsed.Query().Get("appName")

--- a/api/pkg/repositories/mongodb.go
+++ b/api/pkg/repositories/mongodb.go
@@ -92,7 +92,7 @@ func NewMongoDB(uri string) (*mongo.Database, error) {
 func parseMongoDBName(uri string) (string, error) {
 	parsed, err := url.Parse(uri)
 	if err != nil {
-		return "", stacktrace.Propagate(err, fmt.Sprintf("cannot parse MongoDB URI [%s]", uri))
+		return "", stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot parse MongoDB URI [%s]", uri))
 	}
 
 	appName := parsed.Query().Get("appName")
@@ -108,7 +108,7 @@ func createMongoIndexes(ctx context.Context, db *mongo.Database) error {
 	heartbeatsCol := db.Collection(collectionHeartbeats)
 
 	_, err := heartbeatsCol.Indexes().CreateMany(ctx, []mongo.IndexModel{
-		{Keys: bson.D{{"user_id", 1}, {"owner", 1}, {"timestamp", -1}}},
+		{Keys: bson.D{{Key: "user_id", Value: 1}, {Key: "owner", Value: 1}, {Key: "timestamp", Value: -1}}},
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "cannot create indexes on heartbeats collection")
@@ -117,7 +117,7 @@ func createMongoIndexes(ctx context.Context, db *mongo.Database) error {
 	// Heartbeat monitors indexes
 	monitorsCol := db.Collection(collectionHeartbeatMonitors)
 	_, err = monitorsCol.Indexes().CreateMany(ctx, []mongo.IndexModel{
-		{Keys: bson.D{{"user_id", 1}, {"owner", 1}}},
+		{Keys: bson.D{{Key: "user_id", Value: 1}, {Key: "owner", Value: 1}}},
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "cannot create indexes on heartbeat_monitors collection")

--- a/api/pkg/requests/message_receive_request.go
+++ b/api/pkg/requests/message_receive_request.go
@@ -66,7 +66,7 @@ func (input *MessageReceive) ToMessageReceiveParams(userID entities.UserID, sour
 		UserID:      userID,
 		Timestamp:   input.Timestamp,
 		Encrypted:   input.Encrypted,
-		Owner:       *phone,
+		Owner:       phone,
 		Content:     input.Content,
 		SIM:         input.SIM,
 		Attachments: attachments,

--- a/api/pkg/services/billing_service.go
+++ b/api/pkg/services/billing_service.go
@@ -55,15 +55,13 @@ func (service *BillingService) IsEntitledWithCount(ctx context.Context, userID e
 
 	user, err := service.userRepository.Load(ctx, userID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with ID [%s], entitlement successful", userID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load user with ID [%s], entitlement successful", userID)))
 		return nil
 	}
 
 	usage, err := service.billingUsageRepository.GetCurrent(ctx, userID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load billing usage for user with ID [%s], entitlement successful", userID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load billing usage for user with ID [%s], entitlement successful", userID)))
 		return nil
 	}
 
@@ -104,19 +102,18 @@ func (service *BillingService) sendLimitExceededEmail(ctx context.Context, user 
 
 	email, err := service.emailFactory.UsageLimitExceeded(user, usage)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create usage limit email for user [%s]", user.ID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot create usage limit email for user [%s]", user.ID))
 		return
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
-		msg := fmt.Sprintf("canot send usage limit exceeded notification to user [%s]", user.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "canot send usage limit exceeded notification to user [%s]", user.ID))
 		return
 	}
 
 	ctxLogger.Info(fmt.Sprintf("usage limit exceeded email sent to user [%s]", user.ID))
 	if err = service.cache.Set(ctx, key, "", time.Hour*12); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot set item in redis with key [%s]", key)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot set item in redis with key [%s]", key))
 	}
 }
 
@@ -144,8 +141,7 @@ func (service *BillingService) RegisterSentMessage(ctx context.Context, messageI
 	ctxLogger := service.tracer.CtxLogger(service.logger, span)
 
 	if err := service.billingUsageRepository.RegisterSentMessage(ctx, timestamp, userID); err != nil {
-		msg := fmt.Sprintf("could not register [sent] message with ID [%s] for user with ID [%s]", messageID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not register [sent] message with ID [%s] for user with ID [%s]", messageID, userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("registered [sent] message with ID [%s] for user [%s]", messageID, userID))
@@ -161,8 +157,7 @@ func (service *BillingService) RegisterReceivedMessage(ctx context.Context, mess
 	ctxLogger := service.tracer.CtxLogger(service.logger, span)
 
 	if err := service.billingUsageRepository.RegisterReceivedMessage(ctx, timestamp, userID); err != nil {
-		msg := fmt.Sprintf("could not register [received] message with ID [%s] for user with ID [%s]", messageID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not register [received] message with ID [%s] for user with ID [%s]", messageID, userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("registered [received] message with ID [%s] for user [%s]", messageID, userID))
@@ -176,8 +171,7 @@ func (service *BillingService) DeleteAllForUser(ctx context.Context, userID enti
 	defer span.End()
 
 	if err := service.billingUsageRepository.DeleteAllForUser(ctx, userID); err != nil {
-		msg := fmt.Sprintf("could not delete [entities.BillingUsage] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not delete [entities.BillingUsage] for user with ID [%s]", userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.BillingUsage] for user with ID [%s]", userID))
@@ -190,15 +184,13 @@ func (service *BillingService) sendUsageAlert(ctx context.Context, userID entiti
 
 	user, err := service.userRepository.Load(ctx, userID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with ID [%s]", userID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load user with ID [%s]", userID)))
 		return
 	}
 
 	billingUsage, err := service.billingUsageRepository.GetCurrent(ctx, userID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load billing usage for user with ID [%s]", userID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load billing usage for user with ID [%s]", userID)))
 		return
 	}
 
@@ -208,13 +200,12 @@ func (service *BillingService) sendUsageAlert(ctx context.Context, userID entiti
 
 	email, err := service.emailFactory.UsageLimitAlert(user, billingUsage)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create usage alert email for user [%s]", user.ID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot create usage alert email for user [%s]", user.ID))
 		return
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
-		msg := fmt.Sprintf("canot send usage alert notification to user [%s]", user.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "canot send usage alert notification to user [%s]", user.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("usage alert email sent to user [%s]", user.ID))

--- a/api/pkg/services/billing_service.go
+++ b/api/pkg/services/billing_service.go
@@ -56,14 +56,14 @@ func (service *BillingService) IsEntitledWithCount(ctx context.Context, userID e
 	user, err := service.userRepository.Load(ctx, userID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with ID [%s], entitlement successful", userID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return nil
 	}
 
 	usage, err := service.billingUsageRepository.GetCurrent(ctx, userID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load billing usage for user with ID [%s], entitlement successful", userID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return nil
 	}
 
@@ -104,19 +104,19 @@ func (service *BillingService) sendLimitExceededEmail(ctx context.Context, user 
 
 	email, err := service.emailFactory.UsageLimitExceeded(user, usage)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot create usage limit email for user [%s]", user.ID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create usage limit email for user [%s]", user.ID)))
 		return
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
 		msg := fmt.Sprintf("canot send usage limit exceeded notification to user [%s]", user.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return
 	}
 
 	ctxLogger.Info(fmt.Sprintf("usage limit exceeded email sent to user [%s]", user.ID))
 	if err = service.cache.Set(ctx, key, "", time.Hour*12); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot set item in redis with key [%s]", key)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot set item in redis with key [%s]", key)))
 	}
 }
 
@@ -145,7 +145,7 @@ func (service *BillingService) RegisterSentMessage(ctx context.Context, messageI
 
 	if err := service.billingUsageRepository.RegisterSentMessage(ctx, timestamp, userID); err != nil {
 		msg := fmt.Sprintf("could not register [sent] message with ID [%s] for user with ID [%s]", messageID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("registered [sent] message with ID [%s] for user [%s]", messageID, userID))
@@ -162,7 +162,7 @@ func (service *BillingService) RegisterReceivedMessage(ctx context.Context, mess
 
 	if err := service.billingUsageRepository.RegisterReceivedMessage(ctx, timestamp, userID); err != nil {
 		msg := fmt.Sprintf("could not register [received] message with ID [%s] for user with ID [%s]", messageID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("registered [received] message with ID [%s] for user [%s]", messageID, userID))
@@ -177,7 +177,7 @@ func (service *BillingService) DeleteAllForUser(ctx context.Context, userID enti
 
 	if err := service.billingUsageRepository.DeleteAllForUser(ctx, userID); err != nil {
 		msg := fmt.Sprintf("could not delete [entities.BillingUsage] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.BillingUsage] for user with ID [%s]", userID))
@@ -191,14 +191,14 @@ func (service *BillingService) sendUsageAlert(ctx context.Context, userID entiti
 	user, err := service.userRepository.Load(ctx, userID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with ID [%s]", userID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return
 	}
 
 	billingUsage, err := service.billingUsageRepository.GetCurrent(ctx, userID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load billing usage for user with ID [%s]", userID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return
 	}
 
@@ -208,13 +208,13 @@ func (service *BillingService) sendUsageAlert(ctx context.Context, userID entiti
 
 	email, err := service.emailFactory.UsageLimitAlert(user, billingUsage)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot create usage alert email for user [%s]", user.ID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create usage alert email for user [%s]", user.ID)))
 		return
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
 		msg := fmt.Sprintf("canot send usage alert notification to user [%s]", user.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("usage alert email sent to user [%s]", user.ID))

--- a/api/pkg/services/discord_service.go
+++ b/api/pkg/services/discord_service.go
@@ -60,7 +60,7 @@ func (service *DiscordService) DeleteAllForUser(ctx context.Context, userID enti
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
 		msg := fmt.Sprintf("could not delete all [entities.Discord] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.Discord] for user with ID [%s]", userID))
@@ -77,7 +77,7 @@ func (service *DiscordService) Index(ctx context.Context, userID entities.UserID
 	discordIntegrations, err := service.repository.Index(ctx, userID, params)
 	if err != nil {
 		msg := fmt.Sprintf("could not fetch discord integrations with params [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] discord integrations with prams [%+#v]", len(discordIntegrations), params))
@@ -93,12 +93,12 @@ func (service *DiscordService) Delete(ctx context.Context, userID entities.UserI
 
 	if _, err := service.repository.Load(ctx, userID, discordID); err != nil {
 		msg := fmt.Sprintf("cannot load discord integration with userID [%s] and discordID [%s]", userID, discordID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	if err := service.repository.Delete(ctx, userID, discordID); err != nil {
 		msg := fmt.Sprintf("cannot delete discord integration with id [%s] and discordID [%s]", discordID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted discord integration with id [%s] and user id [%s]", discordID, userID))
@@ -120,7 +120,7 @@ func (service *DiscordService) Store(ctx context.Context, params *DiscordStorePa
 
 	if err := service.createSlashCommand(ctx, params.ServerID); err != nil {
 		msg := fmt.Sprintf("cannot create slash command for server [%s]", params.ServerID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	discordIntegration := &entities.Discord{
@@ -135,7 +135,7 @@ func (service *DiscordService) Store(ctx context.Context, params *DiscordStorePa
 
 	if err := service.repository.Save(ctx, discordIntegration); err != nil {
 		msg := fmt.Sprintf("cannot save discord integration with id [%s]", discordIntegration.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("discord integration saved with id [%s] in the [%T]", discordIntegration.ID, service.repository))
@@ -179,7 +179,7 @@ func (service *DiscordService) createSlashCommand(ctx context.Context, serverID 
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create slash command for server [%s]", serverID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("upserted a slash command with ID [%s] for discord server [%s] and applicationID [%s]", command.ID, serverID, command.ApplicationID))
@@ -203,12 +203,12 @@ func (service *DiscordService) Update(ctx context.Context, params *DiscordUpdate
 	discordIntegration, err := service.repository.Load(ctx, params.UserID, params.DiscordID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load discord integration with userID [%s] and discordID [%s]", params.UserID, params.DiscordID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	if err = service.createSlashCommand(ctx, params.ServerID); err != nil {
 		msg := fmt.Sprintf("cannot create slash command for server [%s]", params.ServerID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	discordIntegration.Name = params.Name
@@ -217,7 +217,7 @@ func (service *DiscordService) Update(ctx context.Context, params *DiscordUpdate
 
 	if err = service.repository.Save(ctx, discordIntegration); err != nil {
 		msg := fmt.Sprintf("cannot save discord integration with id [%s] after update", discordIntegration.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("discord integration updated with id [%s] in the [%T]", discordIntegration.ID, service.repository))
@@ -232,7 +232,7 @@ func (service *DiscordService) HandleMessageReceived(ctx context.Context, userID
 	discordIntegrations, err := service.repository.FetchHavingIncomingChannel(ctx, userID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load discord integrations for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	if len(discordIntegrations) == 0 {
@@ -259,7 +259,7 @@ func (service *DiscordService) sendMessage(ctx context.Context, event cloudevent
 
 	payload := new(events.MessagePhoneReceivedPayload)
 	if err := event.DataAs(payload); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload)))
 		return
 	}
 
@@ -267,7 +267,7 @@ func (service *DiscordService) sendMessage(ctx context.Context, event cloudevent
 	message, response, err := service.client.Channel.CreateMessage(ctx, discord.IncomingChannelID, request)
 	if err != nil {
 		msg := fmt.Sprintf("cannot send [%s] event to discord channel [%s] for user [%s]", event.Type(), discord.IncomingChannelID, discord.UserID)
-		ctxLogger.Warn(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Warn(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 
 		eventPayload := &events.DiscordSendFailedPayload{
 			DiscordID:        discord.ID,
@@ -328,13 +328,13 @@ func (service *DiscordService) handleDiscordMessageFailed(ctx context.Context, s
 	event, err := service.createEvent(events.EventTypeDiscordSendFailed, source, payload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event [%s] for user with id [%s]", events.EventTypeDiscordSendFailed, payload.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event [%s] for user with id [%s]", event.Type(), payload.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return
 	}
 

--- a/api/pkg/services/discord_service.go
+++ b/api/pkg/services/discord_service.go
@@ -59,8 +59,7 @@ func (service *DiscordService) DeleteAllForUser(ctx context.Context, userID enti
 	defer span.End()
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
-		msg := fmt.Sprintf("could not delete all [entities.Discord] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not delete all [entities.Discord] for user with ID [%s]", userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.Discord] for user with ID [%s]", userID))
@@ -76,8 +75,7 @@ func (service *DiscordService) Index(ctx context.Context, userID entities.UserID
 
 	discordIntegrations, err := service.repository.Index(ctx, userID, params)
 	if err != nil {
-		msg := fmt.Sprintf("could not fetch discord integrations with params [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not fetch discord integrations with params [%+#v]", params))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] discord integrations with prams [%+#v]", len(discordIntegrations), params))
@@ -92,13 +90,11 @@ func (service *DiscordService) Delete(ctx context.Context, userID entities.UserI
 	ctxLogger := service.tracer.CtxLogger(service.logger, span)
 
 	if _, err := service.repository.Load(ctx, userID, discordID); err != nil {
-		msg := fmt.Sprintf("cannot load discord integration with userID [%s] and discordID [%s]", userID, discordID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "cannot load discord integration with userID [%s] and discordID [%s]", userID, discordID))
 	}
 
 	if err := service.repository.Delete(ctx, userID, discordID); err != nil {
-		msg := fmt.Sprintf("cannot delete discord integration with id [%s] and discordID [%s]", discordID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete discord integration with id [%s] and discordID [%s]", discordID, userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted discord integration with id [%s] and user id [%s]", discordID, userID))
@@ -119,8 +115,7 @@ func (service *DiscordService) Store(ctx context.Context, params *DiscordStorePa
 	defer span.End()
 
 	if err := service.createSlashCommand(ctx, params.ServerID); err != nil {
-		msg := fmt.Sprintf("cannot create slash command for server [%s]", params.ServerID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create slash command for server [%s]", params.ServerID))
 	}
 
 	discordIntegration := &entities.Discord{
@@ -134,8 +129,7 @@ func (service *DiscordService) Store(ctx context.Context, params *DiscordStorePa
 	}
 
 	if err := service.repository.Save(ctx, discordIntegration); err != nil {
-		msg := fmt.Sprintf("cannot save discord integration with id [%s]", discordIntegration.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save discord integration with id [%s]", discordIntegration.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("discord integration saved with id [%s] in the [%T]", discordIntegration.ID, service.repository))
@@ -178,8 +172,7 @@ func (service *DiscordService) createSlashCommand(ctx context.Context, serverID 
 		},
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create slash command for server [%s]", serverID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create slash command for server [%s]", serverID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("upserted a slash command with ID [%s] for discord server [%s] and applicationID [%s]", command.ID, serverID, command.ApplicationID))
@@ -202,13 +195,11 @@ func (service *DiscordService) Update(ctx context.Context, params *DiscordUpdate
 
 	discordIntegration, err := service.repository.Load(ctx, params.UserID, params.DiscordID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load discord integration with userID [%s] and discordID [%s]", params.UserID, params.DiscordID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "cannot load discord integration with userID [%s] and discordID [%s]", params.UserID, params.DiscordID))
 	}
 
 	if err = service.createSlashCommand(ctx, params.ServerID); err != nil {
-		msg := fmt.Sprintf("cannot create slash command for server [%s]", params.ServerID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create slash command for server [%s]", params.ServerID))
 	}
 
 	discordIntegration.Name = params.Name
@@ -216,8 +207,7 @@ func (service *DiscordService) Update(ctx context.Context, params *DiscordUpdate
 	discordIntegration.IncomingChannelID = params.IncomingChannelID
 
 	if err = service.repository.Save(ctx, discordIntegration); err != nil {
-		msg := fmt.Sprintf("cannot save discord integration with id [%s] after update", discordIntegration.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save discord integration with id [%s] after update", discordIntegration.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("discord integration updated with id [%s] in the [%T]", discordIntegration.ID, service.repository))
@@ -231,8 +221,7 @@ func (service *DiscordService) HandleMessageReceived(ctx context.Context, userID
 
 	discordIntegrations, err := service.repository.FetchHavingIncomingChannel(ctx, userID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load discord integrations for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "cannot load discord integrations for user with ID [%s]", userID))
 	}
 
 	if len(discordIntegrations) == 0 {
@@ -259,15 +248,14 @@ func (service *DiscordService) sendMessage(ctx context.Context, event cloudevent
 
 	payload := new(events.MessagePhoneReceivedPayload)
 	if err := event.DataAs(payload); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
 		return
 	}
 
 	request := service.createDiscordMessage(ctxLogger, payload)
 	message, response, err := service.client.Channel.CreateMessage(ctx, discord.IncomingChannelID, request)
 	if err != nil {
-		msg := fmt.Sprintf("cannot send [%s] event to discord channel [%s] for user [%s]", event.Type(), discord.IncomingChannelID, discord.UserID)
-		ctxLogger.Warn(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Warn(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot send [%s] event to discord channel [%s] for user [%s]", event.Type(), discord.IncomingChannelID, discord.UserID)))
 
 		eventPayload := &events.DiscordSendFailedPayload{
 			DiscordID:        discord.ID,
@@ -327,14 +315,12 @@ func (service *DiscordService) handleDiscordMessageFailed(ctx context.Context, s
 
 	event, err := service.createEvent(events.EventTypeDiscordSendFailed, source, payload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event [%s] for user with id [%s]", events.EventTypeDiscordSendFailed, payload.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create event [%s] for user with id [%s]", events.EventTypeDiscordSendFailed, payload.UserID)))
 		return
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event [%s] for user with id [%s]", event.Type(), payload.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event [%s] for user with id [%s]", event.Type(), payload.UserID)))
 		return
 	}
 

--- a/api/pkg/services/email_notification_service.go
+++ b/api/pkg/services/email_notification_service.go
@@ -66,8 +66,7 @@ func (service *EmailNotificationService) NotifyMessageExpired(ctx context.Contex
 
 	user, err := service.userRepository.Load(ctx, payload.UserID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with ID [%s] and for expired message with ID [%s]", payload.UserID, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "cannot load user with ID [%s] and for expired message with ID [%s]", payload.UserID, payload.MessageID))
 	}
 
 	if !user.NotificationMessageStatusEnabled {
@@ -77,13 +76,11 @@ func (service *EmailNotificationService) NotifyMessageExpired(ctx context.Contex
 
 	email, err := service.factory.MessageExpired(user, payload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create email for user with ID [%s] and for expired message with ID [%s]", payload.UserID, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create email for user with ID [%s] and for expired message with ID [%s]", payload.UserID, payload.MessageID))
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
-		msg := fmt.Sprintf("cannot send email for user with ID [%s] and for expired message with ID [%s]", payload.UserID, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot send email for user with ID [%s] and for expired message with ID [%s]", payload.UserID, payload.MessageID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("[%s] email sent to [%s] for message with ID [%s]", events.EventTypeMessageSendExpired, user.ID, payload.MessageID))
@@ -104,8 +101,7 @@ func (service *EmailNotificationService) NotifyMessageFailed(ctx context.Context
 
 	user, err := service.userRepository.Load(ctx, payload.UserID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with ID [%s] for [%s] message with ID [%s]", payload.UserID, events.EventTypeMessageSendFailed, payload.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "cannot load user with ID [%s] for [%s] message with ID [%s]", payload.UserID, events.EventTypeMessageSendFailed, payload.ID))
 	}
 
 	if !user.NotificationMessageStatusEnabled {
@@ -115,13 +111,11 @@ func (service *EmailNotificationService) NotifyMessageFailed(ctx context.Context
 
 	email, err := service.factory.MessageFailed(user, payload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create email for user with ID [%s] for [%s] message with ID [%s]", payload.UserID, events.EventTypeMessageSendFailed, payload.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create email for user with ID [%s] for [%s] message with ID [%s]", payload.UserID, events.EventTypeMessageSendFailed, payload.ID))
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
-		msg := fmt.Sprintf("cannot send email for user with ID [%s] for [%s] message with ID [%s]", payload.UserID, events.EventTypeMessageSendFailed, payload.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot send email for user with ID [%s] for [%s] message with ID [%s]", payload.UserID, events.EventTypeMessageSendFailed, payload.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("[%s] email sent to [%s] for message with ID [%s]", events.EventTypeMessageSendFailed, user.ID, payload.ID))
@@ -142,8 +136,7 @@ func (service *EmailNotificationService) NotifyWebhookSendFailed(ctx context.Con
 
 	user, err := service.userRepository.Load(ctx, payload.UserID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with ID [%s] for [%s] event with ID [%s]", payload.UserID, events.EventTypeWebhookSendFailed, payload.EventID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "cannot load user with ID [%s] for [%s] event with ID [%s]", payload.UserID, events.EventTypeWebhookSendFailed, payload.EventID))
 	}
 
 	if !user.NotificationWebhookEnabled {
@@ -153,13 +146,11 @@ func (service *EmailNotificationService) NotifyWebhookSendFailed(ctx context.Con
 
 	email, err := service.factory.WebhookSendFailed(user, payload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create [%s] email for user with ID [%s] for [%s] event with ID [%s]", events.EventTypeWebhookSendFailed, payload.UserID, payload.EventType, payload.EventID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create [%s] email for user with ID [%s] for [%s] event with ID [%s]", events.EventTypeWebhookSendFailed, payload.UserID, payload.EventType, payload.EventID))
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
-		msg := fmt.Sprintf("cannot send [%s] email for user with ID [%s] for [%s] event with ID [%s]", events.EventTypeWebhookSendFailed, payload.UserID, payload.EventType, payload.EventID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot send [%s] email for user with ID [%s] for [%s] event with ID [%s]", events.EventTypeWebhookSendFailed, payload.UserID, payload.EventType, payload.EventID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("[%s] email sent to [%s] for [%s] event with ID [%s]", events.EventTypeWebhookSendFailed, user.ID, payload.EventType, payload.EventID))
@@ -180,8 +171,7 @@ func (service *EmailNotificationService) NotifyDiscordSendFailed(ctx context.Con
 
 	user, err := service.userRepository.Load(ctx, payload.UserID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with ID [%s] for [%s] event for message with ID [%s]", payload.UserID, payload.EventType, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "cannot load user with ID [%s] for [%s] event for message with ID [%s]", payload.UserID, payload.EventType, payload.MessageID))
 	}
 
 	if !user.NotificationWebhookEnabled {
@@ -191,13 +181,11 @@ func (service *EmailNotificationService) NotifyDiscordSendFailed(ctx context.Con
 
 	email, err := service.factory.DiscordSendFailed(user, payload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create email for user with ID [%s] for [%s] event and message with ID  [%s]", payload.UserID, payload.EventType, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create email for user with ID [%s] for [%s] event and message with ID  [%s]", payload.UserID, payload.EventType, payload.MessageID))
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
-		msg := fmt.Sprintf("cannot send email for user with ID [%s] for [%s] message with ID [%s]", payload.UserID, events.EventTypeMessageSendFailed, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot send email for user with ID [%s] for [%s] message with ID [%s]", payload.UserID, events.EventTypeMessageSendFailed, payload.MessageID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("[%s] email sent to [%s] for [%s] event with ID [%s]", payload.EventType, user.ID, payload.EventType, payload.MessageID))
@@ -221,6 +209,6 @@ func (service *EmailNotificationService) addToCache(ctx context.Context, timeout
 
 	cacheKey := service.getCacheKey(event, owner)
 	if err := service.cache.Set(ctx, cacheKey, "", timeout); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot set item in redis with key [%s] for owner [%s]", cacheKey, owner)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot set item in redis with key [%s] for owner [%s]", cacheKey, owner))
 	}
 }

--- a/api/pkg/services/email_notification_service.go
+++ b/api/pkg/services/email_notification_service.go
@@ -67,7 +67,7 @@ func (service *EmailNotificationService) NotifyMessageExpired(ctx context.Contex
 	user, err := service.userRepository.Load(ctx, payload.UserID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with ID [%s] and for expired message with ID [%s]", payload.UserID, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	if !user.NotificationMessageStatusEnabled {
@@ -78,12 +78,12 @@ func (service *EmailNotificationService) NotifyMessageExpired(ctx context.Contex
 	email, err := service.factory.MessageExpired(user, payload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot create email for user with ID [%s] and for expired message with ID [%s]", payload.UserID, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
 		msg := fmt.Sprintf("cannot send email for user with ID [%s] and for expired message with ID [%s]", payload.UserID, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("[%s] email sent to [%s] for message with ID [%s]", events.EventTypeMessageSendExpired, user.ID, payload.MessageID))
@@ -104,8 +104,8 @@ func (service *EmailNotificationService) NotifyMessageFailed(ctx context.Context
 
 	user, err := service.userRepository.Load(ctx, payload.UserID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with ID [%s] for [%s] message with ID [%s]", payload.UserID, payload.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		msg := fmt.Sprintf("cannot load user with ID [%s] for [%s] message with ID [%s]", payload.UserID, events.EventTypeMessageSendFailed, payload.ID)
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	if !user.NotificationMessageStatusEnabled {
@@ -115,13 +115,13 @@ func (service *EmailNotificationService) NotifyMessageFailed(ctx context.Context
 
 	email, err := service.factory.MessageFailed(user, payload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create email for user with ID [%s] for [%s] message with ID [%s]", payload.UserID, payload.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		msg := fmt.Sprintf("cannot create email for user with ID [%s] for [%s] message with ID [%s]", payload.UserID, events.EventTypeMessageSendFailed, payload.ID)
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
 		msg := fmt.Sprintf("cannot send email for user with ID [%s] for [%s] message with ID [%s]", payload.UserID, events.EventTypeMessageSendFailed, payload.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("[%s] email sent to [%s] for message with ID [%s]", events.EventTypeMessageSendFailed, user.ID, payload.ID))
@@ -143,7 +143,7 @@ func (service *EmailNotificationService) NotifyWebhookSendFailed(ctx context.Con
 	user, err := service.userRepository.Load(ctx, payload.UserID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with ID [%s] for [%s] event with ID [%s]", payload.UserID, events.EventTypeWebhookSendFailed, payload.EventID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	if !user.NotificationWebhookEnabled {
@@ -154,12 +154,12 @@ func (service *EmailNotificationService) NotifyWebhookSendFailed(ctx context.Con
 	email, err := service.factory.WebhookSendFailed(user, payload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot create [%s] email for user with ID [%s] for [%s] event with ID [%s]", events.EventTypeWebhookSendFailed, payload.UserID, payload.EventType, payload.EventID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
 		msg := fmt.Sprintf("cannot send [%s] email for user with ID [%s] for [%s] event with ID [%s]", events.EventTypeWebhookSendFailed, payload.UserID, payload.EventType, payload.EventID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("[%s] email sent to [%s] for [%s] event with ID [%s]", events.EventTypeWebhookSendFailed, user.ID, payload.EventType, payload.EventID))
@@ -181,7 +181,7 @@ func (service *EmailNotificationService) NotifyDiscordSendFailed(ctx context.Con
 	user, err := service.userRepository.Load(ctx, payload.UserID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with ID [%s] for [%s] event for message with ID [%s]", payload.UserID, payload.EventType, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	if !user.NotificationWebhookEnabled {
@@ -192,12 +192,12 @@ func (service *EmailNotificationService) NotifyDiscordSendFailed(ctx context.Con
 	email, err := service.factory.DiscordSendFailed(user, payload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot create email for user with ID [%s] for [%s] event and message with ID  [%s]", payload.UserID, payload.EventType, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
 		msg := fmt.Sprintf("cannot send email for user with ID [%s] for [%s] message with ID [%s]", payload.UserID, events.EventTypeMessageSendFailed, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("[%s] email sent to [%s] for [%s] event with ID [%s]", payload.EventType, user.ID, payload.EventType, payload.MessageID))
@@ -221,6 +221,6 @@ func (service *EmailNotificationService) addToCache(ctx context.Context, timeout
 
 	cacheKey := service.getCacheKey(event, owner)
 	if err := service.cache.Set(ctx, cacheKey, "", timeout); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot set item in redis with key [%s] for owner [%s]", cacheKey, owner)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot set item in redis with key [%s] for owner [%s]", cacheKey, owner)))
 	}
 }

--- a/api/pkg/services/emulator_fcm_client.go
+++ b/api/pkg/services/emulator_fcm_client.go
@@ -77,7 +77,7 @@ func (c *EmulatorFCMClient) Send(ctx context.Context, message *messaging.Message
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot send FCM to emulator at [%s]", url))
+		return "", stacktrace.Propagate(err, "cannot send FCM to emulator at [%s]", url)
 	}
 	defer resp.Body.Close()
 

--- a/api/pkg/services/emulator_fcm_client.go
+++ b/api/pkg/services/emulator_fcm_client.go
@@ -77,7 +77,7 @@ func (c *EmulatorFCMClient) Send(ctx context.Context, message *messaging.Message
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", stacktrace.Propagate(err, fmt.Sprintf("cannot send FCM to emulator at [%s]", url))
+		return "", stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot send FCM to emulator at [%s]", url))
 	}
 	defer resp.Body.Close()
 

--- a/api/pkg/services/emulator_push_queue.go
+++ b/api/pkg/services/emulator_push_queue.go
@@ -74,7 +74,7 @@ func (queue *emulatorPushQueue) push(task PushQueueTask, queueID string) func() 
 		request.Header("Content-Type", "application/json")
 
 		if err := request.Fetch(ctx); err != nil {
-			queue.logger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot send http request to [%s] for queue task [%s]", task.URL, queueID)))
+			queue.logger.Error(stacktrace.Propagate(err, "cannot send http request to [%s] for queue task [%s]", task.URL, queueID))
 			return
 		}
 

--- a/api/pkg/services/emulator_push_queue.go
+++ b/api/pkg/services/emulator_push_queue.go
@@ -74,7 +74,7 @@ func (queue *emulatorPushQueue) push(task PushQueueTask, queueID string) func() 
 		request.Header("Content-Type", "application/json")
 
 		if err := request.Fetch(ctx); err != nil {
-			queue.logger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot send http request to [%s] for queue task [%s]", task.URL, queueID)))
+			queue.logger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot send http request to [%s] for queue task [%s]", task.URL, queueID)))
 			return
 		}
 

--- a/api/pkg/services/entitlement_service.go
+++ b/api/pkg/services/entitlement_service.go
@@ -79,7 +79,7 @@ func (service *EntitlementService) Check(
 	if err != nil {
 		return nil, service.tracer.WrapErrorSpan(
 			span,
-			stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load user [%s] for entitlement check", userID)),
+			stacktrace.Propagate(err, "cannot load user [%s] for entitlement check", userID),
 		)
 	}
 
@@ -92,7 +92,7 @@ func (service *EntitlementService) Check(
 	if err != nil {
 		return nil, service.tracer.WrapErrorSpan(
 			span,
-			stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot count entities [%s] for user [%s]", entityName, userID)),
+			stacktrace.Propagate(err, "cannot count entities [%s] for user [%s]", entityName, userID),
 		)
 	}
 

--- a/api/pkg/services/entitlement_service.go
+++ b/api/pkg/services/entitlement_service.go
@@ -79,7 +79,7 @@ func (service *EntitlementService) Check(
 	if err != nil {
 		return nil, service.tracer.WrapErrorSpan(
 			span,
-			stacktrace.Propagate(err, fmt.Sprintf("cannot load user [%s] for entitlement check", userID)),
+			stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load user [%s] for entitlement check", userID)),
 		)
 	}
 
@@ -92,7 +92,7 @@ func (service *EntitlementService) Check(
 	if err != nil {
 		return nil, service.tracer.WrapErrorSpan(
 			span,
-			stacktrace.Propagate(err, fmt.Sprintf("cannot count entities [%s] for user [%s]", entityName, userID)),
+			stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot count entities [%s] for user [%s]", entityName, userID)),
 		)
 	}
 

--- a/api/pkg/services/event_dispatcher_service.go
+++ b/api/pkg/services/event_dispatcher_service.go
@@ -54,7 +54,7 @@ func (dispatcher *EventDispatcher) DispatchSync(ctx context.Context, event cloud
 
 	if err := event.Validate(); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event with ID [%s] and type [%s] because it is invalid", event.ID(), event.Type())
-		return dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	dispatcher.Publish(ctx, event)
@@ -68,18 +68,18 @@ func (dispatcher *EventDispatcher) DispatchWithTimeout(ctx context.Context, even
 
 	if err = event.Validate(); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event with ID [%s] and type [%s] because it is invalid", event.ID(), event.Type())
-		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	task, err := dispatcher.createCloudTask(event)
 	if err != nil {
 		msg := fmt.Sprintf("cannot create cloud task for event [%s] with id [%s]", event.Type(), event.ID())
-		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if queueID, err = dispatcher.enqueue(ctx, event, task, timeout); err != nil {
 		msg := fmt.Sprintf("cannot enqueue event with ID [%s] and type [%s]", event.ID(), event.Type())
-		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return queueID, nil
@@ -92,7 +92,7 @@ func (dispatcher *EventDispatcher) enqueue(ctx context.Context, event cloudevent
 	queueID, err := dispatcher.queue.Enqueue(ctx, task, timeout)
 	if errors.Is(err, context.DeadlineExceeded) {
 		msg := fmt.Sprintf("cannot enqueue event with ID [%s] and type [%s] to [%T]", event.ID(), event.Type(), dispatcher.queue)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		queueID, err = fmt.Sprintf("local-%s", event.ID()), nil
 		time.AfterFunc(timeout, func() {
 			dispatcher.Publish(ctx, event)
@@ -139,7 +139,7 @@ func (dispatcher *EventDispatcher) Publish(ctx context.Context, event cloudevent
 		go func(ctx context.Context, sub events.EventListener) {
 			if err := sub(ctx, event); err != nil {
 				msg := fmt.Sprintf("subscriber [%T] cannot handle event [%s]", sub, event.Type())
-				ctxLogger.Error(stacktrace.Propagate(err, msg))
+				ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 			}
 			wg.Done()
 		}(ctx, sub)
@@ -169,7 +169,7 @@ func (dispatcher *EventDispatcher) addCloudEventAttributes(span trace.Span, even
 func (dispatcher *EventDispatcher) createCloudTask(event cloudevents.Event) (*PushQueueTask, error) {
 	eventContent, err := json.Marshal(event)
 	if err != nil {
-		return nil, stacktrace.Propagate(err, fmt.Sprintf("cannot marshall [%T] with ID [%s]", event, event.ID()))
+		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot marshall [%T] with ID [%s]", event, event.ID()))
 	}
 
 	return &PushQueueTask{

--- a/api/pkg/services/event_dispatcher_service.go
+++ b/api/pkg/services/event_dispatcher_service.go
@@ -53,8 +53,7 @@ func (dispatcher *EventDispatcher) DispatchSync(ctx context.Context, event cloud
 	defer span.End()
 
 	if err := event.Validate(); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event with ID [%s] and type [%s] because it is invalid", event.ID(), event.Type())
-		return dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event with ID [%s] and type [%s] because it is invalid", event.ID(), event.Type()))
 	}
 
 	dispatcher.Publish(ctx, event)
@@ -67,19 +66,16 @@ func (dispatcher *EventDispatcher) DispatchWithTimeout(ctx context.Context, even
 	defer span.End()
 
 	if err = event.Validate(); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event with ID [%s] and type [%s] because it is invalid", event.ID(), event.Type())
-		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event with ID [%s] and type [%s] because it is invalid", event.ID(), event.Type()))
 	}
 
 	task, err := dispatcher.createCloudTask(event)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create cloud task for event [%s] with id [%s]", event.Type(), event.ID())
-		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create cloud task for event [%s] with id [%s]", event.Type(), event.ID()))
 	}
 
 	if queueID, err = dispatcher.enqueue(ctx, event, task, timeout); err != nil {
-		msg := fmt.Sprintf("cannot enqueue event with ID [%s] and type [%s]", event.ID(), event.Type())
-		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return queueID, dispatcher.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot enqueue event with ID [%s] and type [%s]", event.ID(), event.Type()))
 	}
 
 	return queueID, nil
@@ -91,8 +87,7 @@ func (dispatcher *EventDispatcher) enqueue(ctx context.Context, event cloudevent
 
 	queueID, err := dispatcher.queue.Enqueue(ctx, task, timeout)
 	if errors.Is(err, context.DeadlineExceeded) {
-		msg := fmt.Sprintf("cannot enqueue event with ID [%s] and type [%s] to [%T]", event.ID(), event.Type(), dispatcher.queue)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot enqueue event with ID [%s] and type [%s] to [%T]", event.ID(), event.Type(), dispatcher.queue))
 		queueID, err = fmt.Sprintf("local-%s", event.ID()), nil
 		time.AfterFunc(timeout, func() {
 			dispatcher.Publish(ctx, event)
@@ -138,8 +133,7 @@ func (dispatcher *EventDispatcher) Publish(ctx context.Context, event cloudevent
 		wg.Add(1)
 		go func(ctx context.Context, sub events.EventListener) {
 			if err := sub(ctx, event); err != nil {
-				msg := fmt.Sprintf("subscriber [%T] cannot handle event [%s]", sub, event.Type())
-				ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+				ctxLogger.Error(stacktrace.Propagate(err, "subscriber [%T] cannot handle event [%s]", sub, event.Type()))
 			}
 			wg.Done()
 		}(ctx, sub)
@@ -169,7 +163,7 @@ func (dispatcher *EventDispatcher) addCloudEventAttributes(span trace.Span, even
 func (dispatcher *EventDispatcher) createCloudTask(event cloudevents.Event) (*PushQueueTask, error) {
 	eventContent, err := json.Marshal(event)
 	if err != nil {
-		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot marshall [%T] with ID [%s]", event, event.ID()))
+		return nil, stacktrace.Propagate(err, "cannot marshall [%T] with ID [%s]", event, event.ID())
 	}
 
 	return &PushQueueTask{

--- a/api/pkg/services/google_cloud_push_queue_service.go
+++ b/api/pkg/services/google_cloud_push_queue_service.go
@@ -81,9 +81,8 @@ func (queue *googlePushQueue) enqueueImpl(ctx context.Context, task *PushQueueTa
 
 	queueTask, err := queue.client.CreateTask(requestCtx, req)
 	if err != nil {
-		msg := fmt.Sprintf("cannot schedule task [%s] to URL [%s]", string(task.Body), task.URL)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
-		return queueID, queue.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot schedule task [%s] to URL [%s]", string(task.Body), task.URL))
+		return queueID, queue.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot schedule task [%s] to URL [%s]", string(task.Body), task.URL))
 	}
 
 	ctxLogger.Info(fmt.Sprintf(

--- a/api/pkg/services/google_cloud_push_queue_service.go
+++ b/api/pkg/services/google_cloud_push_queue_service.go
@@ -82,8 +82,8 @@ func (queue *googlePushQueue) enqueueImpl(ctx context.Context, task *PushQueueTa
 	queueTask, err := queue.client.CreateTask(requestCtx, req)
 	if err != nil {
 		msg := fmt.Sprintf("cannot schedule task [%s] to URL [%s]", string(task.Body), task.URL)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
-		return queueID, queue.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		return queueID, queue.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf(

--- a/api/pkg/services/heartbeat_service.go
+++ b/api/pkg/services/heartbeat_service.go
@@ -55,13 +55,11 @@ func (service *HeartbeatService) DeleteAllForUser(ctx context.Context, userID en
 	defer span.End()
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
-		msg := fmt.Sprintf("could not delete all [entities.Heartbeat] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not delete all [entities.Heartbeat] for user with ID [%s]", userID))
 	}
 
 	if err := service.monitorRepository.DeleteAllForUser(ctx, userID); err != nil {
-		msg := fmt.Sprintf("could not delete all [entities.HeartbeatMonitor] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not delete all [entities.HeartbeatMonitor] for user with ID [%s]", userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.Heartbeat] and [entities.HeartbeatMonitor] for user with ID [%s]", userID))
@@ -77,8 +75,7 @@ func (service *HeartbeatService) Index(ctx context.Context, userID entities.User
 
 	heartbeats, err := service.repository.Index(ctx, userID, owner, params)
 	if err != nil {
-		msg := fmt.Sprintf("could not fetch heartbeats with parms [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not fetch heartbeats with parms [%+#v]", params))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] messages with prams [%+#v]", len(*heartbeats), params))
@@ -112,8 +109,7 @@ func (service *HeartbeatService) Store(ctx context.Context, params HeartbeatStor
 	}
 
 	if err := service.repository.Store(ctx, heartbeat); err != nil {
-		msg := fmt.Sprintf("cannot save heartbeat with id [%s]", heartbeat.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save heartbeat with id [%s]", heartbeat.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("heartbeat saved with id [%s] for user [%s]", heartbeat.ID, heartbeat.UserID))
@@ -124,8 +120,7 @@ func (service *HeartbeatService) Store(ctx context.Context, params HeartbeatStor
 		return heartbeat, nil
 	}
 	if err != nil {
-		msg := fmt.Sprintf("cannot load heartbeat monitor for owner [%s] and user [%s]", params.Owner, params.UserID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot load heartbeat monitor for owner [%s] and user [%s]", params.Owner, params.UserID))
 		return heartbeat, nil
 	}
 
@@ -150,8 +145,7 @@ func (service *HeartbeatService) handleHeartbeatWhenPhoneWasOffline(ctx context.
 	defer span.End()
 
 	if err := service.UpdatePhoneOnline(ctx, monitor.UserID, monitor.ID, true); err != nil {
-		msg := fmt.Sprintf("cannot update phone online status for heartbeat monitor [%s]", monitor.ID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update phone online status for heartbeat monitor [%s]", monitor.ID)))
 	}
 
 	event, err := service.createEvent(events.EventTypePhoneHeartbeatOnline, source, &events.PhoneHeartbeatOnlinePayload{
@@ -163,14 +157,12 @@ func (service *HeartbeatService) handleHeartbeatWhenPhoneWasOffline(ctx context.
 		Owner:                  heartbeat.Owner,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create [%s] event for monitor with ID [%s]", events.EventTypePhoneHeartbeatOnline, monitor.ID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create [%s] event for monitor with ID [%s]", events.EventTypePhoneHeartbeatOnline, monitor.ID)))
 		return
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event [%s] for heartbeat monitor with phone id [%s]", event.Type(), monitor.PhoneID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event [%s] for heartbeat monitor with phone id [%s]", event.Type(), monitor.PhoneID)))
 		return
 	}
 
@@ -185,8 +177,7 @@ func (service *HeartbeatService) StoreMonitor(ctx context.Context, params *Heart
 
 	monitor, scheduleCheck, err := service.phoneMonitor(ctx, params)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create monitor for with userID [%s] and owner [%s]", params.UserID, params.Owner)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create monitor for with userID [%s] and owner [%s]", params.UserID, params.Owner))
 	}
 
 	if !scheduleCheck {
@@ -204,8 +195,7 @@ func (service *HeartbeatService) StoreMonitor(ctx context.Context, params *Heart
 		Source:    params.Source,
 	}
 	if err = service.scheduleHeartbeatCheck(ctx, time.Now().UTC(), monitorParams); err != nil {
-		msg := fmt.Sprintf("cannot schedule healthcheck for monitor [%s] with owner [%s] and userID [%s]", monitor.ID, params.Owner, params.UserID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot schedule healthcheck for monitor [%s] with owner [%s] and userID [%s]", monitor.ID, params.Owner, params.UserID))
 	}
 
 	return monitor, nil
@@ -228,8 +218,7 @@ func (service *HeartbeatService) phoneMonitor(ctx context.Context, params *Heart
 		}
 
 		if err = service.monitorRepository.Store(ctx, monitor); err != nil {
-			msg := fmt.Sprintf("cannot save heartbeat monitor for owner [%s] and user [%s]", monitor.Owner, monitor.UserID)
-			return nil, false, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+			return nil, false, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save heartbeat monitor for owner [%s] and user [%s]", monitor.Owner, monitor.UserID))
 		}
 
 		ctxLogger.Info(fmt.Sprintf("heartbeat monitor saved with id [%s] for owner [%s] and user [%s]", monitor.ID, monitor.Owner, monitor.UserID))
@@ -237,8 +226,7 @@ func (service *HeartbeatService) phoneMonitor(ctx context.Context, params *Heart
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot check if monitor exists with userID [%s] and owner [%s]", params.UserID, params.Owner)
-		return nil, false, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, false, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot check if monitor exists with userID [%s] and owner [%s]", params.UserID, params.Owner))
 	}
 
 	return monitor, monitor.RequiresCheck(), nil
@@ -252,8 +240,7 @@ func (service *HeartbeatService) DeleteMonitor(ctx context.Context, userID entit
 	ctxLogger := service.tracer.CtxLogger(service.logger, span)
 
 	if err := service.monitorRepository.Delete(ctx, userID, owner); err != nil {
-		msg := fmt.Sprintf("cannot delete heartbeat monitor with userID [%s] and owner [%s]", userID, owner)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete heartbeat monitor with userID [%s] and owner [%s]", userID, owner))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("heartbeat monitor deleted for userID [%s] and owner [%s]", userID, owner))
@@ -268,8 +255,7 @@ func (service *HeartbeatService) UpdatePhoneOnline(ctx context.Context, userID e
 	ctxLogger := service.tracer.CtxLogger(service.logger, span)
 
 	if err := service.monitorRepository.UpdatePhoneOnline(ctx, userID, monitorID, phoneOnline); err != nil {
-		msg := fmt.Sprintf("cannot update heartbeat monitor [%s] with userID [%s] and status [%t]", monitorID, userID, phoneOnline)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update heartbeat monitor [%s] with userID [%s] and status [%t]", monitorID, userID, phoneOnline))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("heartbeat monitor [%s] updated for userID [%s] and status [%t]", monitorID, userID, phoneOnline))
@@ -299,8 +285,7 @@ func (service *HeartbeatService) Monitor(ctx context.Context, params *HeartbeatM
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot check if monitor exists with userID [%s] and owner [%s]", params.UserID, params.Owner)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot check if monitor exists with userID [%s] and owner [%s]", params.UserID, params.Owner))
 		return service.scheduleHeartbeatCheck(ctx, time.Now().UTC(), params)
 	}
 
@@ -310,8 +295,7 @@ func (service *HeartbeatService) Monitor(ctx context.Context, params *HeartbeatM
 
 	heartbeat, err := service.repository.Last(ctx, params.UserID, params.Owner)
 	if err != nil {
-		msg := fmt.Sprintf("cannot fetch last heartbeat for userID [%s] and owner [%s] and ID [%s] removing check", params.UserID, params.Owner, params.MonitorID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot fetch last heartbeat for userID [%s] and owner [%s] and ID [%s] removing check", params.UserID, params.Owner, params.MonitorID))
 		return nil
 	}
 
@@ -342,14 +326,12 @@ func (service *HeartbeatService) handleMissedMonitor(ctx context.Context, lastTi
 		Owner:                  params.Owner,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event when phone monitor [%s] missed heartbeat", params.MonitorID.String())
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create event when phone monitor [%s] missed heartbeat", params.MonitorID.String())))
 		return
 	}
 
 	if _, err = service.dispatcher.DispatchWithTimeout(ctx, event, heartbeatCheckInterval); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event [%s] for heartbeat monitor with phone id [%s]", event.Type(), params.PhoneID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event [%s] for heartbeat monitor with phone id [%s]", event.Type(), params.PhoneID)))
 	}
 }
 
@@ -359,8 +341,7 @@ func (service *HeartbeatService) handleFailedMonitor(ctx context.Context, lastTi
 
 	err := service.scheduleHeartbeatCheck(ctx, time.Now().UTC(), params)
 	if err != nil {
-		msg := fmt.Sprintf("cannot schedule healthcheck for monitor with owner [%s] and userID [%s]", params.Owner, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot schedule healthcheck for monitor with owner [%s] and userID [%s]", params.Owner, params.UserID))
 	}
 
 	event, err := service.createPhoneHeartbeatOfflineEvent(params.Source, &events.PhoneHeartbeatOfflinePayload{
@@ -372,13 +353,11 @@ func (service *HeartbeatService) handleFailedMonitor(ctx context.Context, lastTi
 		Owner:                  params.Owner,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event when phone monitor failed")
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create event when phone monitor failed"))
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event [%s] for heartbeat monitor with phone id [%s]", event.Type(), params.PhoneID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event [%s] for heartbeat monitor with phone id [%s]", event.Type(), params.PhoneID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("heartbeat monitor with id [%s] and phone id [%s] failed for user [%s]", params.MonitorID, params.PhoneID, params.UserID))
@@ -397,19 +376,16 @@ func (service *HeartbeatService) scheduleHeartbeatCheck(ctx context.Context, las
 		Owner:       params.Owner,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event when phone monitor failed")
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create event when phone monitor failed"))
 	}
 
 	queueID, err := service.dispatcher.DispatchWithTimeout(ctx, event, heartbeatCheckInterval)
 	if err != nil {
-		msg := fmt.Sprintf("cannot dispatch event [%s] for heartbeat monitor with phone id [%s]", event.Type(), params.PhoneID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event [%s] for heartbeat monitor with phone id [%s]", event.Type(), params.PhoneID))
 	}
 
 	if err = service.monitorRepository.UpdateQueueID(ctx, params.MonitorID, queueID); err != nil {
-		msg := fmt.Sprintf("cannot update monitor with id [%s] with queue with ID [%s]", params.MonitorID, queueID)
-		service.logger.Error(stacktrace.Propagate(err, "%s", msg))
+		service.logger.Error(stacktrace.Propagate(err, "cannot update monitor with id [%s] with queue with ID [%s]", params.MonitorID, queueID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("heartbeat check scheduled for monitor with id [%s] and phone id [%s] and queue id [%s] for user [%s]", params.MonitorID, params.PhoneID, queueID, params.UserID))

--- a/api/pkg/services/heartbeat_service.go
+++ b/api/pkg/services/heartbeat_service.go
@@ -56,12 +56,12 @@ func (service *HeartbeatService) DeleteAllForUser(ctx context.Context, userID en
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
 		msg := fmt.Sprintf("could not delete all [entities.Heartbeat] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := service.monitorRepository.DeleteAllForUser(ctx, userID); err != nil {
 		msg := fmt.Sprintf("could not delete all [entities.HeartbeatMonitor] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.Heartbeat] and [entities.HeartbeatMonitor] for user with ID [%s]", userID))
@@ -78,7 +78,7 @@ func (service *HeartbeatService) Index(ctx context.Context, userID entities.User
 	heartbeats, err := service.repository.Index(ctx, userID, owner, params)
 	if err != nil {
 		msg := fmt.Sprintf("could not fetch heartbeats with parms [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] messages with prams [%+#v]", len(*heartbeats), params))
@@ -113,7 +113,7 @@ func (service *HeartbeatService) Store(ctx context.Context, params HeartbeatStor
 
 	if err := service.repository.Store(ctx, heartbeat); err != nil {
 		msg := fmt.Sprintf("cannot save heartbeat with id [%s]", heartbeat.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("heartbeat saved with id [%s] for user [%s]", heartbeat.ID, heartbeat.UserID))
@@ -125,7 +125,7 @@ func (service *HeartbeatService) Store(ctx context.Context, params HeartbeatStor
 	}
 	if err != nil {
 		msg := fmt.Sprintf("cannot load heartbeat monitor for owner [%s] and user [%s]", params.Owner, params.UserID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return heartbeat, nil
 	}
 
@@ -151,7 +151,7 @@ func (service *HeartbeatService) handleHeartbeatWhenPhoneWasOffline(ctx context.
 
 	if err := service.UpdatePhoneOnline(ctx, monitor.UserID, monitor.ID, true); err != nil {
 		msg := fmt.Sprintf("cannot update phone online status for heartbeat monitor [%s]", monitor.ID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 	}
 
 	event, err := service.createEvent(events.EventTypePhoneHeartbeatOnline, source, &events.PhoneHeartbeatOnlinePayload{
@@ -164,13 +164,13 @@ func (service *HeartbeatService) handleHeartbeatWhenPhoneWasOffline(ctx context.
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create [%s] event for monitor with ID [%s]", events.EventTypePhoneHeartbeatOnline, monitor.ID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event [%s] for heartbeat monitor with phone id [%s]", event.Type(), monitor.PhoneID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return
 	}
 
@@ -186,7 +186,7 @@ func (service *HeartbeatService) StoreMonitor(ctx context.Context, params *Heart
 	monitor, scheduleCheck, err := service.phoneMonitor(ctx, params)
 	if err != nil {
 		msg := fmt.Sprintf("cannot create monitor for with userID [%s] and owner [%s]", params.UserID, params.Owner)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if !scheduleCheck {
@@ -205,7 +205,7 @@ func (service *HeartbeatService) StoreMonitor(ctx context.Context, params *Heart
 	}
 	if err = service.scheduleHeartbeatCheck(ctx, time.Now().UTC(), monitorParams); err != nil {
 		msg := fmt.Sprintf("cannot schedule healthcheck for monitor [%s] with owner [%s] and userID [%s]", monitor.ID, params.Owner, params.UserID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return monitor, nil
@@ -229,7 +229,7 @@ func (service *HeartbeatService) phoneMonitor(ctx context.Context, params *Heart
 
 		if err = service.monitorRepository.Store(ctx, monitor); err != nil {
 			msg := fmt.Sprintf("cannot save heartbeat monitor for owner [%s] and user [%s]", monitor.Owner, monitor.UserID)
-			return nil, false, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+			return nil, false, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 		}
 
 		ctxLogger.Info(fmt.Sprintf("heartbeat monitor saved with id [%s] for owner [%s] and user [%s]", monitor.ID, monitor.Owner, monitor.UserID))
@@ -238,7 +238,7 @@ func (service *HeartbeatService) phoneMonitor(ctx context.Context, params *Heart
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot check if monitor exists with userID [%s] and owner [%s]", params.UserID, params.Owner)
-		return nil, false, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, false, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return monitor, monitor.RequiresCheck(), nil
@@ -253,7 +253,7 @@ func (service *HeartbeatService) DeleteMonitor(ctx context.Context, userID entit
 
 	if err := service.monitorRepository.Delete(ctx, userID, owner); err != nil {
 		msg := fmt.Sprintf("cannot delete heartbeat monitor with userID [%s] and owner [%s]", userID, owner)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("heartbeat monitor deleted for userID [%s] and owner [%s]", userID, owner))
@@ -269,7 +269,7 @@ func (service *HeartbeatService) UpdatePhoneOnline(ctx context.Context, userID e
 
 	if err := service.monitorRepository.UpdatePhoneOnline(ctx, userID, monitorID, phoneOnline); err != nil {
 		msg := fmt.Sprintf("cannot update heartbeat monitor [%s] with userID [%s] and status [%t]", monitorID, userID, phoneOnline)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("heartbeat monitor [%s] updated for userID [%s] and status [%t]", monitorID, userID, phoneOnline))
@@ -300,7 +300,7 @@ func (service *HeartbeatService) Monitor(ctx context.Context, params *HeartbeatM
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot check if monitor exists with userID [%s] and owner [%s]", params.UserID, params.Owner)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return service.scheduleHeartbeatCheck(ctx, time.Now().UTC(), params)
 	}
 
@@ -311,7 +311,7 @@ func (service *HeartbeatService) Monitor(ctx context.Context, params *HeartbeatM
 	heartbeat, err := service.repository.Last(ctx, params.UserID, params.Owner)
 	if err != nil {
 		msg := fmt.Sprintf("cannot fetch last heartbeat for userID [%s] and owner [%s] and ID [%s] removing check", params.UserID, params.Owner, params.MonitorID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return nil
 	}
 
@@ -343,13 +343,13 @@ func (service *HeartbeatService) handleMissedMonitor(ctx context.Context, lastTi
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event when phone monitor [%s] missed heartbeat", params.MonitorID.String())
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return
 	}
 
 	if _, err = service.dispatcher.DispatchWithTimeout(ctx, event, heartbeatCheckInterval); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event [%s] for heartbeat monitor with phone id [%s]", event.Type(), params.PhoneID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 	}
 }
 
@@ -360,7 +360,7 @@ func (service *HeartbeatService) handleFailedMonitor(ctx context.Context, lastTi
 	err := service.scheduleHeartbeatCheck(ctx, time.Now().UTC(), params)
 	if err != nil {
 		msg := fmt.Sprintf("cannot schedule healthcheck for monitor with owner [%s] and userID [%s]", params.Owner, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	event, err := service.createPhoneHeartbeatOfflineEvent(params.Source, &events.PhoneHeartbeatOfflinePayload{
@@ -373,12 +373,12 @@ func (service *HeartbeatService) handleFailedMonitor(ctx context.Context, lastTi
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event when phone monitor failed")
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event [%s] for heartbeat monitor with phone id [%s]", event.Type(), params.PhoneID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("heartbeat monitor with id [%s] and phone id [%s] failed for user [%s]", params.MonitorID, params.PhoneID, params.UserID))
@@ -398,18 +398,18 @@ func (service *HeartbeatService) scheduleHeartbeatCheck(ctx context.Context, las
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event when phone monitor failed")
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	queueID, err := service.dispatcher.DispatchWithTimeout(ctx, event, heartbeatCheckInterval)
 	if err != nil {
 		msg := fmt.Sprintf("cannot dispatch event [%s] for heartbeat monitor with phone id [%s]", event.Type(), params.PhoneID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.monitorRepository.UpdateQueueID(ctx, params.MonitorID, queueID); err != nil {
 		msg := fmt.Sprintf("cannot update monitor with id [%s] with queue with ID [%s]", params.MonitorID, queueID)
-		service.logger.Error(stacktrace.Propagate(err, msg))
+		service.logger.Error(stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("heartbeat check scheduled for monitor with id [%s] and phone id [%s] and queue id [%s] for user [%s]", params.MonitorID, params.PhoneID, queueID, params.UserID))

--- a/api/pkg/services/integration_3cx_service.go
+++ b/api/pkg/services/integration_3cx_service.go
@@ -49,8 +49,7 @@ func (service *Integration3CXService) DeleteAllForUser(ctx context.Context, user
 	defer span.End()
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
-		msg := fmt.Sprintf("could not delete all [entities.Integration3CX] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not delete all [entities.Integration3CX] for user with ID [%s]", userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.Integration3CX] for user with ID [%s]", userID))
@@ -69,8 +68,7 @@ func (service *Integration3CXService) Send(ctx context.Context, userID entities.
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load [3cx] integration for user [%s] and event [%s]", userID, event.Type())
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "cannot load [3cx] integration for user [%s] and event [%s]", userID, event.Type()))
 	}
 
 	service.sendNotification(ctx, event, webhooks)
@@ -86,29 +84,25 @@ func (service *Integration3CXService) sendNotification(ctx context.Context, even
 
 	payload, err := service.getPayload(event)
 	if err != nil {
-		msg := fmt.Sprintf("cannot generate [3cx] payload from [%s] event with ID [%s] for user [%s]", event.Type(), event.ID(), integration.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot generate [3cx] payload from [%s] event with ID [%s] for user [%s]", event.Type(), event.ID(), integration.UserID)))
 		return
 	}
 
 	body, err := json.Marshal(payload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot marshal [%T] for  [%s] event with ID [%s] for user [%s]", payload, event.Type(), event.ID(), integration.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot marshal [%T] for  [%s] event with ID [%s] for user [%s]", payload, event.Type(), event.ID(), integration.UserID)))
 	}
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, integration.WebhookURL, bytes.NewBuffer(body))
 	if err != nil {
-		msg := fmt.Sprintf("cannot create [%T] for [%s] event with ID [%s] for user [%s]", request, event.Type(), event.ID(), integration.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create [%T] for [%s] event with ID [%s] for user [%s]", request, event.Type(), event.ID(), integration.UserID)))
 		return
 	}
 	request.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
 	response, err := service.client.Do(request)
 	if err != nil {
-		msg := fmt.Sprintf("cannot send [%s] event to [3cx] webhook [%s] for user [%s]", event.Type(), integration.WebhookURL, integration.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot send [%s] event to [3cx] webhook [%s] for user [%s]", event.Type(), integration.WebhookURL, integration.UserID)))
 	}
 	defer func() {
 		err = response.Body.Close()
@@ -141,14 +135,14 @@ func (service *Integration3CXService) getPayload(event cloudevents.Event) (fiber
 	case events.EventTypeMessageSendFailed:
 		return service.getMessageSendFailedPayload(event)
 	default:
-		return nil, stacktrace.NewError("%s", fmt.Sprintf("cannot generate [3cx] payload for event [%s] with ID [%s]", event.Type(), event.ID()))
+		return nil, stacktrace.NewError("cannot generate [3cx] payload for event [%s] with ID [%s]", event.Type(), event.ID())
 	}
 }
 
 func (service *Integration3CXService) getEventDeliveredPayload(event cloudevents.Event) (fiber.Map, error) {
 	payload := new(events.MessagePhoneDeliveredPayload)
 	if err := event.DataAs(payload); err != nil {
-		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
+		return nil, stacktrace.Propagate(err, "cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload)
 	}
 
 	return fiber.Map{
@@ -178,7 +172,7 @@ func (service *Integration3CXService) getEventDeliveredPayload(event cloudevents
 func (service *Integration3CXService) getMessageSentPayload(event cloudevents.Event) (fiber.Map, error) {
 	payload := new(events.MessagePhoneSentPayload)
 	if err := event.DataAs(payload); err != nil {
-		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
+		return nil, stacktrace.Propagate(err, "cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload)
 	}
 
 	return fiber.Map{
@@ -208,7 +202,7 @@ func (service *Integration3CXService) getMessageSentPayload(event cloudevents.Ev
 func (service *Integration3CXService) getMessageSendFailedPayload(event cloudevents.Event) (fiber.Map, error) {
 	payload := new(events.MessageSendFailedPayload)
 	if err := event.DataAs(payload); err != nil {
-		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
+		return nil, stacktrace.Propagate(err, "cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload)
 	}
 
 	return fiber.Map{
@@ -238,7 +232,7 @@ func (service *Integration3CXService) getMessageSendFailedPayload(event cloudeve
 func (service *Integration3CXService) getMessageReceivedPayload(event cloudevents.Event) (fiber.Map, error) {
 	payload := new(events.MessagePhoneReceivedPayload)
 	if err := event.DataAs(payload); err != nil {
-		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
+		return nil, stacktrace.Propagate(err, "cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload)
 	}
 
 	return fiber.Map{

--- a/api/pkg/services/integration_3cx_service.go
+++ b/api/pkg/services/integration_3cx_service.go
@@ -50,7 +50,7 @@ func (service *Integration3CXService) DeleteAllForUser(ctx context.Context, user
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
 		msg := fmt.Sprintf("could not delete all [entities.Integration3CX] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.Integration3CX] for user with ID [%s]", userID))
@@ -70,7 +70,7 @@ func (service *Integration3CXService) Send(ctx context.Context, userID entities.
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load [3cx] integration for user [%s] and event [%s]", userID, event.Type())
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	service.sendNotification(ctx, event, webhooks)
@@ -87,20 +87,20 @@ func (service *Integration3CXService) sendNotification(ctx context.Context, even
 	payload, err := service.getPayload(event)
 	if err != nil {
 		msg := fmt.Sprintf("cannot generate [3cx] payload from [%s] event with ID [%s] for user [%s]", event.Type(), event.ID(), integration.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return
 	}
 
 	body, err := json.Marshal(payload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot marshal [%T] for  [%s] event with ID [%s] for user [%s]", payload, event.Type(), event.ID(), integration.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 	}
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, integration.WebhookURL, bytes.NewBuffer(body))
 	if err != nil {
 		msg := fmt.Sprintf("cannot create [%T] for [%s] event with ID [%s] for user [%s]", request, event.Type(), event.ID(), integration.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return
 	}
 	request.Header.Set("Content-Type", "application/json; charset=UTF-8")
@@ -108,7 +108,7 @@ func (service *Integration3CXService) sendNotification(ctx context.Context, even
 	response, err := service.client.Do(request)
 	if err != nil {
 		msg := fmt.Sprintf("cannot send [%s] event to [3cx] webhook [%s] for user [%s]", event.Type(), integration.WebhookURL, integration.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 	}
 	defer func() {
 		err = response.Body.Close()
@@ -141,14 +141,14 @@ func (service *Integration3CXService) getPayload(event cloudevents.Event) (fiber
 	case events.EventTypeMessageSendFailed:
 		return service.getMessageSendFailedPayload(event)
 	default:
-		return nil, stacktrace.NewError(fmt.Sprintf("cannot generate [3cx] payload for event [%s] with ID [%s]", event.Type(), event.ID()))
+		return nil, stacktrace.NewError("%s", fmt.Sprintf("cannot generate [3cx] payload for event [%s] with ID [%s]", event.Type(), event.ID()))
 	}
 }
 
 func (service *Integration3CXService) getEventDeliveredPayload(event cloudevents.Event) (fiber.Map, error) {
 	payload := new(events.MessagePhoneDeliveredPayload)
 	if err := event.DataAs(payload); err != nil {
-		return nil, stacktrace.Propagate(err, fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
+		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
 	}
 
 	return fiber.Map{
@@ -178,7 +178,7 @@ func (service *Integration3CXService) getEventDeliveredPayload(event cloudevents
 func (service *Integration3CXService) getMessageSentPayload(event cloudevents.Event) (fiber.Map, error) {
 	payload := new(events.MessagePhoneSentPayload)
 	if err := event.DataAs(payload); err != nil {
-		return nil, stacktrace.Propagate(err, fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
+		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
 	}
 
 	return fiber.Map{
@@ -208,7 +208,7 @@ func (service *Integration3CXService) getMessageSentPayload(event cloudevents.Ev
 func (service *Integration3CXService) getMessageSendFailedPayload(event cloudevents.Event) (fiber.Map, error) {
 	payload := new(events.MessageSendFailedPayload)
 	if err := event.DataAs(payload); err != nil {
-		return nil, stacktrace.Propagate(err, fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
+		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
 	}
 
 	return fiber.Map{
@@ -238,7 +238,7 @@ func (service *Integration3CXService) getMessageSendFailedPayload(event cloudeve
 func (service *Integration3CXService) getMessageReceivedPayload(event cloudevents.Event) (fiber.Map, error) {
 	payload := new(events.MessagePhoneReceivedPayload)
 	if err := event.DataAs(payload); err != nil {
-		return nil, stacktrace.Propagate(err, fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
+		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
 	}
 
 	return fiber.Map{

--- a/api/pkg/services/lemonsqueezy_service.go
+++ b/api/pkg/services/lemonsqueezy_service.go
@@ -53,7 +53,7 @@ func (service *LemonsqueezyService) GetUserID(ctx context.Context, request *lemo
 	user, err := service.userRepository.LoadByEmail(ctx, request.Data.Attributes.UserEmail)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with email [%s]", request.Data.Attributes.UserEmail)
-		return "", service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return "", service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return user.ID, nil
@@ -67,7 +67,7 @@ func (service *LemonsqueezyService) HandleSubscriptionCreatedEvent(ctx context.C
 	userID, err := service.GetUserID(ctx, request)
 	if err != nil {
 		msg := fmt.Sprintf("cannot get user ID for subscription created event with ID [%s]", request.Data.ID)
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	payload := &events.UserSubscriptionCreatedPayload{
@@ -82,12 +82,12 @@ func (service *LemonsqueezyService) HandleSubscriptionCreatedEvent(ctx context.C
 	event, err := service.createEvent(events.UserSubscriptionCreated, source, payload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot create [%s] event for user [%s]", events.UserSubscriptionCreated, payload.UserID)
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", events.UserSubscriptionCreated, payload.UserID)
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 	ctxLogger.Info(fmt.Sprintf("[%s] subscription [%s] created for user [%s]", payload.SubscriptionName, payload.SubscriptionID, payload.UserID))
 	return nil
@@ -101,7 +101,7 @@ func (service *LemonsqueezyService) HandleSubscriptionCanceledEvent(ctx context.
 	user, err := service.userRepository.LoadBySubscriptionID(ctx, request.Data.ID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with subscription ID [%s]", request.Data.ID)
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	payload := &events.UserSubscriptionCancelledPayload{
@@ -116,12 +116,12 @@ func (service *LemonsqueezyService) HandleSubscriptionCanceledEvent(ctx context.
 	event, err := service.createEvent(events.UserSubscriptionCancelled, source, payload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot created [%s] event for user [%s]", events.UserSubscriptionCancelled, payload.UserID)
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", events.UserSubscriptionCancelled, payload.UserID)
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 	ctxLogger.Info(fmt.Sprintf("[%s] subscription [%s] cancelled for user [%s]", payload.SubscriptionName, payload.SubscriptionID, payload.UserID))
 	return nil
@@ -140,7 +140,7 @@ func (service *LemonsqueezyService) HandleSubscriptionUpdatedEvent(ctx context.C
 	user, err := service.userRepository.LoadBySubscriptionID(ctx, request.Data.ID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with subscription ID [%s]", request.Data.ID)
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	payload := &events.UserSubscriptionUpdatedPayload{
@@ -156,12 +156,12 @@ func (service *LemonsqueezyService) HandleSubscriptionUpdatedEvent(ctx context.C
 	event, err := service.createEvent(events.UserSubscriptionUpdated, source, payload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot created [%s] event for user [%s]", events.UserSubscriptionUpdated, payload.UserID)
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", event.Type(), payload.UserID)
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 	ctxLogger.Info(fmt.Sprintf("[%s] subscription [%s] updated for user [%s]", payload.SubscriptionName, payload.SubscriptionID, payload.UserID))
 	return nil
@@ -175,7 +175,7 @@ func (service *LemonsqueezyService) HandleSubscriptionExpiredEvent(ctx context.C
 	user, err := service.userRepository.LoadBySubscriptionID(ctx, request.Data.ID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with subscription ID [%s]", request.Data.ID)
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	payload := &events.UserSubscriptionExpiredPayload{
@@ -191,12 +191,12 @@ func (service *LemonsqueezyService) HandleSubscriptionExpiredEvent(ctx context.C
 	event, err := service.createEvent(events.UserSubscriptionExpired, source, payload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot created [%s] event for user [%s]", events.UserSubscriptionExpired, payload.UserID)
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", event.Type(), payload.UserID)
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 	ctxLogger.Info(fmt.Sprintf("[%s] subscription [%s] expired for user [%s]", payload.SubscriptionName, payload.SubscriptionID, payload.UserID))
 	return nil
@@ -242,6 +242,6 @@ func (service *LemonsqueezyService) subscriptionName(variant string) entities.Su
 		}
 	}
 
-	service.logger.Warn(stacktrace.NewError(fmt.Sprintf("unknown subscription variant [%s], defaulting to free", variant)))
+	service.logger.Warn(stacktrace.NewError("%s", fmt.Sprintf("unknown subscription variant [%s], defaulting to free", variant)))
 	return entities.SubscriptionNameFree
 }

--- a/api/pkg/services/lemonsqueezy_service.go
+++ b/api/pkg/services/lemonsqueezy_service.go
@@ -52,8 +52,7 @@ func (service *LemonsqueezyService) GetUserID(ctx context.Context, request *lemo
 	ctxLogger.Info(fmt.Sprintf("user_id not found in request meta data. Searching via email [%s]", request.Data.Attributes.UserEmail))
 	user, err := service.userRepository.LoadByEmail(ctx, request.Data.Attributes.UserEmail)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with email [%s]", request.Data.Attributes.UserEmail)
-		return "", service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return "", service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load user with email [%s]", request.Data.Attributes.UserEmail))
 	}
 
 	return user.ID, nil
@@ -66,8 +65,7 @@ func (service *LemonsqueezyService) HandleSubscriptionCreatedEvent(ctx context.C
 
 	userID, err := service.GetUserID(ctx, request)
 	if err != nil {
-		msg := fmt.Sprintf("cannot get user ID for subscription created event with ID [%s]", request.Data.ID)
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot get user ID for subscription created event with ID [%s]", request.Data.ID)
 	}
 
 	payload := &events.UserSubscriptionCreatedPayload{
@@ -81,13 +79,11 @@ func (service *LemonsqueezyService) HandleSubscriptionCreatedEvent(ctx context.C
 
 	event, err := service.createEvent(events.UserSubscriptionCreated, source, payload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create [%s] event for user [%s]", events.UserSubscriptionCreated, payload.UserID)
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot create [%s] event for user [%s]", events.UserSubscriptionCreated, payload.UserID)
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", events.UserSubscriptionCreated, payload.UserID)
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot dispatch [%s] event for user [%s]", events.UserSubscriptionCreated, payload.UserID)
 	}
 	ctxLogger.Info(fmt.Sprintf("[%s] subscription [%s] created for user [%s]", payload.SubscriptionName, payload.SubscriptionID, payload.UserID))
 	return nil
@@ -100,8 +96,7 @@ func (service *LemonsqueezyService) HandleSubscriptionCanceledEvent(ctx context.
 
 	user, err := service.userRepository.LoadBySubscriptionID(ctx, request.Data.ID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with subscription ID [%s]", request.Data.ID)
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot load user with subscription ID [%s]", request.Data.ID)
 	}
 
 	payload := &events.UserSubscriptionCancelledPayload{
@@ -115,13 +110,11 @@ func (service *LemonsqueezyService) HandleSubscriptionCanceledEvent(ctx context.
 
 	event, err := service.createEvent(events.UserSubscriptionCancelled, source, payload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot created [%s] event for user [%s]", events.UserSubscriptionCancelled, payload.UserID)
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot created [%s] event for user [%s]", events.UserSubscriptionCancelled, payload.UserID)
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", events.UserSubscriptionCancelled, payload.UserID)
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot dispatch [%s] event for user [%s]", events.UserSubscriptionCancelled, payload.UserID)
 	}
 	ctxLogger.Info(fmt.Sprintf("[%s] subscription [%s] cancelled for user [%s]", payload.SubscriptionName, payload.SubscriptionID, payload.UserID))
 	return nil
@@ -139,8 +132,7 @@ func (service *LemonsqueezyService) HandleSubscriptionUpdatedEvent(ctx context.C
 
 	user, err := service.userRepository.LoadBySubscriptionID(ctx, request.Data.ID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with subscription ID [%s]", request.Data.ID)
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot load user with subscription ID [%s]", request.Data.ID)
 	}
 
 	payload := &events.UserSubscriptionUpdatedPayload{
@@ -155,13 +147,11 @@ func (service *LemonsqueezyService) HandleSubscriptionUpdatedEvent(ctx context.C
 
 	event, err := service.createEvent(events.UserSubscriptionUpdated, source, payload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot created [%s] event for user [%s]", events.UserSubscriptionUpdated, payload.UserID)
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot created [%s] event for user [%s]", events.UserSubscriptionUpdated, payload.UserID)
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", event.Type(), payload.UserID)
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot dispatch [%s] event for user [%s]", event.Type(), payload.UserID)
 	}
 	ctxLogger.Info(fmt.Sprintf("[%s] subscription [%s] updated for user [%s]", payload.SubscriptionName, payload.SubscriptionID, payload.UserID))
 	return nil
@@ -174,8 +164,7 @@ func (service *LemonsqueezyService) HandleSubscriptionExpiredEvent(ctx context.C
 
 	user, err := service.userRepository.LoadBySubscriptionID(ctx, request.Data.ID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with subscription ID [%s]", request.Data.ID)
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot load user with subscription ID [%s]", request.Data.ID)
 	}
 
 	payload := &events.UserSubscriptionExpiredPayload{
@@ -190,13 +179,11 @@ func (service *LemonsqueezyService) HandleSubscriptionExpiredEvent(ctx context.C
 
 	event, err := service.createEvent(events.UserSubscriptionExpired, source, payload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot created [%s] event for user [%s]", events.UserSubscriptionExpired, payload.UserID)
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot created [%s] event for user [%s]", events.UserSubscriptionExpired, payload.UserID)
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", event.Type(), payload.UserID)
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot dispatch [%s] event for user [%s]", event.Type(), payload.UserID)
 	}
 	ctxLogger.Info(fmt.Sprintf("[%s] subscription [%s] expired for user [%s]", payload.SubscriptionName, payload.SubscriptionID, payload.UserID))
 	return nil
@@ -242,6 +229,6 @@ func (service *LemonsqueezyService) subscriptionName(variant string) entities.Su
 		}
 	}
 
-	service.logger.Warn(stacktrace.NewError("%s", fmt.Sprintf("unknown subscription variant [%s], defaulting to free", variant)))
+	service.logger.Warn(stacktrace.NewError("unknown subscription variant [%s], defaulting to free", variant))
 	return entities.SubscriptionNameFree
 }

--- a/api/pkg/services/marketting_service.go
+++ b/api/pkg/services/marketting_service.go
@@ -45,7 +45,7 @@ func (service *MarketingService) DeleteContact(ctx context.Context, email string
 
 	response, _, err := service.plunkClient.Contacts.List(ctx, map[string]string{"search": email})
 	if err != nil {
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot search for contact with email [%s]", email)))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot search for contact with email [%s]", email))
 	}
 
 	if len(response.Data) == 0 {
@@ -55,7 +55,7 @@ func (service *MarketingService) DeleteContact(ctx context.Context, email string
 
 	contact := response.Data[0]
 	if _, err = service.plunkClient.Contacts.Delete(ctx, contact.ID); err != nil {
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot delete user with ID [%s] from contacts", contact.Data[string(semconv.EnduserIDKey)])))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete user with ID [%s] from contacts", contact.Data[string(semconv.EnduserIDKey)]))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted user with ID [%s] from as marketting contact with ID [%s]", contact.Data[string(semconv.EnduserIDKey)], contact.ID))
@@ -69,8 +69,7 @@ func (service *MarketingService) CreateContact(ctx context.Context, userID entit
 
 	userRecord, err := service.authClient.GetUser(ctx, userID.String())
 	if err != nil {
-		msg := fmt.Sprintf("cannot get auth user with id [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot get auth user with id [%s]", userID))
 	}
 
 	data := service.attributes(userRecord)
@@ -84,8 +83,7 @@ func (service *MarketingService) CreateContact(ctx context.Context, userID entit
 		Data:       data,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create contact for user with id [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create contact for user with id [%s]", userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("user [%s] added to marketting list with contact ID [%s] and event ID [%s]", userID, event.Data.Contact, event.Data.Event))

--- a/api/pkg/services/marketting_service.go
+++ b/api/pkg/services/marketting_service.go
@@ -45,7 +45,7 @@ func (service *MarketingService) DeleteContact(ctx context.Context, email string
 
 	response, _, err := service.plunkClient.Contacts.List(ctx, map[string]string{"search": email})
 	if err != nil {
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, fmt.Sprintf("cannot search for contact with email [%s]", email)))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot search for contact with email [%s]", email)))
 	}
 
 	if len(response.Data) == 0 {
@@ -55,7 +55,7 @@ func (service *MarketingService) DeleteContact(ctx context.Context, email string
 
 	contact := response.Data[0]
 	if _, err = service.plunkClient.Contacts.Delete(ctx, contact.ID); err != nil {
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, fmt.Sprintf("cannot delete user with ID [%s] from contacts", contact.Data[string(semconv.EnduserIDKey)])))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot delete user with ID [%s] from contacts", contact.Data[string(semconv.EnduserIDKey)])))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted user with ID [%s] from as marketting contact with ID [%s]", contact.Data[string(semconv.EnduserIDKey)], contact.ID))
@@ -70,7 +70,7 @@ func (service *MarketingService) CreateContact(ctx context.Context, userID entit
 	userRecord, err := service.authClient.GetUser(ctx, userID.String())
 	if err != nil {
 		msg := fmt.Sprintf("cannot get auth user with id [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	data := service.attributes(userRecord)
@@ -85,7 +85,7 @@ func (service *MarketingService) CreateContact(ctx context.Context, userID entit
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create contact for user with id [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("user [%s] added to marketting list with contact ID [%s] and event ID [%s]", userID, event.Data.Contact, event.Data.Event))

--- a/api/pkg/services/message_send_schedule_service.go
+++ b/api/pkg/services/message_send_schedule_service.go
@@ -94,7 +94,7 @@ func (service *MessageSendScheduleService) Store(
 			span,
 			stacktrace.Propagate(
 				err,
-				fmt.Sprintf("cannot store message send schedule [%s]", schedule.ID),
+				"%s", fmt.Sprintf("cannot store message send schedule [%s]", schedule.ID),
 			),
 		)
 	}
@@ -127,7 +127,7 @@ func (service *MessageSendScheduleService) Update(
 			span,
 			stacktrace.Propagate(
 				err,
-				fmt.Sprintf("cannot update message send schedule [%s]", schedule.ID),
+				"%s", fmt.Sprintf("cannot update message send schedule [%s]", schedule.ID),
 			),
 		)
 	}
@@ -146,7 +146,7 @@ func (service *MessageSendScheduleService) Delete(
 
 	if err := service.repository.Delete(ctx, userID, scheduleID); err != nil {
 		msg := fmt.Sprintf("cannot delete message send schedule with ID [%s] for user [%s]", scheduleID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	event, err := service.createEvent(events.EventTypeMessageSendScheduleDeleted, fmt.Sprintf("%T", service), events.MessageSendScheduleDeletedPayload{
@@ -156,12 +156,12 @@ func (service *MessageSendScheduleService) Delete(
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create [%s] event for schedule [%s]", events.EventTypeMessageSendScheduleDeleted, scheduleID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch [%s] event for schedule [%s]", event.Type(), scheduleID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -204,7 +204,7 @@ func (service *MessageSendScheduleService) DeleteAllForUser(
 			span,
 			stacktrace.Propagate(
 				err,
-				fmt.Sprintf("cannot delete message send schedules for user [%s]", userID),
+				"%s", fmt.Sprintf("cannot delete message send schedules for user [%s]", userID),
 			),
 		)
 	}

--- a/api/pkg/services/message_send_schedule_service.go
+++ b/api/pkg/services/message_send_schedule_service.go
@@ -94,7 +94,7 @@ func (service *MessageSendScheduleService) Store(
 			span,
 			stacktrace.Propagate(
 				err,
-				"%s", fmt.Sprintf("cannot store message send schedule [%s]", schedule.ID),
+				"cannot store message send schedule [%s]", schedule.ID,
 			),
 		)
 	}
@@ -127,7 +127,7 @@ func (service *MessageSendScheduleService) Update(
 			span,
 			stacktrace.Propagate(
 				err,
-				"%s", fmt.Sprintf("cannot update message send schedule [%s]", schedule.ID),
+				"cannot update message send schedule [%s]", schedule.ID,
 			),
 		)
 	}
@@ -145,8 +145,7 @@ func (service *MessageSendScheduleService) Delete(
 	defer span.End()
 
 	if err := service.repository.Delete(ctx, userID, scheduleID); err != nil {
-		msg := fmt.Sprintf("cannot delete message send schedule with ID [%s] for user [%s]", scheduleID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete message send schedule with ID [%s] for user [%s]", scheduleID, userID))
 	}
 
 	event, err := service.createEvent(events.EventTypeMessageSendScheduleDeleted, fmt.Sprintf("%T", service), events.MessageSendScheduleDeletedPayload{
@@ -155,13 +154,11 @@ func (service *MessageSendScheduleService) Delete(
 		Timestamp:  time.Now().UTC(),
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create [%s] event for schedule [%s]", events.EventTypeMessageSendScheduleDeleted, scheduleID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create [%s] event for schedule [%s]", events.EventTypeMessageSendScheduleDeleted, scheduleID))
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch [%s] event for schedule [%s]", event.Type(), scheduleID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch [%s] event for schedule [%s]", event.Type(), scheduleID))
 	}
 
 	return nil
@@ -204,7 +201,7 @@ func (service *MessageSendScheduleService) DeleteAllForUser(
 			span,
 			stacktrace.Propagate(
 				err,
-				"%s", fmt.Sprintf("cannot delete message send schedules for user [%s]", userID),
+				"cannot delete message send schedules for user [%s]", userID,
 			),
 		)
 	}

--- a/api/pkg/services/message_service.go
+++ b/api/pkg/services/message_service.go
@@ -79,8 +79,7 @@ func (service *MessageService) GetOutstanding(ctx context.Context, params Messag
 
 	message, err := service.repository.GetOutstanding(ctx, params.UserID, params.MessageID, params.PhoneNumbers)
 	if err != nil {
-		msg := fmt.Sprintf("could not fetch outstanding messages with params [%s]", spew.Sdump(params))
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "could not fetch outstanding messages with params [%s]", spew.Sdump(params)))
 	}
 
 	event, err := service.createMessagePhoneSendingEvent(params.Source, events.MessagePhoneSendingPayload{
@@ -94,15 +93,13 @@ func (service *MessageService) GetOutstanding(ctx context.Context, params Messag
 		SIM:       message.SIM,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create [%T] for message with ID [%s]", event, message.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create [%T] for message with ID [%s]", event, message.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID))
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("dispatched event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID))
@@ -115,8 +112,7 @@ func (service *MessageService) DeleteAllForUser(ctx context.Context, userID enti
 	defer span.End()
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
-		msg := fmt.Sprintf("could not delete [entities.Message] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not delete [entities.Message] for user with ID [%s]", userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.Message] for user with ID [%s]", userID))
@@ -130,8 +126,7 @@ func (service *MessageService) GetBulkMessages(ctx context.Context, userID entit
 
 	orders, err := service.repository.GetBulkMessages(ctx, userID, 10)
 	if err != nil {
-		msg := fmt.Sprintf("could not fetch bulk messages for user [%s]", userID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not fetch bulk messages for user [%s]", userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] bulk messages for user [%s]", len(orders), userID))
@@ -146,8 +141,7 @@ func (service *MessageService) DeleteMessage(ctx context.Context, source string,
 	ctxLogger := service.tracer.CtxLogger(service.logger, span)
 
 	if err := service.repository.Delete(ctx, message.UserID, message.ID); err != nil {
-		msg := fmt.Sprintf("could not delete message with ID [%s] for user wit ID [%s]", message.ID, message.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "could not delete message with ID [%s] for user wit ID [%s]", message.ID, message.UserID))
 	}
 
 	var prevID *uuid.UUID
@@ -175,14 +169,12 @@ func (service *MessageService) DeleteMessage(ctx context.Context, source string,
 		SIM:                    message.SIM,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create [%T] for message with ID [%s]", event, message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create [%T] for message with ID [%s]", event, message.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID))
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("dispatched event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID))
@@ -197,8 +189,7 @@ func (service *MessageService) DeleteByOwnerAndContact(ctx context.Context, user
 	ctxLogger := service.tracer.CtxLogger(service.logger, span)
 
 	if err := service.repository.DeleteByOwnerAndContact(ctx, userID, owner, contact); err != nil {
-		msg := fmt.Sprintf("could not all delete messages for user with ID [%s] between owner [%s] and contact [%s] ", userID, owner, contact)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "could not all delete messages for user with ID [%s] between owner [%s] and contact [%s] ", userID, owner, contact))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all messages for user with ID [%s] between owner [%s] and contact [%s] ", userID, owner, contact))
@@ -212,8 +203,7 @@ func (service *MessageService) RespondToMissedCall(ctx context.Context, source s
 
 	phone, err := service.phoneService.Load(ctx, payload.UserID, payload.Owner)
 	if err != nil {
-		msg := fmt.Sprintf("cannot find phone with owner [%s] for user with ID [%s] when handling missed phone call message [%s]", payload.Owner, payload.UserID, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find phone with owner [%s] for user with ID [%s] when handling missed phone call message [%s]", payload.Owner, payload.UserID, payload.MessageID))
 	}
 
 	if phone.MissedCallAutoReply == nil || strings.TrimSpace(*phone.MissedCallAutoReply) == "" {
@@ -235,8 +225,7 @@ func (service *MessageService) RespondToMissedCall(ctx context.Context, source s
 		RequestReceivedAt: time.Now().UTC(),
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot send auto response message for owner [%s] for user with ID [%s] when handling missed phone call message [%s]", payload.Owner, payload.UserID, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot send auto response message for owner [%s] for user with ID [%s] when handling missed phone call message [%s]", payload.Owner, payload.UserID, payload.MessageID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created response message with ID [%s] for missed call event [%s] for user [%s]", message.ID, payload.MessageID, message.UserID))
@@ -260,8 +249,7 @@ func (service *MessageService) GetMessages(ctx context.Context, params MessageGe
 
 	messages, err := service.repository.Index(ctx, params.UserID, params.Owner, params.Contact, params.IndexParams)
 	if err != nil {
-		msg := fmt.Sprintf("could not fetch messages with parms [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not fetch messages with parms [%+#v]", params))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] messages with prams [%+#v]", len(*messages), params))
@@ -275,8 +263,7 @@ func (service *MessageService) GetMessage(ctx context.Context, userID entities.U
 
 	message, err := service.repository.Load(ctx, userID, messageID)
 	if err != nil {
-		msg := fmt.Sprintf("could not fetch messages with ID [%s]", messageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "could not fetch messages with ID [%s]", messageID))
 	}
 
 	return message, nil
@@ -306,12 +293,11 @@ func (service *MessageService) StoreEvent(ctx context.Context, message *entities
 	case entities.MessageEventNameFailed:
 		err = service.handleMessageFailedEvent(ctx, params, message)
 	default:
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", fmt.Sprintf("cannot handle message event [%s]", params.EventName)))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.NewError("cannot handle message event [%s]", params.EventName))
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("could not handle phone event [%s] for message with id [%s]", params.EventName, message.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not handle phone event [%s] for message with id [%s]", params.EventName, message.ID))
 	}
 
 	return service.repository.Load(ctx, message.UserID, params.MessageID)
@@ -342,8 +328,7 @@ func (service *MessageService) ReceiveMessage(ctx context.Context, params *Messa
 	ctxLogger.Info(fmt.Sprintf("uploading [%d] attachments for user [%s] message [%s]", len(params.Attachments), params.UserID, messageID))
 	attachmentURLs, err := service.uploadAttachments(ctx, params.UserID, messageID, params.Attachments)
 	if err != nil {
-		msg := fmt.Sprintf("cannot upload attachments for user [%s] message [%s]", params.UserID, messageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot upload attachments for user [%s] message [%s]", params.UserID, messageID))
 	}
 
 	owner := phonenumbers.Format(params.Owner, phonenumbers.E164)
@@ -364,15 +349,13 @@ func (service *MessageService) ReceiveMessage(ctx context.Context, params *Messa
 
 	event, err := service.createMessagePhoneReceivedEvent(params.Source, eventPayload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create %T from payload with message id [%s]", event, eventPayload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create %T from payload with message id [%s]", event, eventPayload.MessageID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created event [%s] with id [%s] and message id [%s]", event.Type(), event.ID(), eventPayload.MessageID))
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID())
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID()))
 	}
 	ctxLogger.Info(fmt.Sprintf("event [%s] dispatched successfully", event.ID()))
 
@@ -395,13 +378,11 @@ func (service *MessageService) handleMessageSentEvent(ctx context.Context, param
 		SIM:       message.SIM,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event [%s] for message [%s]", events.EventTypeMessagePhoneSent, message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create event [%s] for message [%s]", events.EventTypeMessagePhoneSent, message.ID))
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID())
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID()))
 	}
 	return nil
 }
@@ -422,13 +403,11 @@ func (service *MessageService) handleMessageDeliveredEvent(ctx context.Context, 
 		SIM:       message.SIM,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event [%s] for message [%s]", events.EventTypeMessagePhoneSent, message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create event [%s] for message [%s]", events.EventTypeMessagePhoneSent, message.ID))
 	}
 
 	if _, err = service.eventDispatcher.DispatchWithTimeout(ctx, event, time.Second); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event type [%s] and id [%s] for message [%s]", event.Type(), event.ID(), message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event type [%s] and id [%s] for message [%s]", event.Type(), event.ID(), message.ID))
 	}
 	return nil
 }
@@ -455,13 +434,11 @@ func (service *MessageService) handleMessageFailedEvent(ctx context.Context, par
 		SIM:          message.SIM,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event [%s] for message [%s]", events.EventTypeMessageSendFailed, message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create event [%s] for message [%s]", events.EventTypeMessageSendFailed, message.ID))
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID())
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID()))
 	}
 	return nil
 }
@@ -508,21 +485,18 @@ func (service *MessageService) SendMessage(ctx context.Context, params MessageSe
 
 	event, err := service.createMessageAPISentEvent(params.Source, eventPayload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create %T from payload with message id [%s]", event, eventPayload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create %T from payload with message id [%s]", event, eventPayload.MessageID))
 	}
 	ctxLogger.Info(fmt.Sprintf("created event [%s] with id [%s] and message id [%s] and user [%s]", event.Type(), event.ID(), eventPayload.MessageID, eventPayload.UserID))
 
 	message, err := service.storeSentMessage(ctx, eventPayload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot store message with id [%s]", eventPayload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot store message with id [%s]", eventPayload.MessageID))
 	}
 
 	timeout := service.getSendDelay(ctxLogger, eventPayload, params, messagesPerMinute)
 	if _, err = service.eventDispatcher.DispatchWithTimeout(ctx, event, timeout); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID())
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID()))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("[%s] event with ID [%s] dispatched succesfully for message [%s] with user [%s] and delay [%s]", event.Type(), event.ID(), eventPayload.MessageID, eventPayload.UserID, timeout))
@@ -557,21 +531,18 @@ func (service *MessageService) RegisterMissedCall(ctx context.Context, params *M
 
 	event, err := service.createEvent(events.MessageCallMissed, params.Source, eventPayload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create [%T] from payload with message id [%s]", event, eventPayload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create [%T] from payload with message id [%s]", event, eventPayload.MessageID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created event [%s] with id [%s] and message id [%s] and user [%s]", event.Type(), event.ID(), eventPayload.MessageID, eventPayload.UserID))
 
 	message, err := service.storeMissedCallMessage(ctx, eventPayload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot store missed call message message with id [%s]", eventPayload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot store missed call message message with id [%s]", eventPayload.MessageID))
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID())
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID()))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("[%s] event with ID [%s] dispatched succesfully for message [%s] with user [%s]", event.Type(), event.ID(), eventPayload.MessageID, eventPayload.UserID))
@@ -624,8 +595,7 @@ func (service *MessageService) storeReceivedMessage(ctx context.Context, params 
 	}
 
 	if err := service.repository.Store(ctx, message); err != nil {
-		msg := fmt.Sprintf("cannot save message with id [%s]", params.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save message with id [%s]", params.MessageID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message saved with id [%s]", message.ID))
@@ -649,7 +619,7 @@ func (service *MessageService) uploadAttachments(ctx context.Context, userID ent
 		g.Go(func() error {
 			decoded, err := base64.StdEncoding.DecodeString(attachment.Content)
 			if err != nil {
-				return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot decode base64 content for attachment [%d]", i))
+				return stacktrace.Propagate(err, "cannot decode base64 content for attachment [%d]", i)
 			}
 
 			sanitizedName := repositories.SanitizeFilename(attachment.Name, i)
@@ -660,7 +630,7 @@ func (service *MessageService) uploadAttachments(ctx context.Context, userID ent
 			paths[i] = path
 
 			if err = service.attachmentRepository.Upload(gCtx, path, decoded, attachment.ContentType); err != nil {
-				return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot upload attachment [%d] to path [%s]", i, path))
+				return stacktrace.Propagate(err, "cannot upload attachment [%d] to path [%s]", i, path)
 			}
 
 			urls[i] = fmt.Sprintf("%s/v1/attachments/%s/%s/%d/%s", service.apiBaseURL, userID, messageID, i, filename)
@@ -698,18 +668,15 @@ func (service *MessageService) HandleMessageSending(ctx context.Context, params 
 
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find message with id [%s]", params.ID))
 	}
 
 	if !message.IsSending() {
-		msg := fmt.Sprintf("message has wrong status [%s]. expected %s", message.Status, entities.MessageStatusSending)
-		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("message has wrong status [%s]. expected %s", message.Status, entities.MessageStatusSending))
 	}
 
 	if err = service.repository.Update(ctx, message.AddSendAttempt(params.Timestamp)); err != nil {
-		msg := fmt.Sprintf("cannot update message with id [%s] after sending", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update message with id [%s] after sending", message.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message with id [%s] updated after adding send attempt", message.ID))
@@ -725,8 +692,7 @@ func (service *MessageService) HandleMessageSent(ctx context.Context, params Han
 
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find message with id [%s]", params.ID))
 	}
 
 	if message.IsSent() || message.IsDelivered() {
@@ -735,13 +701,11 @@ func (service *MessageService) HandleMessageSent(ctx context.Context, params Han
 	}
 
 	if !message.IsSending() && !message.IsExpired() && !message.IsScheduled() {
-		msg := fmt.Sprintf("message has wrong status [%s]. expected [%s, %s, %s]", message.Status, entities.MessageStatusSending, entities.MessageStatusExpired, entities.MessageStatusScheduled)
-		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("message has wrong status [%s]. expected [%s, %s, %s]", message.Status, entities.MessageStatusSending, entities.MessageStatusExpired, entities.MessageStatusScheduled))
 	}
 
 	if err = service.repository.Update(ctx, message.Sent(params.Timestamp)); err != nil {
-		msg := fmt.Sprintf("cannot update message with id [%s] as sent", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update message with id [%s] as sent", message.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message with id [%s] has been updated to status [%s]", message.ID, message.Status))
@@ -765,18 +729,15 @@ func (service *MessageService) HandleMessageFailed(ctx context.Context, params H
 
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find message with id [%s]", params.ID))
 	}
 
 	if message.IsDelivered() {
-		msg := fmt.Sprintf("message has already been delivered with status [%s]", message.Status)
-		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("message has already been delivered with status [%s]", message.Status))
 	}
 
 	if err = service.repository.Update(ctx, message.Failed(params.Timestamp, params.ErrorMessage)); err != nil {
-		msg := fmt.Sprintf("cannot update message with id [%s] as sent", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update message with id [%s] as sent", message.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message with id [%s] has been updated to status [%s]", message.ID, message.Status))
@@ -792,19 +753,16 @@ func (service *MessageService) HandleMessageDelivered(ctx context.Context, param
 
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find message with id [%s]", params.ID))
 	}
 
 	if !message.IsSent() && !message.IsSending() && !message.IsExpired() && !message.IsScheduled() {
-		msg := fmt.Sprintf("message has wrong status [%s]. expected [%s, %s, %s, %s]", message.Status, entities.MessageStatusSent, entities.MessageStatusScheduled, entities.MessageStatusSending, entities.MessageStatusExpired)
-		ctxLogger.Warn(stacktrace.NewError("%s", msg))
+		ctxLogger.Warn(stacktrace.NewError("message has wrong status [%s]. expected [%s, %s, %s, %s]", message.Status, entities.MessageStatusSent, entities.MessageStatusScheduled, entities.MessageStatusSending, entities.MessageStatusExpired))
 		return nil
 	}
 
 	if err = service.repository.Update(ctx, message.Delivered(params.Timestamp)); err != nil {
-		msg := fmt.Sprintf("cannot update message with id [%s] as delivered", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update message with id [%s] as delivered", message.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message with id [%s] has been updated to status [%s]", message.ID, message.Status))
@@ -820,17 +778,15 @@ func (service *MessageService) HandleMessageNotificationScheduled(ctx context.Co
 
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find message with id [%s]", params.ID))
 	}
 
 	if !message.IsPending() && !message.IsExpired() && !message.IsSending() {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("received scheduled event for message with id [%s] message has status [%s]", message.ID, message.Status)))
+		ctxLogger.Warn(stacktrace.NewError("received scheduled event for message with id [%s] message has status [%s]", message.ID, message.Status))
 	}
 
 	if err = service.repository.Update(ctx, message.NotificationScheduled(params.Timestamp)); err != nil {
-		msg := fmt.Sprintf("cannot update message with id [%s] as expired", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update message with id [%s] as expired", message.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message with id [%s] has been scheduled to send at [%s]", message.ID, message.NotificationScheduledAt.String()))
@@ -846,13 +802,11 @@ func (service *MessageService) HandleMessageNotificationSent(ctx context.Context
 
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find message with id [%s]", params.ID))
 	}
 
 	if err = service.repository.Update(ctx, message.AddSendAttemptCount()); err != nil {
-		msg := fmt.Sprintf("cannot update message with id [%s] as expired", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update message with id [%s] as expired", message.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("notification for message with id [%s] has been sent at [%s]", message.ID, params.Timestamp.String()))
@@ -868,18 +822,15 @@ func (service *MessageService) HandleMessageExpired(ctx context.Context, params 
 
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find message with id [%s]", params.ID))
 	}
 
 	if !message.IsSending() && !message.IsScheduled() && !message.IsPending() {
-		msg := fmt.Sprintf("message has wrong status [%s]. expected [%s, %s, %s]", message.Status, entities.MessageStatusSending, entities.MessageStatusScheduled, entities.MessageStatusPending)
-		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("message has wrong status [%s]. expected [%s, %s, %s]", message.Status, entities.MessageStatusSending, entities.MessageStatusScheduled, entities.MessageStatusPending))
 	}
 
 	if err = service.repository.Update(ctx, message.Expired(params.Timestamp)); err != nil {
-		msg := fmt.Sprintf("cannot update message with id [%s] as expired", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update message with id [%s] as expired", message.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message with id [%s] has been updated to status [%s]", message.ID, message.Status))
@@ -899,13 +850,11 @@ func (service *MessageService) HandleMessageExpired(ctx context.Context, params 
 		SIM:       message.SIM,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create [%s] event for expired message with ID [%s]", events.EventTypeMessageSendRetry, message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create [%s] event for expired message with ID [%s]", events.EventTypeMessageSendRetry, message.ID))
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch [%s] event for message with ID [%s]", event.Type(), message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch [%s] event for message with ID [%s]", event.Type(), message.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("retried sending message with ID [%s]", message.ID))
@@ -940,13 +889,11 @@ func (service *MessageService) ScheduleExpirationCheck(ctx context.Context, para
 		UserID:      params.UserID,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event [%s] for message with id [%s]", events.EventTypeMessageSendExpiredCheck, params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create event [%s] for message with id [%s]", events.EventTypeMessageSendExpiredCheck, params.MessageID))
 	}
 
 	if _, err = service.eventDispatcher.DispatchWithTimeout(ctx, event, params.MessageExpirationDuration); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event [%s] for message with ID [%s]", event.Type(), params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event [%s] for message with ID [%s]", event.Type(), params.MessageID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("scheduled message id [%s] to expire at [%s]", params.MessageID, params.NotificationSentAt.Add(params.MessageExpirationDuration)))
@@ -974,8 +921,7 @@ func (service *MessageService) CheckExpired(ctx context.Context, params MessageC
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot load message with userID [%s] and messageID [%s]", params.UserID, params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load message with userID [%s] and messageID [%s]", params.UserID, params.MessageID))
 	}
 
 	if !message.IsPending() && !message.IsSending() && !message.IsScheduled() {
@@ -997,13 +943,11 @@ func (service *MessageService) CheckExpired(ctx context.Context, params MessageC
 		SIM:              message.SIM,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event [%s] for message with id [%s]", events.EventTypeMessageSendExpired, params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create event [%s] for message with id [%s]", events.EventTypeMessageSendExpired, params.MessageID))
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event [%s] for message with ID [%s]", event.Type(), params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event [%s] for message with ID [%s]", event.Type(), params.MessageID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message [%s] has expired with status [%s]", params.MessageID, message.Status))
@@ -1028,8 +972,7 @@ func (service *MessageService) SearchMessages(ctx context.Context, params *Messa
 
 	messages, err := service.repository.Search(ctx, params.UserID, params.Owners, params.Types, params.Statuses, params.IndexParams)
 	if err != nil {
-		msg := fmt.Sprintf("could not search messages with parms [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not search messages with parms [%+#v]", params))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] messages with prams [%+#v]", len(messages), params))
@@ -1044,8 +987,7 @@ func (service *MessageService) phoneSettings(ctx context.Context, userID entitie
 
 	phone, err := service.phoneService.Load(ctx, userID, owner)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load phone for userID [%s] and owner [%s]. using default max send attempt of 2", userID, owner)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot load phone for userID [%s] and owner [%s]. using default max send attempt of 2", userID, owner))
 		return 2, entities.SIM1, 0
 	}
 
@@ -1085,8 +1027,7 @@ func (service *MessageService) storeSentMessage(ctx context.Context, payload eve
 	}
 
 	if err := service.repository.Store(ctx, message); err != nil {
-		msg := fmt.Sprintf("cannot save message with id [%s]", payload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save message with id [%s]", payload.MessageID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message saved with id [%s]", payload.MessageID))
@@ -1115,8 +1056,7 @@ func (service *MessageService) storeMissedCallMessage(ctx context.Context, paylo
 	}
 
 	if err := service.repository.Store(ctx, message); err != nil {
-		msg := fmt.Sprintf("cannot save missed call message with id [%s]", payload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save missed call message with id [%s]", payload.MessageID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("missed call message saved with id [%s]", payload.MessageID))

--- a/api/pkg/services/message_service.go
+++ b/api/pkg/services/message_service.go
@@ -80,7 +80,7 @@ func (service *MessageService) GetOutstanding(ctx context.Context, params Messag
 	message, err := service.repository.GetOutstanding(ctx, params.UserID, params.MessageID, params.PhoneNumbers)
 	if err != nil {
 		msg := fmt.Sprintf("could not fetch outstanding messages with params [%s]", spew.Sdump(params))
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	event, err := service.createMessagePhoneSendingEvent(params.Source, events.MessagePhoneSendingPayload{
@@ -95,14 +95,14 @@ func (service *MessageService) GetOutstanding(ctx context.Context, params Messag
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create [%T] for message with ID [%s]", event, message.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID))
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("dispatched event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID))
@@ -116,7 +116,7 @@ func (service *MessageService) DeleteAllForUser(ctx context.Context, userID enti
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
 		msg := fmt.Sprintf("could not delete [entities.Message] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.Message] for user with ID [%s]", userID))
@@ -131,7 +131,7 @@ func (service *MessageService) GetBulkMessages(ctx context.Context, userID entit
 	orders, err := service.repository.GetBulkMessages(ctx, userID, 10)
 	if err != nil {
 		msg := fmt.Sprintf("could not fetch bulk messages for user [%s]", userID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] bulk messages for user [%s]", len(orders), userID))
@@ -147,7 +147,7 @@ func (service *MessageService) DeleteMessage(ctx context.Context, source string,
 
 	if err := service.repository.Delete(ctx, message.UserID, message.ID); err != nil {
 		msg := fmt.Sprintf("could not delete message with ID [%s] for user wit ID [%s]", message.ID, message.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	var prevID *uuid.UUID
@@ -176,13 +176,13 @@ func (service *MessageService) DeleteMessage(ctx context.Context, source string,
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create [%T] for message with ID [%s]", event, message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID))
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("dispatched event [%s] with id [%s] for message [%s]", event.Type(), event.ID(), message.ID))
@@ -198,7 +198,7 @@ func (service *MessageService) DeleteByOwnerAndContact(ctx context.Context, user
 
 	if err := service.repository.DeleteByOwnerAndContact(ctx, userID, owner, contact); err != nil {
 		msg := fmt.Sprintf("could not all delete messages for user with ID [%s] between owner [%s] and contact [%s] ", userID, owner, contact)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all messages for user with ID [%s] between owner [%s] and contact [%s] ", userID, owner, contact))
@@ -213,7 +213,7 @@ func (service *MessageService) RespondToMissedCall(ctx context.Context, source s
 	phone, err := service.phoneService.Load(ctx, payload.UserID, payload.Owner)
 	if err != nil {
 		msg := fmt.Sprintf("cannot find phone with owner [%s] for user with ID [%s] when handling missed phone call message [%s]", payload.Owner, payload.UserID, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if phone.MissedCallAutoReply == nil || strings.TrimSpace(*phone.MissedCallAutoReply) == "" {
@@ -236,7 +236,7 @@ func (service *MessageService) RespondToMissedCall(ctx context.Context, source s
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot send auto response message for owner [%s] for user with ID [%s] when handling missed phone call message [%s]", payload.Owner, payload.UserID, payload.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created response message with ID [%s] for missed call event [%s] for user [%s]", message.ID, payload.MessageID, message.UserID))
@@ -261,7 +261,7 @@ func (service *MessageService) GetMessages(ctx context.Context, params MessageGe
 	messages, err := service.repository.Index(ctx, params.UserID, params.Owner, params.Contact, params.IndexParams)
 	if err != nil {
 		msg := fmt.Sprintf("could not fetch messages with parms [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] messages with prams [%+#v]", len(*messages), params))
@@ -276,7 +276,7 @@ func (service *MessageService) GetMessage(ctx context.Context, userID entities.U
 	message, err := service.repository.Load(ctx, userID, messageID)
 	if err != nil {
 		msg := fmt.Sprintf("could not fetch messages with ID [%s]", messageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	return message, nil
@@ -306,12 +306,12 @@ func (service *MessageService) StoreEvent(ctx context.Context, message *entities
 	case entities.MessageEventNameFailed:
 		err = service.handleMessageFailedEvent(ctx, params, message)
 	default:
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.NewError(fmt.Sprintf("cannot handle message event [%s]", params.EventName)))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", fmt.Sprintf("cannot handle message event [%s]", params.EventName)))
 	}
 
 	if err != nil {
 		msg := fmt.Sprintf("could not handle phone event [%s] for message with id [%s]", params.EventName, message.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return service.repository.Load(ctx, message.UserID, params.MessageID)
@@ -321,7 +321,7 @@ func (service *MessageService) StoreEvent(ctx context.Context, message *entities
 type MessageReceiveParams struct {
 	Contact     string
 	UserID      entities.UserID
-	Owner       phonenumbers.PhoneNumber
+	Owner       *phonenumbers.PhoneNumber
 	Content     string
 	SIM         entities.SIM
 	Timestamp   time.Time
@@ -343,10 +343,10 @@ func (service *MessageService) ReceiveMessage(ctx context.Context, params *Messa
 	attachmentURLs, err := service.uploadAttachments(ctx, params.UserID, messageID, params.Attachments)
 	if err != nil {
 		msg := fmt.Sprintf("cannot upload attachments for user [%s] message [%s]", params.UserID, messageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
-	owner := phonenumbers.Format(&params.Owner, phonenumbers.E164)
+	owner := phonenumbers.Format(params.Owner, phonenumbers.E164)
 
 	eventPayload := events.MessagePhoneReceivedPayload{
 		MessageID:   messageID,
@@ -365,14 +365,14 @@ func (service *MessageService) ReceiveMessage(ctx context.Context, params *Messa
 	event, err := service.createMessagePhoneReceivedEvent(params.Source, eventPayload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot create %T from payload with message id [%s]", event, eventPayload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created event [%s] with id [%s] and message id [%s]", event.Type(), event.ID(), eventPayload.MessageID))
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID())
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	ctxLogger.Info(fmt.Sprintf("event [%s] dispatched successfully", event.ID()))
 
@@ -396,12 +396,12 @@ func (service *MessageService) handleMessageSentEvent(ctx context.Context, param
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event [%s] for message [%s]", events.EventTypeMessagePhoneSent, message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID())
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	return nil
 }
@@ -423,12 +423,12 @@ func (service *MessageService) handleMessageDeliveredEvent(ctx context.Context, 
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event [%s] for message [%s]", events.EventTypeMessagePhoneSent, message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if _, err = service.eventDispatcher.DispatchWithTimeout(ctx, event, time.Second); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event type [%s] and id [%s] for message [%s]", event.Type(), event.ID(), message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	return nil
 }
@@ -456,12 +456,12 @@ func (service *MessageService) handleMessageFailedEvent(ctx context.Context, par
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event [%s] for message [%s]", events.EventTypeMessageSendFailed, message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID())
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	return nil
 }
@@ -509,20 +509,20 @@ func (service *MessageService) SendMessage(ctx context.Context, params MessageSe
 	event, err := service.createMessageAPISentEvent(params.Source, eventPayload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot create %T from payload with message id [%s]", event, eventPayload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	ctxLogger.Info(fmt.Sprintf("created event [%s] with id [%s] and message id [%s] and user [%s]", event.Type(), event.ID(), eventPayload.MessageID, eventPayload.UserID))
 
 	message, err := service.storeSentMessage(ctx, eventPayload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot store message with id [%s]", eventPayload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	timeout := service.getSendDelay(ctxLogger, eventPayload, params, messagesPerMinute)
 	if _, err = service.eventDispatcher.DispatchWithTimeout(ctx, event, timeout); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID())
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("[%s] event with ID [%s] dispatched succesfully for message [%s] with user [%s] and delay [%s]", event.Type(), event.ID(), eventPayload.MessageID, eventPayload.UserID, timeout))
@@ -558,7 +558,7 @@ func (service *MessageService) RegisterMissedCall(ctx context.Context, params *M
 	event, err := service.createEvent(events.MessageCallMissed, params.Source, eventPayload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot create [%T] from payload with message id [%s]", event, eventPayload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created event [%s] with id [%s] and message id [%s] and user [%s]", event.Type(), event.ID(), eventPayload.MessageID, eventPayload.UserID))
@@ -566,12 +566,12 @@ func (service *MessageService) RegisterMissedCall(ctx context.Context, params *M
 	message, err := service.storeMissedCallMessage(ctx, eventPayload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot store missed call message message with id [%s]", eventPayload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event type [%s] and id [%s]", event.Type(), event.ID())
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("[%s] event with ID [%s] dispatched succesfully for message [%s] with user [%s]", event.Type(), event.ID(), eventPayload.MessageID, eventPayload.UserID))
@@ -625,7 +625,7 @@ func (service *MessageService) storeReceivedMessage(ctx context.Context, params 
 
 	if err := service.repository.Store(ctx, message); err != nil {
 		msg := fmt.Sprintf("cannot save message with id [%s]", params.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message saved with id [%s]", message.ID))
@@ -649,7 +649,7 @@ func (service *MessageService) uploadAttachments(ctx context.Context, userID ent
 		g.Go(func() error {
 			decoded, err := base64.StdEncoding.DecodeString(attachment.Content)
 			if err != nil {
-				return stacktrace.Propagate(err, fmt.Sprintf("cannot decode base64 content for attachment [%d]", i))
+				return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot decode base64 content for attachment [%d]", i))
 			}
 
 			sanitizedName := repositories.SanitizeFilename(attachment.Name, i)
@@ -660,7 +660,7 @@ func (service *MessageService) uploadAttachments(ctx context.Context, userID ent
 			paths[i] = path
 
 			if err = service.attachmentRepository.Upload(gCtx, path, decoded, attachment.ContentType); err != nil {
-				return stacktrace.Propagate(err, fmt.Sprintf("cannot upload attachment [%d] to path [%s]", i, path))
+				return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot upload attachment [%d] to path [%s]", i, path))
 			}
 
 			urls[i] = fmt.Sprintf("%s/v1/attachments/%s/%s/%d/%s", service.apiBaseURL, userID, messageID, i, filename)
@@ -699,17 +699,17 @@ func (service *MessageService) HandleMessageSending(ctx context.Context, params 
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if !message.IsSending() {
 		msg := fmt.Sprintf("message has wrong status [%s]. expected %s", message.Status, entities.MessageStatusSending)
-		return service.tracer.WrapErrorSpan(span, stacktrace.NewError(msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg))
 	}
 
 	if err = service.repository.Update(ctx, message.AddSendAttempt(params.Timestamp)); err != nil {
 		msg := fmt.Sprintf("cannot update message with id [%s] after sending", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message with id [%s] updated after adding send attempt", message.ID))
@@ -726,7 +726,7 @@ func (service *MessageService) HandleMessageSent(ctx context.Context, params Han
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if message.IsSent() || message.IsDelivered() {
@@ -736,12 +736,12 @@ func (service *MessageService) HandleMessageSent(ctx context.Context, params Han
 
 	if !message.IsSending() && !message.IsExpired() && !message.IsScheduled() {
 		msg := fmt.Sprintf("message has wrong status [%s]. expected [%s, %s, %s]", message.Status, entities.MessageStatusSending, entities.MessageStatusExpired, entities.MessageStatusScheduled)
-		return service.tracer.WrapErrorSpan(span, stacktrace.NewError(msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg))
 	}
 
 	if err = service.repository.Update(ctx, message.Sent(params.Timestamp)); err != nil {
 		msg := fmt.Sprintf("cannot update message with id [%s] as sent", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message with id [%s] has been updated to status [%s]", message.ID, message.Status))
@@ -766,17 +766,17 @@ func (service *MessageService) HandleMessageFailed(ctx context.Context, params H
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if message.IsDelivered() {
 		msg := fmt.Sprintf("message has already been delivered with status [%s]", message.Status)
-		return service.tracer.WrapErrorSpan(span, stacktrace.NewError(msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg))
 	}
 
 	if err = service.repository.Update(ctx, message.Failed(params.Timestamp, params.ErrorMessage)); err != nil {
 		msg := fmt.Sprintf("cannot update message with id [%s] as sent", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message with id [%s] has been updated to status [%s]", message.ID, message.Status))
@@ -793,18 +793,18 @@ func (service *MessageService) HandleMessageDelivered(ctx context.Context, param
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if !message.IsSent() && !message.IsSending() && !message.IsExpired() && !message.IsScheduled() {
 		msg := fmt.Sprintf("message has wrong status [%s]. expected [%s, %s, %s, %s]", message.Status, entities.MessageStatusSent, entities.MessageStatusScheduled, entities.MessageStatusSending, entities.MessageStatusExpired)
-		ctxLogger.Warn(stacktrace.NewError(msg))
+		ctxLogger.Warn(stacktrace.NewError("%s", msg))
 		return nil
 	}
 
 	if err = service.repository.Update(ctx, message.Delivered(params.Timestamp)); err != nil {
 		msg := fmt.Sprintf("cannot update message with id [%s] as delivered", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message with id [%s] has been updated to status [%s]", message.ID, message.Status))
@@ -821,16 +821,16 @@ func (service *MessageService) HandleMessageNotificationScheduled(ctx context.Co
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if !message.IsPending() && !message.IsExpired() && !message.IsSending() {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("received scheduled event for message with id [%s] message has status [%s]", message.ID, message.Status)))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("received scheduled event for message with id [%s] message has status [%s]", message.ID, message.Status)))
 	}
 
 	if err = service.repository.Update(ctx, message.NotificationScheduled(params.Timestamp)); err != nil {
 		msg := fmt.Sprintf("cannot update message with id [%s] as expired", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message with id [%s] has been scheduled to send at [%s]", message.ID, message.NotificationScheduledAt.String()))
@@ -847,12 +847,12 @@ func (service *MessageService) HandleMessageNotificationSent(ctx context.Context
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.repository.Update(ctx, message.AddSendAttemptCount()); err != nil {
 		msg := fmt.Sprintf("cannot update message with id [%s] as expired", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("notification for message with id [%s] has been sent at [%s]", message.ID, params.Timestamp.String()))
@@ -869,17 +869,17 @@ func (service *MessageService) HandleMessageExpired(ctx context.Context, params 
 	message, err := service.repository.Load(ctx, params.UserID, params.ID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot find message with id [%s]", params.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if !message.IsSending() && !message.IsScheduled() && !message.IsPending() {
 		msg := fmt.Sprintf("message has wrong status [%s]. expected [%s, %s, %s]", message.Status, entities.MessageStatusSending, entities.MessageStatusScheduled, entities.MessageStatusPending)
-		return service.tracer.WrapErrorSpan(span, stacktrace.NewError(msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg))
 	}
 
 	if err = service.repository.Update(ctx, message.Expired(params.Timestamp)); err != nil {
 		msg := fmt.Sprintf("cannot update message with id [%s] as expired", message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message with id [%s] has been updated to status [%s]", message.ID, message.Status))
@@ -900,12 +900,12 @@ func (service *MessageService) HandleMessageExpired(ctx context.Context, params 
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create [%s] event for expired message with ID [%s]", events.EventTypeMessageSendRetry, message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch [%s] event for message with ID [%s]", event.Type(), message.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("retried sending message with ID [%s]", message.ID))
@@ -941,12 +941,12 @@ func (service *MessageService) ScheduleExpirationCheck(ctx context.Context, para
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event [%s] for message with id [%s]", events.EventTypeMessageSendExpiredCheck, params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if _, err = service.eventDispatcher.DispatchWithTimeout(ctx, event, params.MessageExpirationDuration); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event [%s] for message with ID [%s]", event.Type(), params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("scheduled message id [%s] to expire at [%s]", params.MessageID, params.NotificationSentAt.Add(params.MessageExpirationDuration)))
@@ -975,7 +975,7 @@ func (service *MessageService) CheckExpired(ctx context.Context, params MessageC
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot load message with userID [%s] and messageID [%s]", params.UserID, params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if !message.IsPending() && !message.IsSending() && !message.IsScheduled() {
@@ -998,12 +998,12 @@ func (service *MessageService) CheckExpired(ctx context.Context, params MessageC
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event [%s] for message with id [%s]", events.EventTypeMessageSendExpired, params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event [%s] for message with ID [%s]", event.Type(), params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message [%s] has expired with status [%s]", params.MessageID, message.Status))
@@ -1029,7 +1029,7 @@ func (service *MessageService) SearchMessages(ctx context.Context, params *Messa
 	messages, err := service.repository.Search(ctx, params.UserID, params.Owners, params.Types, params.Statuses, params.IndexParams)
 	if err != nil {
 		msg := fmt.Sprintf("could not search messages with parms [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] messages with prams [%+#v]", len(messages), params))
@@ -1045,7 +1045,7 @@ func (service *MessageService) phoneSettings(ctx context.Context, userID entitie
 	phone, err := service.phoneService.Load(ctx, userID, owner)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load phone for userID [%s] and owner [%s]. using default max send attempt of 2", userID, owner)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return 2, entities.SIM1, 0
 	}
 
@@ -1086,7 +1086,7 @@ func (service *MessageService) storeSentMessage(ctx context.Context, payload eve
 
 	if err := service.repository.Store(ctx, message); err != nil {
 		msg := fmt.Sprintf("cannot save message with id [%s]", payload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("message saved with id [%s]", payload.MessageID))
@@ -1116,7 +1116,7 @@ func (service *MessageService) storeMissedCallMessage(ctx context.Context, paylo
 
 	if err := service.repository.Store(ctx, message); err != nil {
 		msg := fmt.Sprintf("cannot save missed call message with id [%s]", payload.MessageID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("missed call message saved with id [%s]", payload.MessageID))

--- a/api/pkg/services/message_thread_service.go
+++ b/api/pkg/services/message_thread_service.go
@@ -67,8 +67,7 @@ func (service *MessageThreadService) DeleteAllForUser(ctx context.Context, userI
 	defer span.End()
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
-		msg := fmt.Sprintf("could not delete [entities.MessageThread] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not delete [entities.MessageThread] for user with ID [%s]", userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.MessageThread] for user with ID [%s]", userID))
@@ -89,17 +88,16 @@ func (service *MessageThreadService) UpdateThread(ctx context.Context, params Me
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot find thread with owner [%s], and contact [%s]. creating new thread", params.Owner, params.Contact)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find thread with owner [%s], and contact [%s]. creating new thread", params.Owner, params.Contact))
 	}
 
 	if thread.OrderTimestamp.Unix() > params.Timestamp.Unix() && thread.Status != entities.MessageStatusSending && thread.HasLastMessage(params.MessageID) {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("thread [%s] has timestamp [%s] and status [%s] which is greater than timestamp [%s] for message [%s] and status [%s]", thread.ID, thread.OrderTimestamp, thread.Status, params.Timestamp, params.MessageID, params.Status)))
+		ctxLogger.Warn(stacktrace.NewError("thread [%s] has timestamp [%s] and status [%s] which is greater than timestamp [%s] for message [%s] and status [%s]", thread.ID, thread.OrderTimestamp, thread.Status, params.Timestamp, params.MessageID, params.Status))
 		return nil
 	}
 
 	if thread.Status == entities.MessageStatusDelivered && thread.LastMessageID != nil && thread.HasLastMessage(params.MessageID) {
-		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("thread [%s] already has status [%s] not updating with status [%s] for message [%s]", thread.ID, thread.Status, params.Status, params.MessageID)))
+		ctxLogger.Warn(stacktrace.NewError("thread [%s] already has status [%s] not updating with status [%s] for message [%s]", thread.ID, thread.Status, params.Status, params.MessageID))
 		return nil
 	}
 
@@ -114,8 +112,7 @@ func (service *MessageThreadService) UpdateThread(ctx context.Context, params Me
 	}
 
 	if err = service.repository.Update(ctx, thread.Update(params.Timestamp, params.MessageID, params.Content, params.Status)); err != nil {
-		msg := fmt.Sprintf("cannot update message thread with id [%s] after adding message [%s]", thread.ID, params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update message thread with id [%s] after adding message [%s]", thread.ID, params.MessageID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("thread with id [%s] updated with last message [%s] and status [%s]", thread.ID, thread.LastMessageID, thread.Status))
@@ -138,13 +135,11 @@ func (service *MessageThreadService) UpdateStatus(ctx context.Context, params Me
 
 	thread, err := service.repository.Load(ctx, params.UserID, params.MessageThreadID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot find thread with id [%s]", params.MessageThreadID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find thread with id [%s]", params.MessageThreadID))
 	}
 
 	if err = service.repository.Update(ctx, thread.UpdateArchive(params.IsArchived)); err != nil {
-		msg := fmt.Sprintf("cannot update message thread with id [%s] with archive status [%t]", thread.ID, params.IsArchived)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update message thread with id [%s] with archive status [%t]", thread.ID, params.IsArchived))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("thread with id [%s] updated with archive status [%t]", thread.ID, thread.IsArchived))
@@ -158,14 +153,12 @@ func (service *MessageThreadService) UpdateAfterDeletedMessage(ctx context.Conte
 
 	thread, err := service.repository.LoadByOwnerContact(ctx, payload.UserID, payload.Owner, payload.Contact)
 	if err != nil {
-		msg := fmt.Sprintf("cannot find thread for user [%s] with owner [%s], and contact [%s]", payload.UserID, payload.Owner, payload.Contact)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot find thread for user [%s] with owner [%s], and contact [%s]", payload.UserID, payload.Owner, payload.Contact))
 	}
 
 	if payload.PreviousMessageID == nil {
 		if err = service.repository.Delete(ctx, thread.UserID, thread.ID); err != nil {
-			msg := fmt.Sprintf("cannot delete thread with ID [%s] for user [%s] and owner [%s]", thread.ID, thread.UserID, thread.Owner)
-			ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+			ctxLogger.Error(stacktrace.Propagate(err, "cannot delete thread with ID [%s] for user [%s] and owner [%s]", thread.ID, thread.UserID, thread.Owner))
 			return nil
 		}
 		msg := fmt.Sprintf("previous message ID is nil for thread with ID [%s] and user [%s]", thread.ID, thread.UserID)
@@ -185,8 +178,7 @@ func (service *MessageThreadService) UpdateAfterDeletedMessage(ctx context.Conte
 	thread.UpdatedAt = time.Now().UTC()
 
 	if err = service.repository.Update(ctx, thread); err != nil {
-		msg := fmt.Sprintf("cannot update thread with ID [%s] for user with ID [%s]", thread.ID, thread.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update thread with ID [%s] for user with ID [%s]", thread.ID, thread.UserID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("last message has been removed from thread with ID [%s] and userID [%s]", thread.ID, thread.UserID))
@@ -215,8 +207,7 @@ func (service *MessageThreadService) createThread(ctx context.Context, params Me
 	}
 
 	if err := service.repository.Store(ctx, thread); err != nil {
-		msg := fmt.Sprintf("cannot store thread with id [%s] for message with ID [%s]", thread.ID, params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot store thread with id [%s] for message with ID [%s]", thread.ID, params.MessageID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf(
@@ -271,8 +262,7 @@ func (service *MessageThreadService) GetThreads(ctx context.Context, params Mess
 
 	threads, err := service.repository.Index(ctx, params.UserID, params.Owner, params.IsArchived, params.IndexParams)
 	if err != nil {
-		msg := fmt.Sprintf("could not fetch messages threads for params [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not fetch messages threads for params [%+#v]", params))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] threads with params [%+#v]", len(*threads), params))
@@ -286,8 +276,7 @@ func (service *MessageThreadService) GetThread(ctx context.Context, userID entit
 
 	thread, err := service.repository.Load(ctx, userID, messageThreadID)
 	if err != nil {
-		msg := fmt.Sprintf("could not fetch thread with ID [%s] for user [%s]", messageThreadID, userID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "could not fetch thread with ID [%s] for user [%s]", messageThreadID, userID))
 	}
 
 	return thread, nil
@@ -299,8 +288,7 @@ func (service *MessageThreadService) DeleteThread(ctx context.Context, source st
 	defer span.End()
 
 	if err := service.repository.Delete(ctx, thread.UserID, thread.ID); err != nil {
-		msg := fmt.Sprintf("could not delete message thread with ID [%s] for user with ID [%s]", thread.ID, thread.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "could not delete message thread with ID [%s] for user with ID [%s]", thread.ID, thread.UserID))
 	}
 
 	event, err := service.createEvent(events.MessageThreadAPIDeleted, source, &events.MessageThreadAPIDeletedPayload{
@@ -314,14 +302,12 @@ func (service *MessageThreadService) DeleteThread(ctx context.Context, source st
 		Timestamp:       time.Now().UTC(),
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create [%T] for message thread dleted with ID [%s]", event, thread.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create [%T] for message thread dleted with ID [%s]", event, thread.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created event [%s] with id [%s] for message thread [%s]", event.Type(), event.ID(), thread.ID))
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event [%s] with id [%s] for message thread [%s]", event.Type(), event.ID(), thread.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event [%s] with id [%s] for message thread [%s]", event.Type(), event.ID(), thread.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("dispatched [%s] event with id [%s] for message thread [%s]", event.Type(), event.ID(), thread.ID))

--- a/api/pkg/services/message_thread_service.go
+++ b/api/pkg/services/message_thread_service.go
@@ -68,7 +68,7 @@ func (service *MessageThreadService) DeleteAllForUser(ctx context.Context, userI
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
 		msg := fmt.Sprintf("could not delete [entities.MessageThread] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.MessageThread] for user with ID [%s]", userID))
@@ -90,16 +90,16 @@ func (service *MessageThreadService) UpdateThread(ctx context.Context, params Me
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot find thread with owner [%s], and contact [%s]. creating new thread", params.Owner, params.Contact)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if thread.OrderTimestamp.Unix() > params.Timestamp.Unix() && thread.Status != entities.MessageStatusSending && thread.HasLastMessage(params.MessageID) {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("thread [%s] has timestamp [%s] and status [%s] which is greater than timestamp [%s] for message [%s] and status [%s]", thread.ID, thread.OrderTimestamp, thread.Status, params.Timestamp, params.MessageID, params.Status)))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("thread [%s] has timestamp [%s] and status [%s] which is greater than timestamp [%s] for message [%s] and status [%s]", thread.ID, thread.OrderTimestamp, thread.Status, params.Timestamp, params.MessageID, params.Status)))
 		return nil
 	}
 
 	if thread.Status == entities.MessageStatusDelivered && thread.LastMessageID != nil && thread.HasLastMessage(params.MessageID) {
-		ctxLogger.Warn(stacktrace.NewError(fmt.Sprintf("thread [%s] already has status [%s] not updating with status [%s] for message [%s]", thread.ID, thread.Status, params.Status, params.MessageID)))
+		ctxLogger.Warn(stacktrace.NewError("%s", fmt.Sprintf("thread [%s] already has status [%s] not updating with status [%s] for message [%s]", thread.ID, thread.Status, params.Status, params.MessageID)))
 		return nil
 	}
 
@@ -115,7 +115,7 @@ func (service *MessageThreadService) UpdateThread(ctx context.Context, params Me
 
 	if err = service.repository.Update(ctx, thread.Update(params.Timestamp, params.MessageID, params.Content, params.Status)); err != nil {
 		msg := fmt.Sprintf("cannot update message thread with id [%s] after adding message [%s]", thread.ID, params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("thread with id [%s] updated with last message [%s] and status [%s]", thread.ID, thread.LastMessageID, thread.Status))
@@ -139,12 +139,12 @@ func (service *MessageThreadService) UpdateStatus(ctx context.Context, params Me
 	thread, err := service.repository.Load(ctx, params.UserID, params.MessageThreadID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot find thread with id [%s]", params.MessageThreadID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.repository.Update(ctx, thread.UpdateArchive(params.IsArchived)); err != nil {
 		msg := fmt.Sprintf("cannot update message thread with id [%s] with archive status [%t]", thread.ID, params.IsArchived)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("thread with id [%s] updated with archive status [%t]", thread.ID, thread.IsArchived))
@@ -159,13 +159,13 @@ func (service *MessageThreadService) UpdateAfterDeletedMessage(ctx context.Conte
 	thread, err := service.repository.LoadByOwnerContact(ctx, payload.UserID, payload.Owner, payload.Contact)
 	if err != nil {
 		msg := fmt.Sprintf("cannot find thread for user [%s] with owner [%s], and contact [%s]", payload.UserID, payload.Owner, payload.Contact)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if payload.PreviousMessageID == nil {
 		if err = service.repository.Delete(ctx, thread.UserID, thread.ID); err != nil {
 			msg := fmt.Sprintf("cannot delete thread with ID [%s] for user [%s] and owner [%s]", thread.ID, thread.UserID, thread.Owner)
-			ctxLogger.Error(stacktrace.Propagate(err, msg))
+			ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 			return nil
 		}
 		msg := fmt.Sprintf("previous message ID is nil for thread with ID [%s] and user [%s]", thread.ID, thread.UserID)
@@ -186,7 +186,7 @@ func (service *MessageThreadService) UpdateAfterDeletedMessage(ctx context.Conte
 
 	if err = service.repository.Update(ctx, thread); err != nil {
 		msg := fmt.Sprintf("cannot update thread with ID [%s] for user with ID [%s]", thread.ID, thread.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("last message has been removed from thread with ID [%s] and userID [%s]", thread.ID, thread.UserID))
@@ -216,7 +216,7 @@ func (service *MessageThreadService) createThread(ctx context.Context, params Me
 
 	if err := service.repository.Store(ctx, thread); err != nil {
 		msg := fmt.Sprintf("cannot store thread with id [%s] for message with ID [%s]", thread.ID, params.MessageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf(
@@ -272,7 +272,7 @@ func (service *MessageThreadService) GetThreads(ctx context.Context, params Mess
 	threads, err := service.repository.Index(ctx, params.UserID, params.Owner, params.IsArchived, params.IndexParams)
 	if err != nil {
 		msg := fmt.Sprintf("could not fetch messages threads for params [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] threads with params [%+#v]", len(*threads), params))
@@ -287,7 +287,7 @@ func (service *MessageThreadService) GetThread(ctx context.Context, userID entit
 	thread, err := service.repository.Load(ctx, userID, messageThreadID)
 	if err != nil {
 		msg := fmt.Sprintf("could not fetch thread with ID [%s] for user [%s]", messageThreadID, userID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	return thread, nil
@@ -300,7 +300,7 @@ func (service *MessageThreadService) DeleteThread(ctx context.Context, source st
 
 	if err := service.repository.Delete(ctx, thread.UserID, thread.ID); err != nil {
 		msg := fmt.Sprintf("could not delete message thread with ID [%s] for user with ID [%s]", thread.ID, thread.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	event, err := service.createEvent(events.MessageThreadAPIDeleted, source, &events.MessageThreadAPIDeletedPayload{
@@ -315,13 +315,13 @@ func (service *MessageThreadService) DeleteThread(ctx context.Context, source st
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create [%T] for message thread dleted with ID [%s]", event, thread.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created event [%s] with id [%s] for message thread [%s]", event.Type(), event.ID(), thread.ID))
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event [%s] with id [%s] for message thread [%s]", event.Type(), event.ID(), thread.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("dispatched [%s] event with id [%s] for message thread [%s]", event.Type(), event.ID(), thread.ID))

--- a/api/pkg/services/phone_api_key_service.go
+++ b/api/pkg/services/phone_api_key_service.go
@@ -55,8 +55,7 @@ func (service *PhoneAPIKeyService) Index(ctx context.Context, userID entities.Us
 
 	phoneAPIKeys, err := service.repository.Index(ctx, userID, params)
 	if err != nil {
-		msg := fmt.Sprintf("could not fetch phone API Keys with params [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not fetch phone API Keys with params [%+#v]", params))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] phone API Keys with prams [%+#v]", len(phoneAPIKeys), params))
@@ -86,8 +85,7 @@ func (service *PhoneAPIKeyService) Create(ctx context.Context, authContext entit
 	}
 
 	if err = service.repository.Create(ctx, phoneAPIKey); err != nil {
-		msg := fmt.Sprintf("cannot create PhoneAPIKey for user [%s]", authContext.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create PhoneAPIKey for user [%s]", authContext.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created [%T] with ID [%s] for user ID [%s]", phoneAPIKey, phoneAPIKey.ID, authContext.ID))
@@ -101,13 +99,11 @@ func (service *PhoneAPIKeyService) Delete(ctx context.Context, userID entities.U
 
 	phoneAPIKey, err := service.repository.Load(ctx, userID, phoneAPIKeyID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load [%T] with ID [%s] for user [%s]", &entities.PhoneAPIKey{}, phoneAPIKeyID, userID.String())
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot load [%T] with ID [%s] for user [%s]", &entities.PhoneAPIKey{}, phoneAPIKeyID, userID.String())
 	}
 
 	if err = service.repository.Delete(ctx, phoneAPIKey); err != nil {
-		msg := fmt.Sprintf("cannot delete [%T] with ID [%s] for user [%s]", phoneAPIKey, phoneAPIKey.ID, phoneAPIKey.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete [%T] with ID [%s] for user [%s]", phoneAPIKey, phoneAPIKey.ID, phoneAPIKey.UserID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted [%T] with ID [%s] for user ID [%s]", phoneAPIKey, phoneAPIKey.ID, userID))
@@ -121,19 +117,16 @@ func (service *PhoneAPIKeyService) RemovePhone(ctx context.Context, userID entit
 
 	phone, err := service.phoneRepository.LoadByID(ctx, userID, phoneID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load [%T] with ID [%s] for user [%s]", &entities.Phone{}, phoneID, userID.String())
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot load [%T] with ID [%s] for user [%s]", &entities.Phone{}, phoneID, userID.String())
 	}
 
 	phoneAPIKey, err := service.repository.Load(ctx, userID, phoneAPIKeyID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load [%T] with ID [%s] for user [%s]", &entities.PhoneAPIKey{}, phoneAPIKeyID, userID.String())
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot load [%T] with ID [%s] for user [%s]", &entities.PhoneAPIKey{}, phoneAPIKeyID, userID.String())
 	}
 
 	if err = service.repository.RemovePhone(ctx, phoneAPIKey, phone); err != nil {
-		msg := fmt.Sprintf("cannot remove [%T] with ID [%s] from phone API key with ID [%s] for user [%s]", phone, phone.ID, phoneAPIKey.ID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot remove [%T] with ID [%s] from phone API key with ID [%s] for user [%s]", phone, phone.ID, phoneAPIKey.ID, userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("removed [%T] with ID [%s] from [%T] with ID [%s] for user ID [%s]", phone, phoneID, phoneAPIKey, phoneAPIKeyID, userID))
@@ -146,8 +139,7 @@ func (service *PhoneAPIKeyService) RemovePhoneByID(ctx context.Context, userID e
 	defer span.End()
 
 	if err := service.repository.RemovePhoneByID(ctx, userID, phoneID, phoneNumber); err != nil {
-		msg := fmt.Sprintf("cannot remove [%T] with ID [%s] and number [%s] for user [%s]", &entities.Phone{}, phoneID, phoneNumber, userID.String())
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot remove [%T] with ID [%s] and number [%s] for user [%s]", &entities.Phone{}, phoneID, phoneNumber, userID.String())
 	}
 
 	ctxLogger.Info(fmt.Sprintf("removed phone with ID [%s] from [%T] for user ID [%s]", phoneID, &entities.PhoneAPIKey{}, userID))
@@ -160,8 +152,7 @@ func (service *PhoneAPIKeyService) DeleteAllForUser(ctx context.Context, userID 
 	defer span.End()
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
-		msg := fmt.Sprintf("cannot delete all [%T] for user ID [%s]", &entities.PhoneAPIKey{}, userID)
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot delete all [%T] for user ID [%s]", &entities.PhoneAPIKey{}, userID)
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [%T] for user ID [%s]", &entities.PhoneAPIKey{}, userID))
@@ -175,19 +166,16 @@ func (service *PhoneAPIKeyService) AddPhone(ctx context.Context, userID entities
 
 	phone, err := service.phoneRepository.LoadByID(ctx, userID, phoneID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load [%T] with ID [%s] for user [%s]", &entities.Phone{}, phoneID, userID.String())
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot load [%T] with ID [%s] for user [%s]", &entities.Phone{}, phoneID, userID.String())
 	}
 
 	phoneAPIKey, err := service.repository.Load(ctx, userID, phoneAPIKeyID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load [%T] with ID [%s] for user [%s]", &entities.PhoneAPIKey{}, phoneAPIKeyID, userID.String())
-		return stacktrace.Propagate(err, "%s", msg)
+		return stacktrace.Propagate(err, "cannot load [%T] with ID [%s] for user [%s]", &entities.PhoneAPIKey{}, phoneAPIKeyID, userID.String())
 	}
 
 	if err = service.repository.AddPhone(ctx, phoneAPIKey, phone); err != nil {
-		msg := fmt.Sprintf("cannot add [%T] with ID [%s] to phone API key with ID [%s] for user [%s]", phone, phone.ID, phoneAPIKey.ID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot add [%T] with ID [%s] to phone API key with ID [%s] for user [%s]", phone, phone.ID, phoneAPIKey.ID, userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("added [%T] with ID [%s] to [%T] with ID [%s] for user ID [%s]", phone, phone.ID, phoneAPIKey, phoneAPIKeyID, userID))
@@ -198,7 +186,7 @@ func (service *PhoneAPIKeyService) generateRandomBytes(n int) ([]byte, error) {
 	b := make([]byte, n)
 	// Note that err == nil only if we read len(b) bytes.
 	if _, err := rand.Read(b); err != nil {
-		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot generate [%d] random bytes", n))
+		return nil, stacktrace.Propagate(err, "cannot generate [%d] random bytes", n)
 	}
 
 	return b, nil
@@ -206,5 +194,5 @@ func (service *PhoneAPIKeyService) generateRandomBytes(n int) ([]byte, error) {
 
 func (service *PhoneAPIKeyService) generateAPIKey(n int) (string, error) {
 	b, err := service.generateRandomBytes(n)
-	return base64.URLEncoding.EncodeToString(b)[0:n], stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot generate [%d] random bytes", n))
+	return base64.URLEncoding.EncodeToString(b)[0:n], stacktrace.Propagate(err, "cannot generate [%d] random bytes", n)
 }

--- a/api/pkg/services/phone_api_key_service.go
+++ b/api/pkg/services/phone_api_key_service.go
@@ -56,7 +56,7 @@ func (service *PhoneAPIKeyService) Index(ctx context.Context, userID entities.Us
 	phoneAPIKeys, err := service.repository.Index(ctx, userID, params)
 	if err != nil {
 		msg := fmt.Sprintf("could not fetch phone API Keys with params [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] phone API Keys with prams [%+#v]", len(phoneAPIKeys), params))
@@ -87,7 +87,7 @@ func (service *PhoneAPIKeyService) Create(ctx context.Context, authContext entit
 
 	if err = service.repository.Create(ctx, phoneAPIKey); err != nil {
 		msg := fmt.Sprintf("cannot create PhoneAPIKey for user [%s]", authContext.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("created [%T] with ID [%s] for user ID [%s]", phoneAPIKey, phoneAPIKey.ID, authContext.ID))
@@ -102,12 +102,12 @@ func (service *PhoneAPIKeyService) Delete(ctx context.Context, userID entities.U
 	phoneAPIKey, err := service.repository.Load(ctx, userID, phoneAPIKeyID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load [%T] with ID [%s] for user [%s]", &entities.PhoneAPIKey{}, phoneAPIKeyID, userID.String())
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	if err = service.repository.Delete(ctx, phoneAPIKey); err != nil {
 		msg := fmt.Sprintf("cannot delete [%T] with ID [%s] for user [%s]", phoneAPIKey, phoneAPIKey.ID, phoneAPIKey.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted [%T] with ID [%s] for user ID [%s]", phoneAPIKey, phoneAPIKey.ID, userID))
@@ -122,18 +122,18 @@ func (service *PhoneAPIKeyService) RemovePhone(ctx context.Context, userID entit
 	phone, err := service.phoneRepository.LoadByID(ctx, userID, phoneID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load [%T] with ID [%s] for user [%s]", &entities.Phone{}, phoneID, userID.String())
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	phoneAPIKey, err := service.repository.Load(ctx, userID, phoneAPIKeyID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load [%T] with ID [%s] for user [%s]", &entities.PhoneAPIKey{}, phoneAPIKeyID, userID.String())
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	if err = service.repository.RemovePhone(ctx, phoneAPIKey, phone); err != nil {
 		msg := fmt.Sprintf("cannot remove [%T] with ID [%s] from phone API key with ID [%s] for user [%s]", phone, phone.ID, phoneAPIKey.ID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("removed [%T] with ID [%s] from [%T] with ID [%s] for user ID [%s]", phone, phoneID, phoneAPIKey, phoneAPIKeyID, userID))
@@ -147,7 +147,7 @@ func (service *PhoneAPIKeyService) RemovePhoneByID(ctx context.Context, userID e
 
 	if err := service.repository.RemovePhoneByID(ctx, userID, phoneID, phoneNumber); err != nil {
 		msg := fmt.Sprintf("cannot remove [%T] with ID [%s] and number [%s] for user [%s]", &entities.Phone{}, phoneID, phoneNumber, userID.String())
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	ctxLogger.Info(fmt.Sprintf("removed phone with ID [%s] from [%T] for user ID [%s]", phoneID, &entities.PhoneAPIKey{}, userID))
@@ -161,7 +161,7 @@ func (service *PhoneAPIKeyService) DeleteAllForUser(ctx context.Context, userID 
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
 		msg := fmt.Sprintf("cannot delete all [%T] for user ID [%s]", &entities.PhoneAPIKey{}, userID)
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [%T] for user ID [%s]", &entities.PhoneAPIKey{}, userID))
@@ -176,18 +176,18 @@ func (service *PhoneAPIKeyService) AddPhone(ctx context.Context, userID entities
 	phone, err := service.phoneRepository.LoadByID(ctx, userID, phoneID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load [%T] with ID [%s] for user [%s]", &entities.Phone{}, phoneID, userID.String())
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	phoneAPIKey, err := service.repository.Load(ctx, userID, phoneAPIKeyID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load [%T] with ID [%s] for user [%s]", &entities.PhoneAPIKey{}, phoneAPIKeyID, userID.String())
-		return stacktrace.Propagate(err, msg)
+		return stacktrace.Propagate(err, "%s", msg)
 	}
 
 	if err = service.repository.AddPhone(ctx, phoneAPIKey, phone); err != nil {
 		msg := fmt.Sprintf("cannot add [%T] with ID [%s] to phone API key with ID [%s] for user [%s]", phone, phone.ID, phoneAPIKey.ID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("added [%T] with ID [%s] to [%T] with ID [%s] for user ID [%s]", phone, phone.ID, phoneAPIKey, phoneAPIKeyID, userID))
@@ -198,7 +198,7 @@ func (service *PhoneAPIKeyService) generateRandomBytes(n int) ([]byte, error) {
 	b := make([]byte, n)
 	// Note that err == nil only if we read len(b) bytes.
 	if _, err := rand.Read(b); err != nil {
-		return nil, stacktrace.Propagate(err, fmt.Sprintf("cannot generate [%d] random bytes", n))
+		return nil, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot generate [%d] random bytes", n))
 	}
 
 	return b, nil
@@ -206,5 +206,5 @@ func (service *PhoneAPIKeyService) generateRandomBytes(n int) ([]byte, error) {
 
 func (service *PhoneAPIKeyService) generateAPIKey(n int) (string, error) {
 	b, err := service.generateRandomBytes(n)
-	return base64.URLEncoding.EncodeToString(b)[0:n], stacktrace.Propagate(err, fmt.Sprintf("cannot generate [%d] random bytes", n))
+	return base64.URLEncoding.EncodeToString(b)[0:n], stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot generate [%d] random bytes", n))
 }

--- a/api/pkg/services/phone_notification_service.go
+++ b/api/pkg/services/phone_notification_service.go
@@ -58,7 +58,7 @@ func (service *PhoneNotificationService) DeleteAllForUser(ctx context.Context, u
 
 	if err := service.phoneNotificationRepository.DeleteAllForUser(ctx, userID); err != nil {
 		msg := fmt.Sprintf("could not delete all [entities.PhoneNotification] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.PhoneNotification] for user with ID [%s]", userID))
@@ -72,7 +72,7 @@ func (service *PhoneNotificationService) DeleteByMessageID(ctx context.Context, 
 
 	if err := service.phoneNotificationRepository.DeleteByMessageID(ctx, userID, messageID); err != nil {
 		msg := fmt.Sprintf("could not delete [entities.PhoneNotification] for user [%s] and message with ID [%s]", userID, messageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted [entities.PhoneNotification] for user [%s] and message with ID [%s]", userID, messageID))
@@ -87,12 +87,12 @@ func (service *PhoneNotificationService) SendHeartbeatFCM(ctx context.Context, p
 	phone, err := service.phoneRepository.LoadByID(ctx, payload.UserID, payload.PhoneID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load phone with userID [%s] and phoneID [%s]", payload.UserID, payload.PhoneID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if phone.FcmToken == nil {
 		msg := fmt.Sprintf("phone with id [%s] has no FCM token", phone.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	result, err := service.messagingClient.Send(ctx, &messaging.Message{
@@ -106,7 +106,7 @@ func (service *PhoneNotificationService) SendHeartbeatFCM(ctx context.Context, p
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot send heartbeat FCM to phone with id [%s] for user [%s]", phone.ID, phone.UserID)
-		ctxLogger.Warn(stacktrace.Propagate(err, msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 		return nil
 	}
 
@@ -160,7 +160,7 @@ func (service *PhoneNotificationService) Send(ctx context.Context, params *Phone
 	if err != nil {
 		ctxLogger.Warn(stacktrace.Propagate(
 			err,
-			fmt.Sprintf(
+			"%s", fmt.Sprintf(
 				"cannot send FCM to phone with ID [%s] for user with ID [%s] and message [%s]",
 				phone.ID,
 				phone.UserID,
@@ -198,7 +198,7 @@ func (service *PhoneNotificationService) Schedule(ctx context.Context, params *P
 	phone, err := service.phoneRepository.Load(ctx, params.UserID, params.Owner)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load phone with userID [%s] and phone [%s]", params.UserID, params.Owner)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	notification := &entities.PhoneNotification{
@@ -221,7 +221,7 @@ func (service *PhoneNotificationService) Schedule(ctx context.Context, params *P
 		schedule, err = service.messageSendScheduleRepository.Load(ctx, params.UserID, *phone.MessageSendScheduleID)
 		if err != nil && stacktrace.GetCode(err) != repositories.ErrCodeNotFound {
 			msg := fmt.Sprintf("cannot load send schedule [%s] for phone [%s]", *phone.MessageSendScheduleID, phone.ID)
-			return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+			return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 		}
 	}
 
@@ -231,7 +231,7 @@ func (service *PhoneNotificationService) Schedule(ctx context.Context, params *P
 
 	if err = service.phoneNotificationRepository.Schedule(ctx, phone.MessagesPerMinute, schedule, notification); err != nil {
 		msg := fmt.Sprintf("cannot schedule notification for message [%s] to phone [%s]", params.MessageID, phone.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.dispatchMessageNotificationScheduled(ctx, params, notification); err != nil {
@@ -268,7 +268,7 @@ func (service *PhoneNotificationService) scheduleExact(
 
 	if err := service.phoneNotificationRepository.ScheduleExact(ctx, notification); err != nil {
 		msg := fmt.Sprintf("cannot schedule exact notification for message [%s] to phone [%s]", params.MessageID, phone.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err := service.dispatchMessageNotificationScheduled(ctx, params, notification); err != nil {
@@ -301,11 +301,11 @@ func (service *PhoneNotificationService) dispatchMessageNotificationSend(
 		NotificationID: notification.ID,
 	})
 	if err != nil {
-		return stacktrace.Propagate(err, fmt.Sprintf("cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationSend, notification.ID))
+		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationSend, notification.ID))
 	}
 
 	if _, err = service.eventDispatcher.DispatchWithTimeout(ctx, event, notification.ScheduledAt.Sub(time.Now())); err != nil {
-		return stacktrace.Propagate(err, fmt.Sprintf("cannot dispatch event [%s] for notification [%s]", event.Type(), notification.ID))
+		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot dispatch event [%s] for notification [%s]", event.Type(), notification.ID))
 	}
 	return nil
 }
@@ -328,11 +328,11 @@ func (service *PhoneNotificationService) dispatchMessageNotificationScheduled(
 		NotificationID: notification.ID,
 	})
 	if err != nil {
-		return stacktrace.Propagate(err, fmt.Sprintf("cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationScheduled, notification.ID))
+		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationScheduled, notification.ID))
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		return stacktrace.Propagate(err, fmt.Sprintf("cannot dispatch event [%s] for notification [%s]", event.Type(), notification.ID))
+		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot dispatch event [%s] for notification [%s]", event.Type(), notification.ID))
 	}
 	return nil
 }
@@ -344,15 +344,15 @@ func (service *PhoneNotificationService) handleNotificationFailed(ctx context.Co
 	ctxLogger := service.tracer.CtxLogger(service.logger, span)
 
 	msg := fmt.Sprintf("cannot send notification for message [%s] to phone [%s]", params.MessageID, params.PhoneNotificationID)
-	ctxLogger.Warn(stacktrace.Propagate(err, msg))
+	ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
 
 	event, err := service.createMessageNotificationFailedEvent(params.Source, err.Error(), params)
 	if err != nil {
-		return stacktrace.Propagate(err, fmt.Sprintf("cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationFailed, params.PhoneNotificationID))
+		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationFailed, params.PhoneNotificationID))
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		return stacktrace.Propagate(err, fmt.Sprintf("cannot dispatch event [%s] for notification [%s]", event.Type(), params.PhoneNotificationID))
+		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot dispatch event [%s] for notification [%s]", event.Type(), params.PhoneNotificationID))
 	}
 
 	service.updateStatus(ctx, params.PhoneNotificationID, entities.PhoneNotificationStatusFailed)
@@ -374,11 +374,11 @@ func (service *PhoneNotificationService) handleNotificationSent(
 
 	event, err := service.createMessageNotificationSentEvent(params.Source, phone, result, params)
 	if err != nil {
-		return stacktrace.Propagate(err, fmt.Sprintf("cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationSent, params.PhoneNotificationID))
+		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationSent, params.PhoneNotificationID))
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		return stacktrace.Propagate(err, fmt.Sprintf("cannot dispatch event [%s] for notification [%s]", event.Type(), params.PhoneNotificationID))
+		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot dispatch event [%s] for notification [%s]", event.Type(), params.PhoneNotificationID))
 	}
 
 	service.updateStatus(ctx, params.PhoneNotificationID, entities.PhoneNotificationStatusSent)
@@ -425,7 +425,7 @@ func (service *PhoneNotificationService) createMessageNotificationSentEvent(
 
 	if err := event.SetData(cloudevents.ApplicationJSON, payload); err != nil {
 		msg := fmt.Sprintf("cannot encode %T [%#+v] as JSON", payload, payload)
-		return event, stacktrace.Propagate(err, msg)
+		return event, stacktrace.Propagate(err, "%s", msg)
 	}
 
 	return event, nil
@@ -454,7 +454,7 @@ func (service *PhoneNotificationService) createMessageNotificationFailedEvent(
 
 	if err := event.SetData(cloudevents.ApplicationJSON, payload); err != nil {
 		msg := fmt.Sprintf("cannot encode %T [%#+v] as JSON", payload, payload)
-		return event, stacktrace.Propagate(err, msg)
+		return event, stacktrace.Propagate(err, "%s", msg)
 	}
 
 	return event, nil
@@ -473,7 +473,7 @@ func (service *PhoneNotificationService) updateStatus(
 	err := service.phoneNotificationRepository.UpdateStatus(ctx, notificationID, status)
 	if err != nil {
 		msg := fmt.Sprintf("cannot update status of notification with id [%s] to [%s]", notificationID, status)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("updated status of notification with id [%s] to [%s]", notificationID, status))

--- a/api/pkg/services/phone_notification_service.go
+++ b/api/pkg/services/phone_notification_service.go
@@ -57,8 +57,7 @@ func (service *PhoneNotificationService) DeleteAllForUser(ctx context.Context, u
 	defer span.End()
 
 	if err := service.phoneNotificationRepository.DeleteAllForUser(ctx, userID); err != nil {
-		msg := fmt.Sprintf("could not delete all [entities.PhoneNotification] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not delete all [entities.PhoneNotification] for user with ID [%s]", userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.PhoneNotification] for user with ID [%s]", userID))
@@ -71,8 +70,7 @@ func (service *PhoneNotificationService) DeleteByMessageID(ctx context.Context, 
 	defer span.End()
 
 	if err := service.phoneNotificationRepository.DeleteByMessageID(ctx, userID, messageID); err != nil {
-		msg := fmt.Sprintf("could not delete [entities.PhoneNotification] for user [%s] and message with ID [%s]", userID, messageID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not delete [entities.PhoneNotification] for user [%s] and message with ID [%s]", userID, messageID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted [entities.PhoneNotification] for user [%s] and message with ID [%s]", userID, messageID))
@@ -86,13 +84,11 @@ func (service *PhoneNotificationService) SendHeartbeatFCM(ctx context.Context, p
 
 	phone, err := service.phoneRepository.LoadByID(ctx, payload.UserID, payload.PhoneID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load phone with userID [%s] and phoneID [%s]", payload.UserID, payload.PhoneID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load phone with userID [%s] and phoneID [%s]", payload.UserID, payload.PhoneID))
 	}
 
 	if phone.FcmToken == nil {
-		msg := fmt.Sprintf("phone with id [%s] has no FCM token", phone.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "phone with id [%s] has no FCM token", phone.ID))
 	}
 
 	result, err := service.messagingClient.Send(ctx, &messaging.Message{
@@ -105,8 +101,7 @@ func (service *PhoneNotificationService) SendHeartbeatFCM(ctx context.Context, p
 		Token: *phone.FcmToken,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot send heartbeat FCM to phone with id [%s] for user [%s]", phone.ID, phone.UserID)
-		ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Warn(stacktrace.Propagate(err, "cannot send heartbeat FCM to phone with id [%s] for user [%s]", phone.ID, phone.UserID))
 		return nil
 	}
 
@@ -160,12 +155,11 @@ func (service *PhoneNotificationService) Send(ctx context.Context, params *Phone
 	if err != nil {
 		ctxLogger.Warn(stacktrace.Propagate(
 			err,
-			"%s", fmt.Sprintf(
-				"cannot send FCM to phone with ID [%s] for user with ID [%s] and message [%s]",
-				phone.ID,
-				phone.UserID,
-				params.MessageID,
-			),
+
+			"cannot send FCM to phone with ID [%s] for user with ID [%s] and message [%s]",
+			phone.ID,
+			phone.UserID,
+			params.MessageID,
 		))
 		msg := fmt.Sprintf("cannot send notification to your phone [%s]. Reinstall the httpSMS app on your Android phone.", phone.PhoneNumber)
 		return service.handleNotificationFailed(ctx, errors.New(msg), params)
@@ -197,8 +191,7 @@ func (service *PhoneNotificationService) Schedule(ctx context.Context, params *P
 
 	phone, err := service.phoneRepository.Load(ctx, params.UserID, params.Owner)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load phone with userID [%s] and phone [%s]", params.UserID, params.Owner)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load phone with userID [%s] and phone [%s]", params.UserID, params.Owner))
 	}
 
 	notification := &entities.PhoneNotification{
@@ -220,8 +213,7 @@ func (service *PhoneNotificationService) Schedule(ctx context.Context, params *P
 	if phone.MessageSendScheduleID != nil {
 		schedule, err = service.messageSendScheduleRepository.Load(ctx, params.UserID, *phone.MessageSendScheduleID)
 		if err != nil && stacktrace.GetCode(err) != repositories.ErrCodeNotFound {
-			msg := fmt.Sprintf("cannot load send schedule [%s] for phone [%s]", *phone.MessageSendScheduleID, phone.ID)
-			return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+			return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load send schedule [%s] for phone [%s]", *phone.MessageSendScheduleID, phone.ID))
 		}
 	}
 
@@ -230,8 +222,7 @@ func (service *PhoneNotificationService) Schedule(ctx context.Context, params *P
 	}
 
 	if err = service.phoneNotificationRepository.Schedule(ctx, phone.MessagesPerMinute, schedule, notification); err != nil {
-		msg := fmt.Sprintf("cannot schedule notification for message [%s] to phone [%s]", params.MessageID, phone.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot schedule notification for message [%s] to phone [%s]", params.MessageID, phone.ID))
 	}
 
 	if err = service.dispatchMessageNotificationScheduled(ctx, params, notification); err != nil {
@@ -267,8 +258,7 @@ func (service *PhoneNotificationService) scheduleExact(
 	notification.ScheduledAt = scheduledAt
 
 	if err := service.phoneNotificationRepository.ScheduleExact(ctx, notification); err != nil {
-		msg := fmt.Sprintf("cannot schedule exact notification for message [%s] to phone [%s]", params.MessageID, phone.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot schedule exact notification for message [%s] to phone [%s]", params.MessageID, phone.ID))
 	}
 
 	if err := service.dispatchMessageNotificationScheduled(ctx, params, notification); err != nil {
@@ -301,11 +291,11 @@ func (service *PhoneNotificationService) dispatchMessageNotificationSend(
 		NotificationID: notification.ID,
 	})
 	if err != nil {
-		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationSend, notification.ID))
+		return stacktrace.Propagate(err, "cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationSend, notification.ID)
 	}
 
 	if _, err = service.eventDispatcher.DispatchWithTimeout(ctx, event, notification.ScheduledAt.Sub(time.Now())); err != nil {
-		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot dispatch event [%s] for notification [%s]", event.Type(), notification.ID))
+		return stacktrace.Propagate(err, "cannot dispatch event [%s] for notification [%s]", event.Type(), notification.ID)
 	}
 	return nil
 }
@@ -328,11 +318,11 @@ func (service *PhoneNotificationService) dispatchMessageNotificationScheduled(
 		NotificationID: notification.ID,
 	})
 	if err != nil {
-		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationScheduled, notification.ID))
+		return stacktrace.Propagate(err, "cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationScheduled, notification.ID)
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot dispatch event [%s] for notification [%s]", event.Type(), notification.ID))
+		return stacktrace.Propagate(err, "cannot dispatch event [%s] for notification [%s]", event.Type(), notification.ID)
 	}
 	return nil
 }
@@ -343,16 +333,15 @@ func (service *PhoneNotificationService) handleNotificationFailed(ctx context.Co
 
 	ctxLogger := service.tracer.CtxLogger(service.logger, span)
 
-	msg := fmt.Sprintf("cannot send notification for message [%s] to phone [%s]", params.MessageID, params.PhoneNotificationID)
-	ctxLogger.Warn(stacktrace.Propagate(err, "%s", msg))
+	ctxLogger.Warn(stacktrace.Propagate(err, "cannot send notification for message [%s] to phone [%s]", params.MessageID, params.PhoneNotificationID))
 
 	event, err := service.createMessageNotificationFailedEvent(params.Source, err.Error(), params)
 	if err != nil {
-		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationFailed, params.PhoneNotificationID))
+		return stacktrace.Propagate(err, "cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationFailed, params.PhoneNotificationID)
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot dispatch event [%s] for notification [%s]", event.Type(), params.PhoneNotificationID))
+		return stacktrace.Propagate(err, "cannot dispatch event [%s] for notification [%s]", event.Type(), params.PhoneNotificationID)
 	}
 
 	service.updateStatus(ctx, params.PhoneNotificationID, entities.PhoneNotificationStatusFailed)
@@ -374,11 +363,11 @@ func (service *PhoneNotificationService) handleNotificationSent(
 
 	event, err := service.createMessageNotificationSentEvent(params.Source, phone, result, params)
 	if err != nil {
-		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationSent, params.PhoneNotificationID))
+		return stacktrace.Propagate(err, "cannot create [%s] event for notification [%s]", events.EventTypeMessageNotificationSent, params.PhoneNotificationID)
 	}
 
 	if err = service.eventDispatcher.Dispatch(ctx, event); err != nil {
-		return stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot dispatch event [%s] for notification [%s]", event.Type(), params.PhoneNotificationID))
+		return stacktrace.Propagate(err, "cannot dispatch event [%s] for notification [%s]", event.Type(), params.PhoneNotificationID)
 	}
 
 	service.updateStatus(ctx, params.PhoneNotificationID, entities.PhoneNotificationStatusSent)
@@ -424,8 +413,7 @@ func (service *PhoneNotificationService) createMessageNotificationSentEvent(
 	}
 
 	if err := event.SetData(cloudevents.ApplicationJSON, payload); err != nil {
-		msg := fmt.Sprintf("cannot encode %T [%#+v] as JSON", payload, payload)
-		return event, stacktrace.Propagate(err, "%s", msg)
+		return event, stacktrace.Propagate(err, "cannot encode %T [%#+v] as JSON", payload, payload)
 	}
 
 	return event, nil
@@ -453,8 +441,7 @@ func (service *PhoneNotificationService) createMessageNotificationFailedEvent(
 	}
 
 	if err := event.SetData(cloudevents.ApplicationJSON, payload); err != nil {
-		msg := fmt.Sprintf("cannot encode %T [%#+v] as JSON", payload, payload)
-		return event, stacktrace.Propagate(err, "%s", msg)
+		return event, stacktrace.Propagate(err, "cannot encode %T [%#+v] as JSON", payload, payload)
 	}
 
 	return event, nil
@@ -472,8 +459,7 @@ func (service *PhoneNotificationService) updateStatus(
 
 	err := service.phoneNotificationRepository.UpdateStatus(ctx, notificationID, status)
 	if err != nil {
-		msg := fmt.Sprintf("cannot update status of notification with id [%s] to [%s]", notificationID, status)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot update status of notification with id [%s] to [%s]", notificationID, status))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("updated status of notification with id [%s] to [%s]", notificationID, status))

--- a/api/pkg/services/phone_service.go
+++ b/api/pkg/services/phone_service.go
@@ -48,8 +48,7 @@ func (service *PhoneService) DeleteAllForUser(ctx context.Context, userID entiti
 	defer span.End()
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
-		msg := fmt.Sprintf("could not delete all [entities.Phone] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not delete all [entities.Phone] for user with ID [%s]", userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.Phone] for user with ID [%s]", userID))
@@ -62,8 +61,7 @@ func (service *PhoneService) NullifyScheduleID(ctx context.Context, userID entit
 	defer span.End()
 
 	if err := service.repository.NullifyScheduleID(ctx, userID, scheduleID); err != nil {
-		msg := fmt.Sprintf("cannot nullify schedule ID [%s] for user [%s]", scheduleID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot nullify schedule ID [%s] for user [%s]", scheduleID, userID))
 	}
 
 	service.tracer.CtxLogger(service.logger, span).Info(fmt.Sprintf("nullified schedule ID [%s] on phones for user [%s]", scheduleID, userID))
@@ -79,8 +77,7 @@ func (service *PhoneService) Index(ctx context.Context, authUser entities.AuthCo
 
 	phones, err := service.repository.Index(ctx, authUser.ID, params)
 	if err != nil {
-		msg := fmt.Sprintf("could not fetch phones with parms [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not fetch phones with parms [%+#v]", params))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] phones with prams [%+#v]", len(*phones), params))
@@ -132,13 +129,11 @@ func (service *PhoneService) Upsert(ctx context.Context, params *PhoneUpsertPara
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot upsert phone with id [%s] and number [%s]", phone.ID, phone.PhoneNumber)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot upsert phone with id [%s] and number [%s]", phone.ID, phone.PhoneNumber))
 	}
 
 	if err = service.repository.Save(ctx, service.update(phone, params)); err != nil {
-		msg := fmt.Sprintf("cannot update phone with id [%s] and number [%s]", phone.ID, phone.PhoneNumber)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update phone with id [%s] and number [%s]", phone.ID, phone.PhoneNumber))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("phone updated with id [%s] in the phone repository for user [%s]", phone.ID, phone.UserID))
@@ -166,13 +161,11 @@ func (service *PhoneService) dispatchPhoneUpdatedEvent(ctx context.Context, phon
 		SIM:           phone.SIM,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event when phone [%s] is updated for user [%s]", phone.ID, phone.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create event when phone [%s] is updated for user [%s]", phone.ID, phone.UserID))
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event [%s] for phone with id [%s]", event.Type(), phone.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event [%s] for phone with id [%s]", event.Type(), phone.ID))
 	}
 	return nil
 }
@@ -186,13 +179,11 @@ func (service *PhoneService) Delete(ctx context.Context, source string, userID e
 
 	phone, err := service.repository.LoadByID(ctx, userID, phoneID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load phone with userID [%s] and phoneID [%s]", userID, phoneID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load phone with userID [%s] and phoneID [%s]", userID, phoneID))
 	}
 
 	if err = service.repository.Delete(ctx, userID, phoneID); err != nil {
-		msg := fmt.Sprintf("cannot delete phone with id [%s] and user id [%s]", phoneID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete phone with id [%s] and user id [%s]", phoneID, userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted phone with id [%s] and user id [%s]", phoneID, userID))
@@ -205,13 +196,11 @@ func (service *PhoneService) Delete(ctx context.Context, source string, userID e
 		SIM:       phone.SIM,
 	})
 	if err != nil {
-		msg := "cannot create event when phone is deleted"
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create event when phone is deleted"))
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event [%s] for phone with id [%s]", event.Type(), phone.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event [%s] for phone with id [%s]", event.Type(), phone.ID))
 	}
 
 	return nil
@@ -239,16 +228,14 @@ func (service *PhoneService) UpsertFCMToken(ctx context.Context, params *PhoneFC
 	}
 
 	if err != nil {
-		msg := fmt.Sprintf("cannot upsert FCM token for user with id [%s] and number [%s]", params.UserID, params.PhoneNumber)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot upsert FCM token for user with id [%s] and number [%s]", params.UserID, params.PhoneNumber))
 	}
 
 	phone.FcmToken = params.FcmToken
 	phone.SIM = params.SIM
 
 	if err = service.repository.Save(ctx, phone); err != nil {
-		msg := fmt.Sprintf("cannot update phone with id [%s] and number [%s]", phone.ID, phone.PhoneNumber)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot update phone with id [%s] and number [%s]", phone.ID, phone.PhoneNumber))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("phone updated with id [%s] in the phone repository for user [%s]", phone.ID, phone.UserID))
@@ -277,8 +264,7 @@ func (service *PhoneService) createPhone(ctx context.Context, params *PhoneFCMTo
 	}
 
 	if err := service.repository.Save(ctx, phone); err != nil {
-		msg := fmt.Sprintf("cannot create phone with id [%s] and number [%s]", phone.ID, phone.PhoneNumber)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create phone with id [%s] and number [%s]", phone.ID, phone.PhoneNumber))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("phone updated with id [%s] in the phone repository for user [%s]", phone.ID, phone.UserID))

--- a/api/pkg/services/phone_service.go
+++ b/api/pkg/services/phone_service.go
@@ -49,7 +49,7 @@ func (service *PhoneService) DeleteAllForUser(ctx context.Context, userID entiti
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
 		msg := fmt.Sprintf("could not delete all [entities.Phone] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.Phone] for user with ID [%s]", userID))
@@ -63,7 +63,7 @@ func (service *PhoneService) NullifyScheduleID(ctx context.Context, userID entit
 
 	if err := service.repository.NullifyScheduleID(ctx, userID, scheduleID); err != nil {
 		msg := fmt.Sprintf("cannot nullify schedule ID [%s] for user [%s]", scheduleID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	service.tracer.CtxLogger(service.logger, span).Info(fmt.Sprintf("nullified schedule ID [%s] on phones for user [%s]", scheduleID, userID))
@@ -80,7 +80,7 @@ func (service *PhoneService) Index(ctx context.Context, authUser entities.AuthCo
 	phones, err := service.repository.Index(ctx, authUser.ID, params)
 	if err != nil {
 		msg := fmt.Sprintf("could not fetch phones with parms [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] phones with prams [%+#v]", len(*phones), params))
@@ -133,12 +133,12 @@ func (service *PhoneService) Upsert(ctx context.Context, params *PhoneUpsertPara
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot upsert phone with id [%s] and number [%s]", phone.ID, phone.PhoneNumber)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.repository.Save(ctx, service.update(phone, params)); err != nil {
 		msg := fmt.Sprintf("cannot update phone with id [%s] and number [%s]", phone.ID, phone.PhoneNumber)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("phone updated with id [%s] in the phone repository for user [%s]", phone.ID, phone.UserID))
@@ -167,12 +167,12 @@ func (service *PhoneService) dispatchPhoneUpdatedEvent(ctx context.Context, phon
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event when phone [%s] is updated for user [%s]", phone.ID, phone.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event [%s] for phone with id [%s]", event.Type(), phone.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 	return nil
 }
@@ -187,12 +187,12 @@ func (service *PhoneService) Delete(ctx context.Context, source string, userID e
 	phone, err := service.repository.LoadByID(ctx, userID, phoneID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load phone with userID [%s] and phoneID [%s]", userID, phoneID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.repository.Delete(ctx, userID, phoneID); err != nil {
 		msg := fmt.Sprintf("cannot delete phone with id [%s] and user id [%s]", phoneID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted phone with id [%s] and user id [%s]", phoneID, userID))
@@ -206,12 +206,12 @@ func (service *PhoneService) Delete(ctx context.Context, source string, userID e
 	})
 	if err != nil {
 		msg := "cannot create event when phone is deleted"
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event [%s] for phone with id [%s]", event.Type(), phone.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -240,7 +240,7 @@ func (service *PhoneService) UpsertFCMToken(ctx context.Context, params *PhoneFC
 
 	if err != nil {
 		msg := fmt.Sprintf("cannot upsert FCM token for user with id [%s] and number [%s]", params.UserID, params.PhoneNumber)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	phone.FcmToken = params.FcmToken
@@ -248,7 +248,7 @@ func (service *PhoneService) UpsertFCMToken(ctx context.Context, params *PhoneFC
 
 	if err = service.repository.Save(ctx, phone); err != nil {
 		msg := fmt.Sprintf("cannot update phone with id [%s] and number [%s]", phone.ID, phone.PhoneNumber)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("phone updated with id [%s] in the phone repository for user [%s]", phone.ID, phone.UserID))
@@ -278,7 +278,7 @@ func (service *PhoneService) createPhone(ctx context.Context, params *PhoneFCMTo
 
 	if err := service.repository.Save(ctx, phone); err != nil {
 		msg := fmt.Sprintf("cannot create phone with id [%s] and number [%s]", phone.ID, phone.PhoneNumber)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("phone updated with id [%s] in the phone repository for user [%s]", phone.ID, phone.UserID))

--- a/api/pkg/services/service.go
+++ b/api/pkg/services/service.go
@@ -25,7 +25,7 @@ func (service *service) createEvent(eventType string, source string, payload any
 
 	if err := event.SetData(cloudevents.ApplicationJSON, payload); err != nil {
 		msg := fmt.Sprintf("cannot encode %T [%#+v] as JSON", payload, payload)
-		return event, stacktrace.Propagate(err, msg)
+		return event, stacktrace.Propagate(err, "%s", msg)
 	}
 
 	return event, nil
@@ -34,7 +34,7 @@ func (service *service) createEvent(eventType string, source string, payload any
 func (service *service) getFormattedNumber(ctxLogger telemetry.Logger, phoneNumber string) string {
 	matched, err := regexp.MatchString("^\\+?[1-9]\\d{9,14}$", phoneNumber)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("error while matching phoneNumber [%s] with regex [%s]", phoneNumber, "^\\+?[1-9]\\d{10,14}$")))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("error while matching phoneNumber [%s] with regex [%s]", phoneNumber, "^\\+?[1-9]\\d{10,14}$")))
 		return phoneNumber
 	}
 	if !matched {
@@ -43,7 +43,7 @@ func (service *service) getFormattedNumber(ctxLogger telemetry.Logger, phoneNumb
 
 	number, err := phonenumbers.Parse(phoneNumber, phonenumbers.UNKNOWN_REGION)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot parse number [%s]", phoneNumber)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot parse number [%s]", phoneNumber)))
 		return phoneNumber
 	}
 

--- a/api/pkg/services/service.go
+++ b/api/pkg/services/service.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"fmt"
 	"regexp"
 	"time"
 
@@ -24,8 +23,7 @@ func (service *service) createEvent(eventType string, source string, payload any
 	event.SetID(uuid.New().String())
 
 	if err := event.SetData(cloudevents.ApplicationJSON, payload); err != nil {
-		msg := fmt.Sprintf("cannot encode %T [%#+v] as JSON", payload, payload)
-		return event, stacktrace.Propagate(err, "%s", msg)
+		return event, stacktrace.Propagate(err, "cannot encode %T [%#+v] as JSON", payload, payload)
 	}
 
 	return event, nil
@@ -34,7 +32,7 @@ func (service *service) createEvent(eventType string, source string, payload any
 func (service *service) getFormattedNumber(ctxLogger telemetry.Logger, phoneNumber string) string {
 	matched, err := regexp.MatchString("^\\+?[1-9]\\d{9,14}$", phoneNumber)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("error while matching phoneNumber [%s] with regex [%s]", phoneNumber, "^\\+?[1-9]\\d{10,14}$")))
+		ctxLogger.Error(stacktrace.Propagate(err, "error while matching phoneNumber [%s] with regex [%s]", phoneNumber, "^\\+?[1-9]\\d{10,14}$"))
 		return phoneNumber
 	}
 	if !matched {
@@ -43,7 +41,7 @@ func (service *service) getFormattedNumber(ctxLogger telemetry.Logger, phoneNumb
 
 	number, err := phonenumbers.Parse(phoneNumber, phonenumbers.UNKNOWN_REGION)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot parse number [%s]", phoneNumber)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot parse number [%s]", phoneNumber))
 		return phoneNumber
 	}
 

--- a/api/pkg/services/service.go
+++ b/api/pkg/services/service.go
@@ -30,9 +30,11 @@ func (service *service) createEvent(eventType string, source string, payload any
 }
 
 func (service *service) getFormattedNumber(ctxLogger telemetry.Logger, phoneNumber string) string {
-	matched, err := regexp.MatchString("^\\+?[1-9]\\d{9,14}$", phoneNumber)
+	const phoneNumberPattern = "^\\+?[1-9]\\d{9,14}$"
+
+	matched, err := regexp.MatchString(phoneNumberPattern, phoneNumber)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "error while matching phoneNumber [%s] with regex [%s]", phoneNumber, "^\\+?[1-9]\\d{10,14}$"))
+		ctxLogger.Error(stacktrace.Propagate(err, "error while matching phoneNumber [%s] with regex [%s]", phoneNumber, phoneNumberPattern))
 		return phoneNumber
 	}
 	if !matched {

--- a/api/pkg/services/user_service.go
+++ b/api/pkg/services/user_service.go
@@ -67,7 +67,7 @@ func (service *UserService) GetSubscriptionPayments(ctx context.Context, userID 
 	user, err := service.repository.Load(ctx, userID)
 	if err != nil {
 		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, userID)
-		return invoices, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return invoices, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if user.SubscriptionID == nil {
@@ -79,7 +79,7 @@ func (service *UserService) GetSubscriptionPayments(ctx context.Context, userID 
 	invoicesResponse, _, err := service.lemonsqueezyClient.SubscriptionInvoices.List(ctx, map[string]string{"filter[subscription_id]": *user.SubscriptionID})
 	if err != nil {
 		msg := fmt.Sprintf("could not get invoices for subscription [%s] for [%T] with with ID [%s]", *user.SubscriptionID, user, user.ID)
-		return invoices, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return invoices, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] payments for [%T] with ID [%s] and subscription ID [%s]", len(invoicesResponse.Data), user, user.ID, *user.SubscriptionID))
@@ -118,13 +118,13 @@ func (service *UserService) GenerateReceipt(ctx context.Context, params *UserInv
 	invoice, _, err := service.lemonsqueezyClient.SubscriptionInvoices.Generate(ctx, params.SubscriptionInvoiceID, payload)
 	if err != nil {
 		msg := fmt.Sprintf("could not generate subscription payment invoice user with ID [%s] and subscription invoice ID [%s]", params.UserID, params.SubscriptionInvoiceID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	response, err := service.httpClient.Get(invoice.Meta.Urls.DownloadInvoice)
 	if err != nil {
 		msg := fmt.Sprintf("could not download subscription payment invoice for user with ID [%s] and subscription invoice ID [%s]", params.UserID, params.SubscriptionInvoiceID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("generated subscription payment invoice for user with ID [%s] and subscription invoice ID [%s]", params.UserID, params.SubscriptionInvoiceID))
@@ -139,7 +139,7 @@ func (service *UserService) Get(ctx context.Context, source string, authUser ent
 	user, isNew, err := service.repository.LoadOrStore(ctx, authUser)
 	if err != nil {
 		msg := fmt.Sprintf("could not get [%T] with from [%+#v]", user, authUser)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if isNew {
@@ -159,13 +159,13 @@ func (service *UserService) dispatchUserCreatedEvent(ctx context.Context, source
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event [%s] for user [%s]", events.UserAccountCreated, user.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", event.Type(), user.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return
 	}
 }
@@ -178,7 +178,7 @@ func (service *UserService) GetByID(ctx context.Context, userID entities.UserID)
 	user, err := service.repository.Load(ctx, userID)
 	if err != nil {
 		msg := fmt.Sprintf("could not get [%T] with ID [%s]", user, userID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return user, nil
@@ -200,7 +200,7 @@ func (service *UserService) Update(ctx context.Context, source string, authUser 
 	user, isNew, err := service.repository.LoadOrStore(ctx, authUser)
 	if err != nil {
 		msg := fmt.Sprintf("could not get [%T] with from [%+#v]", user, authUser)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if isNew {
@@ -212,7 +212,7 @@ func (service *UserService) Update(ctx context.Context, source string, authUser 
 
 	if err = service.repository.Update(ctx, user); err != nil {
 		msg := fmt.Sprintf("cannot save user with id [%s]", user.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("user saved with id [%s] in the userRepository", user.ID))
@@ -235,7 +235,7 @@ func (service *UserService) UpdateNotificationSettings(ctx context.Context, user
 	user, err := service.repository.Load(ctx, userID)
 	if err != nil {
 		msg := fmt.Sprintf("could not load [%T] with ID [%s]", user, userID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	user.NotificationWebhookEnabled = params.WebhookEnabled
@@ -245,7 +245,7 @@ func (service *UserService) UpdateNotificationSettings(ctx context.Context, user
 
 	if err = service.repository.Update(ctx, user); err != nil {
 		msg := fmt.Sprintf("cannot save user with id [%s] in [%T]", user.ID, service.repository)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("updated notification settings for [%T] with ID [%s] in the [%T]", user, user.ID, service.repository))
@@ -260,7 +260,7 @@ func (service *UserService) RotateAPIKey(ctx context.Context, source string, use
 	user, err := service.repository.RotateAPIKey(ctx, userID)
 	if err != nil {
 		msg := fmt.Sprintf("could not rotate API key for [%T] with ID [%s]", user, userID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("rotated the api key for [%T] with ID [%s] in the [%T]", user, user.ID, service.repository))
@@ -273,13 +273,13 @@ func (service *UserService) RotateAPIKey(ctx context.Context, source string, use
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event [%s] for user [%s]", events.UserAPIKeyRotated, user.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return user, nil
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", event.Type(), user.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
 		return user, nil
 	}
 
@@ -294,17 +294,17 @@ func (service *UserService) Delete(ctx context.Context, source string, userID en
 	user, err := service.repository.Load(ctx, userID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load user with ID [%s] from the [%T]", userID, service.repository)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if !user.IsOnFreePlan() && user.SubscriptionRenewsAt != nil && user.SubscriptionRenewsAt.After(time.Now()) {
 		msg := fmt.Sprintf("cannot delete user with ID [%s] because they are have an active [%s] subscription which renews at [%s]", userID, user.SubscriptionName, user.SubscriptionRenewsAt)
-		return service.tracer.WrapErrorSpan(span, stacktrace.NewError(msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg))
 	}
 
 	if err = service.repository.Delete(ctx, user); err != nil {
 		msg := fmt.Sprintf("could not delete user with ID [%s] from the [%T]", userID, service.repository)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("sucessfully deleted user with ID [%s] in the [%T]", userID, service.repository))
@@ -316,12 +316,12 @@ func (service *UserService) Delete(ctx context.Context, source string, userID en
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event [%s] for user [%s]", events.UserAccountDeleted, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", event.Type(), userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -337,12 +337,12 @@ func (service *UserService) SendAPIKeyRotatedEmail(ctx context.Context, payload 
 	email, err := service.emailFactory.APIKeyRotated(payload.Email, payload.Timestamp, payload.Timezone)
 	if err != nil {
 		msg := fmt.Sprintf("cannot create api key rotated email for user [%s]", payload.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
 		msg := fmt.Sprintf("canot create api key rotated email to user [%s]", payload.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("api key rotated email sent successfully to [%s] with user ID  [%s]", payload.Email, payload.UserID))
@@ -367,7 +367,7 @@ func (service *UserService) SendPhoneDeadEmail(ctx context.Context, params *User
 	user, err := service.repository.Load(ctx, params.UserID)
 	if err != nil {
 		msg := fmt.Sprintf("could not get [%T] with ID [%s]", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if !user.NotificationHeartbeatEnabled {
@@ -378,12 +378,12 @@ func (service *UserService) SendPhoneDeadEmail(ctx context.Context, params *User
 	email, err := service.emailFactory.PhoneDead(user, params.LastHeartbeatTimestamp, params.Owner)
 	if err != nil {
 		msg := fmt.Sprintf("cannot create phone dead email for user [%s]", params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
 		msg := fmt.Sprintf("canot send phone dead notification to user [%s]", params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("phone dead notification sent successfully to [%s] about [%s]", user.Email, params.Owner))
@@ -398,7 +398,7 @@ func (service *UserService) StartSubscription(ctx context.Context, params *event
 	user, err := service.repository.Load(ctx, params.UserID)
 	if err != nil {
 		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	user.SubscriptionID = &params.SubscriptionID
@@ -409,7 +409,7 @@ func (service *UserService) StartSubscription(ctx context.Context, params *event
 
 	if err = service.repository.Update(ctx, user); err != nil {
 		msg := fmt.Sprintf("could not update [%T] with with ID [%s] after update", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -423,12 +423,12 @@ func (service *UserService) InitiateSubscriptionCancel(ctx context.Context, user
 	user, err := service.repository.Load(ctx, userID)
 	if err != nil {
 		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if _, _, err = service.lemonsqueezyClient.Subscriptions.Cancel(ctx, *user.SubscriptionID); err != nil {
 		msg := fmt.Sprintf("could not cancel subscription [%s] for [%T] with with ID [%s]", *user.SubscriptionID, user, user.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("cancelled subscription [%s] for user [%s]", *user.SubscriptionID, user.ID))
@@ -443,13 +443,13 @@ func (service *UserService) GetSubscriptionUpdateURL(ctx context.Context, userID
 	user, err := service.repository.Load(ctx, userID)
 	if err != nil {
 		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, userID)
-		return "", service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return "", service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	subscription, _, err := service.lemonsqueezyClient.Subscriptions.Get(ctx, *user.SubscriptionID)
 	if err != nil {
 		msg := fmt.Sprintf("could not get subscription [%s] for [%T] with with ID [%s]", *user.SubscriptionID, user, user.ID)
-		return url, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return url, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return subscription.Data.Attributes.Urls.CustomerPortal, nil
@@ -463,7 +463,7 @@ func (service *UserService) CancelSubscription(ctx context.Context, params *even
 	user, err := service.repository.Load(ctx, params.UserID)
 	if err != nil {
 		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	user.SubscriptionID = &params.SubscriptionID
@@ -474,7 +474,7 @@ func (service *UserService) CancelSubscription(ctx context.Context, params *even
 
 	if err = service.repository.Update(ctx, user); err != nil {
 		msg := fmt.Sprintf("could not update [%T] with with ID [%s] after update", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -488,7 +488,7 @@ func (service *UserService) ExpireSubscription(ctx context.Context, params *even
 	user, err := service.repository.Load(ctx, params.UserID)
 	if err != nil {
 		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	user.SubscriptionID = nil
@@ -499,7 +499,7 @@ func (service *UserService) ExpireSubscription(ctx context.Context, params *even
 
 	if err = service.repository.Update(ctx, user); err != nil {
 		msg := fmt.Sprintf("could not update [%T] with with ID [%s] after expired subscription update", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -513,7 +513,7 @@ func (service *UserService) UpdateSubscription(ctx context.Context, params *even
 	user, err := service.repository.Load(ctx, params.UserID)
 	if err != nil {
 		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	if params.SubscriptionStatus != "active" {
@@ -530,7 +530,7 @@ func (service *UserService) UpdateSubscription(ctx context.Context, params *even
 
 	if err = service.repository.Update(ctx, user); err != nil {
 		msg := fmt.Sprintf("could not update [%T] with with ID [%s] after subscription update", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	return nil
@@ -543,7 +543,7 @@ func (service *UserService) DeleteAuthUser(ctx context.Context, userID entities.
 
 	if err := service.authClient.DeleteUser(ctx, userID.String()); err != nil {
 		msg := fmt.Sprintf("could not delete [entities.AuthContext] from firebase with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted [entities.AuthContext] from firebase for user with ID [%s]", userID))

--- a/api/pkg/services/user_service.go
+++ b/api/pkg/services/user_service.go
@@ -66,8 +66,7 @@ func (service *UserService) GetSubscriptionPayments(ctx context.Context, userID 
 
 	user, err := service.repository.Load(ctx, userID)
 	if err != nil {
-		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, userID)
-		return invoices, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return invoices, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not get [%T] with with ID [%s]", user, userID))
 	}
 
 	if user.SubscriptionID == nil {
@@ -78,8 +77,7 @@ func (service *UserService) GetSubscriptionPayments(ctx context.Context, userID 
 	ctxLogger.Info(fmt.Sprintf("fetching subscription payments for [%T] with ID [%s] and subscription [%s]", user, user.ID, *user.SubscriptionID))
 	invoicesResponse, _, err := service.lemonsqueezyClient.SubscriptionInvoices.List(ctx, map[string]string{"filter[subscription_id]": *user.SubscriptionID})
 	if err != nil {
-		msg := fmt.Sprintf("could not get invoices for subscription [%s] for [%T] with with ID [%s]", *user.SubscriptionID, user, user.ID)
-		return invoices, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return invoices, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not get invoices for subscription [%s] for [%T] with with ID [%s]", *user.SubscriptionID, user, user.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] payments for [%T] with ID [%s] and subscription ID [%s]", len(invoicesResponse.Data), user, user.ID, *user.SubscriptionID))
@@ -117,14 +115,12 @@ func (service *UserService) GenerateReceipt(ctx context.Context, params *UserInv
 
 	invoice, _, err := service.lemonsqueezyClient.SubscriptionInvoices.Generate(ctx, params.SubscriptionInvoiceID, payload)
 	if err != nil {
-		msg := fmt.Sprintf("could not generate subscription payment invoice user with ID [%s] and subscription invoice ID [%s]", params.UserID, params.SubscriptionInvoiceID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not generate subscription payment invoice user with ID [%s] and subscription invoice ID [%s]", params.UserID, params.SubscriptionInvoiceID))
 	}
 
 	response, err := service.httpClient.Get(invoice.Meta.Urls.DownloadInvoice)
 	if err != nil {
-		msg := fmt.Sprintf("could not download subscription payment invoice for user with ID [%s] and subscription invoice ID [%s]", params.UserID, params.SubscriptionInvoiceID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not download subscription payment invoice for user with ID [%s] and subscription invoice ID [%s]", params.UserID, params.SubscriptionInvoiceID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("generated subscription payment invoice for user with ID [%s] and subscription invoice ID [%s]", params.UserID, params.SubscriptionInvoiceID))
@@ -138,8 +134,7 @@ func (service *UserService) Get(ctx context.Context, source string, authUser ent
 
 	user, isNew, err := service.repository.LoadOrStore(ctx, authUser)
 	if err != nil {
-		msg := fmt.Sprintf("could not get [%T] with from [%+#v]", user, authUser)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not get [%T] with from [%+#v]", user, authUser))
 	}
 
 	if isNew {
@@ -158,14 +153,12 @@ func (service *UserService) dispatchUserCreatedEvent(ctx context.Context, source
 		Timestamp: time.Now().UTC(),
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event [%s] for user [%s]", events.UserAccountCreated, user.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot create event [%s] for user [%s]", events.UserAccountCreated, user.ID))
 		return
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", event.Type(), user.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot dispatch [%s] event for user [%s]", event.Type(), user.ID))
 		return
 	}
 }
@@ -177,8 +170,7 @@ func (service *UserService) GetByID(ctx context.Context, userID entities.UserID)
 
 	user, err := service.repository.Load(ctx, userID)
 	if err != nil {
-		msg := fmt.Sprintf("could not get [%T] with ID [%s]", user, userID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not get [%T] with ID [%s]", user, userID))
 	}
 
 	return user, nil
@@ -199,8 +191,7 @@ func (service *UserService) Update(ctx context.Context, source string, authUser 
 
 	user, isNew, err := service.repository.LoadOrStore(ctx, authUser)
 	if err != nil {
-		msg := fmt.Sprintf("could not get [%T] with from [%+#v]", user, authUser)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not get [%T] with from [%+#v]", user, authUser))
 	}
 
 	if isNew {
@@ -211,8 +202,7 @@ func (service *UserService) Update(ctx context.Context, source string, authUser 
 	user.ActivePhoneID = params.ActivePhoneID
 
 	if err = service.repository.Update(ctx, user); err != nil {
-		msg := fmt.Sprintf("cannot save user with id [%s]", user.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save user with id [%s]", user.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("user saved with id [%s] in the userRepository", user.ID))
@@ -234,8 +224,7 @@ func (service *UserService) UpdateNotificationSettings(ctx context.Context, user
 
 	user, err := service.repository.Load(ctx, userID)
 	if err != nil {
-		msg := fmt.Sprintf("could not load [%T] with ID [%s]", user, userID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not load [%T] with ID [%s]", user, userID))
 	}
 
 	user.NotificationWebhookEnabled = params.WebhookEnabled
@@ -244,8 +233,7 @@ func (service *UserService) UpdateNotificationSettings(ctx context.Context, user
 	user.NotificationNewsletterEnabled = params.NewsletterEnabled
 
 	if err = service.repository.Update(ctx, user); err != nil {
-		msg := fmt.Sprintf("cannot save user with id [%s] in [%T]", user.ID, service.repository)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save user with id [%s] in [%T]", user.ID, service.repository))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("updated notification settings for [%T] with ID [%s] in the [%T]", user, user.ID, service.repository))
@@ -259,8 +247,7 @@ func (service *UserService) RotateAPIKey(ctx context.Context, source string, use
 
 	user, err := service.repository.RotateAPIKey(ctx, userID)
 	if err != nil {
-		msg := fmt.Sprintf("could not rotate API key for [%T] with ID [%s]", user, userID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not rotate API key for [%T] with ID [%s]", user, userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("rotated the api key for [%T] with ID [%s] in the [%T]", user, user.ID, service.repository))
@@ -272,14 +259,12 @@ func (service *UserService) RotateAPIKey(ctx context.Context, source string, use
 		Timezone:  user.Timezone,
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event [%s] for user [%s]", events.UserAPIKeyRotated, user.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot create event [%s] for user [%s]", events.UserAPIKeyRotated, user.ID))
 		return user, nil
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", event.Type(), user.ID)
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", msg))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot dispatch [%s] event for user [%s]", event.Type(), user.ID))
 		return user, nil
 	}
 
@@ -293,18 +278,15 @@ func (service *UserService) Delete(ctx context.Context, source string, userID en
 
 	user, err := service.repository.Load(ctx, userID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load user with ID [%s] from the [%T]", userID, service.repository)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load user with ID [%s] from the [%T]", userID, service.repository))
 	}
 
 	if !user.IsOnFreePlan() && user.SubscriptionRenewsAt != nil && user.SubscriptionRenewsAt.After(time.Now()) {
-		msg := fmt.Sprintf("cannot delete user with ID [%s] because they are have an active [%s] subscription which renews at [%s]", userID, user.SubscriptionName, user.SubscriptionRenewsAt)
-		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.NewError("cannot delete user with ID [%s] because they are have an active [%s] subscription which renews at [%s]", userID, user.SubscriptionName, user.SubscriptionRenewsAt))
 	}
 
 	if err = service.repository.Delete(ctx, user); err != nil {
-		msg := fmt.Sprintf("could not delete user with ID [%s] from the [%T]", userID, service.repository)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not delete user with ID [%s] from the [%T]", userID, service.repository))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("sucessfully deleted user with ID [%s] in the [%T]", userID, service.repository))
@@ -315,13 +297,11 @@ func (service *UserService) Delete(ctx context.Context, source string, userID en
 		Timestamp: time.Now().UTC(),
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event [%s] for user [%s]", events.UserAccountDeleted, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create event [%s] for user [%s]", events.UserAccountDeleted, userID))
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch [%s] event for user [%s]", event.Type(), userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch [%s] event for user [%s]", event.Type(), userID))
 	}
 
 	return nil
@@ -336,13 +316,11 @@ func (service *UserService) SendAPIKeyRotatedEmail(ctx context.Context, payload 
 
 	email, err := service.emailFactory.APIKeyRotated(payload.Email, payload.Timestamp, payload.Timezone)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create api key rotated email for user [%s]", payload.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create api key rotated email for user [%s]", payload.UserID))
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
-		msg := fmt.Sprintf("canot create api key rotated email to user [%s]", payload.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "canot create api key rotated email to user [%s]", payload.UserID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("api key rotated email sent successfully to [%s] with user ID  [%s]", payload.Email, payload.UserID))
@@ -366,8 +344,7 @@ func (service *UserService) SendPhoneDeadEmail(ctx context.Context, params *User
 
 	user, err := service.repository.Load(ctx, params.UserID)
 	if err != nil {
-		msg := fmt.Sprintf("could not get [%T] with ID [%s]", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not get [%T] with ID [%s]", user, params.UserID))
 	}
 
 	if !user.NotificationHeartbeatEnabled {
@@ -377,13 +354,11 @@ func (service *UserService) SendPhoneDeadEmail(ctx context.Context, params *User
 
 	email, err := service.emailFactory.PhoneDead(user, params.LastHeartbeatTimestamp, params.Owner)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create phone dead email for user [%s]", params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create phone dead email for user [%s]", params.UserID))
 	}
 
 	if err = service.mailer.Send(ctx, email); err != nil {
-		msg := fmt.Sprintf("canot send phone dead notification to user [%s]", params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "canot send phone dead notification to user [%s]", params.UserID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("phone dead notification sent successfully to [%s] about [%s]", user.Email, params.Owner))
@@ -397,8 +372,7 @@ func (service *UserService) StartSubscription(ctx context.Context, params *event
 
 	user, err := service.repository.Load(ctx, params.UserID)
 	if err != nil {
-		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not get [%T] with with ID [%s]", user, params.UserID))
 	}
 
 	user.SubscriptionID = &params.SubscriptionID
@@ -408,8 +382,7 @@ func (service *UserService) StartSubscription(ctx context.Context, params *event
 	user.SubscriptionEndsAt = nil
 
 	if err = service.repository.Update(ctx, user); err != nil {
-		msg := fmt.Sprintf("could not update [%T] with with ID [%s] after update", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not update [%T] with with ID [%s] after update", user, params.UserID))
 	}
 
 	return nil
@@ -422,13 +395,11 @@ func (service *UserService) InitiateSubscriptionCancel(ctx context.Context, user
 
 	user, err := service.repository.Load(ctx, userID)
 	if err != nil {
-		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not get [%T] with with ID [%s]", user, userID))
 	}
 
 	if _, _, err = service.lemonsqueezyClient.Subscriptions.Cancel(ctx, *user.SubscriptionID); err != nil {
-		msg := fmt.Sprintf("could not cancel subscription [%s] for [%T] with with ID [%s]", *user.SubscriptionID, user, user.ID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not cancel subscription [%s] for [%T] with with ID [%s]", *user.SubscriptionID, user, user.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("cancelled subscription [%s] for user [%s]", *user.SubscriptionID, user.ID))
@@ -442,14 +413,12 @@ func (service *UserService) GetSubscriptionUpdateURL(ctx context.Context, userID
 
 	user, err := service.repository.Load(ctx, userID)
 	if err != nil {
-		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, userID)
-		return "", service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return "", service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not get [%T] with with ID [%s]", user, userID))
 	}
 
 	subscription, _, err := service.lemonsqueezyClient.Subscriptions.Get(ctx, *user.SubscriptionID)
 	if err != nil {
-		msg := fmt.Sprintf("could not get subscription [%s] for [%T] with with ID [%s]", *user.SubscriptionID, user, user.ID)
-		return url, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return url, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not get subscription [%s] for [%T] with with ID [%s]", *user.SubscriptionID, user, user.ID))
 	}
 
 	return subscription.Data.Attributes.Urls.CustomerPortal, nil
@@ -462,8 +431,7 @@ func (service *UserService) CancelSubscription(ctx context.Context, params *even
 
 	user, err := service.repository.Load(ctx, params.UserID)
 	if err != nil {
-		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not get [%T] with with ID [%s]", user, params.UserID))
 	}
 
 	user.SubscriptionID = &params.SubscriptionID
@@ -473,8 +441,7 @@ func (service *UserService) CancelSubscription(ctx context.Context, params *even
 	user.SubscriptionEndsAt = &params.SubscriptionEndsAt
 
 	if err = service.repository.Update(ctx, user); err != nil {
-		msg := fmt.Sprintf("could not update [%T] with with ID [%s] after update", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not update [%T] with with ID [%s] after update", user, params.UserID))
 	}
 
 	return nil
@@ -487,8 +454,7 @@ func (service *UserService) ExpireSubscription(ctx context.Context, params *even
 
 	user, err := service.repository.Load(ctx, params.UserID)
 	if err != nil {
-		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not get [%T] with with ID [%s]", user, params.UserID))
 	}
 
 	user.SubscriptionID = nil
@@ -498,8 +464,7 @@ func (service *UserService) ExpireSubscription(ctx context.Context, params *even
 	user.SubscriptionEndsAt = nil
 
 	if err = service.repository.Update(ctx, user); err != nil {
-		msg := fmt.Sprintf("could not update [%T] with with ID [%s] after expired subscription update", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not update [%T] with with ID [%s] after expired subscription update", user, params.UserID))
 	}
 
 	return nil
@@ -512,8 +477,7 @@ func (service *UserService) UpdateSubscription(ctx context.Context, params *even
 
 	user, err := service.repository.Load(ctx, params.UserID)
 	if err != nil {
-		msg := fmt.Sprintf("could not get [%T] with with ID [%s]", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not get [%T] with with ID [%s]", user, params.UserID))
 	}
 
 	if params.SubscriptionStatus != "active" {
@@ -529,8 +493,7 @@ func (service *UserService) UpdateSubscription(ctx context.Context, params *even
 	user.SubscriptionStatus = &params.SubscriptionStatus
 
 	if err = service.repository.Update(ctx, user); err != nil {
-		msg := fmt.Sprintf("could not update [%T] with with ID [%s] after subscription update", user, params.UserID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not update [%T] with with ID [%s] after subscription update", user, params.UserID))
 	}
 
 	return nil
@@ -542,8 +505,7 @@ func (service *UserService) DeleteAuthUser(ctx context.Context, userID entities.
 	defer span.End()
 
 	if err := service.authClient.DeleteUser(ctx, userID.String()); err != nil {
-		msg := fmt.Sprintf("could not delete [entities.AuthContext] from firebase with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not delete [entities.AuthContext] from firebase with ID [%s]", userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted [entities.AuthContext] from firebase for user with ID [%s]", userID))

--- a/api/pkg/services/webhook_service.go
+++ b/api/pkg/services/webhook_service.go
@@ -61,8 +61,7 @@ func (service *WebhookService) DeleteAllForUser(ctx context.Context, userID enti
 	defer span.End()
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
-		msg := fmt.Sprintf("could not delete all [entities.Webhook] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not delete all [entities.Webhook] for user with ID [%s]", userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.Webhook] for user with ID [%s]", userID))
@@ -78,8 +77,7 @@ func (service *WebhookService) Index(ctx context.Context, userID entities.UserID
 
 	webhooks, err := service.repository.Index(ctx, userID, params)
 	if err != nil {
-		msg := fmt.Sprintf("could not fetch webhooks with params [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not fetch webhooks with params [%+#v]", params))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] webhooks with prams [%+#v]", len(webhooks), params))
@@ -94,13 +92,11 @@ func (service *WebhookService) Delete(ctx context.Context, userID entities.UserI
 	ctxLogger := service.tracer.CtxLogger(service.logger, span)
 
 	if _, err := service.repository.Load(ctx, userID, webhookID); err != nil {
-		msg := fmt.Sprintf("cannot load webhook with userID [%s] and phoneID [%s]", userID, webhookID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "cannot load webhook with userID [%s] and phoneID [%s]", userID, webhookID))
 	}
 
 	if err := service.repository.Delete(ctx, userID, webhookID); err != nil {
-		msg := fmt.Sprintf("cannot delete webhook with id [%s] and user id [%s]", webhookID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot delete webhook with id [%s] and user id [%s]", webhookID, userID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted webhook with id [%s] and user id [%s]", webhookID, userID))
@@ -135,8 +131,7 @@ func (service *WebhookService) Store(ctx context.Context, params *WebhookStorePa
 	}
 
 	if err := service.repository.Save(ctx, webhook); err != nil {
-		msg := fmt.Sprintf("cannot save webhook with id [%s]", webhook.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save webhook with id [%s]", webhook.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("webhook saved with id [%s] for user [%s] in the [%T]", webhook.ID, webhook.UserID, service.repository))
@@ -160,8 +155,7 @@ func (service *WebhookService) Update(ctx context.Context, params *WebhookUpdate
 
 	webhook, err := service.repository.Load(ctx, params.UserID, params.WebhookID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load webhook with userID [%s] and phoneID [%s]", params.UserID, params.WebhookID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "cannot load webhook with userID [%s] and phoneID [%s]", params.UserID, params.WebhookID))
 	}
 
 	webhook.URL = params.URL
@@ -170,8 +164,7 @@ func (service *WebhookService) Update(ctx context.Context, params *WebhookUpdate
 	webhook.PhoneNumbers = params.PhoneNumbers
 
 	if err = service.repository.Save(ctx, webhook); err != nil {
-		msg := fmt.Sprintf("cannot save webhook with id [%s] after update", webhook.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot save webhook with id [%s] after update", webhook.ID))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("webhook updated with id [%s] in the [%T]", webhook.ID, service.repository))
@@ -185,8 +178,7 @@ func (service *WebhookService) Send(ctx context.Context, userID entities.UserID,
 
 	webhooks, err := service.repository.LoadByEvent(ctx, userID, event.Type(), phoneNumber)
 	if err != nil {
-		msg := fmt.Sprintf("cannot load webhooks for userID [%s] and event [%s]", userID, event.Type())
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "cannot load webhooks for userID [%s] and event [%s]", userID, event.Type()))
 	}
 
 	if len(webhooks) == 0 {
@@ -220,13 +212,12 @@ func (service *WebhookService) sendNotification(ctx context.Context, event cloud
 
 		request, err := service.createRequest(requestCtx, event, webhook)
 		if err != nil {
-			msg := fmt.Sprintf("cannot create [%s] event to webhook [%s] for user [%s] after [%d] attempts", event.Type(), webhook.URL, webhook.UserID, attempts)
-			return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
+			return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create [%s] event to webhook [%s] for user [%s] after [%d] attempts", event.Type(), webhook.URL, webhook.UserID, attempts))
 		}
 
 		response, err := service.client.Do(request)
 		if err != nil {
-			ctxLogger.Warn(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot send [%s] event to webhook [%s] for user [%s] after [%d] attempts", event.Type(), webhook.URL, webhook.UserID, attempts)))
+			ctxLogger.Warn(stacktrace.Propagate(err, "cannot send [%s] event to webhook [%s] for user [%s] after [%d] attempts", event.Type(), webhook.URL, webhook.UserID, attempts))
 			if attempts == 1 {
 				return err
 			}
@@ -237,7 +228,7 @@ func (service *WebhookService) sendNotification(ctx context.Context, event cloud
 		defer func() {
 			err = response.Body.Close()
 			if err != nil {
-				ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot close response body for [%s] event with ID [%s] after [%d] attempts", event.Type(), event.ID(), attempts)))
+				ctxLogger.Error(stacktrace.Propagate(err, "cannot close response body for [%s] event with ID [%s] after [%d] attempts", event.Type(), event.ID(), attempts))
 			}
 		}()
 
@@ -254,8 +245,7 @@ func (service *WebhookService) sendNotification(ctx context.Context, event cloud
 		return nil
 	})
 	if err != nil {
-		msg := fmt.Sprintf("cannot handle [%s] event to webhook [%s] for user [%s] after [%d] attempts", event.Type(), webhook.URL, webhook.UserID, attempts)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot handle [%s] event to webhook [%s] for user [%s] after [%d] attempts", event.Type(), webhook.URL, webhook.UserID, attempts)))
 	}
 }
 
@@ -265,14 +255,12 @@ func (service *WebhookService) createRequest(ctx context.Context, event cloudeve
 
 	payload, err := json.Marshal(service.getPayload(ctxLogger, event, webhook))
 	if err != nil {
-		msg := fmt.Sprintf("cannot marshal payload for user [%s] and webhook [%s] for event [%s]", webhook.UserID, webhook.ID, event.ID())
-		return nil, stacktrace.Propagate(err, "%s", msg)
+		return nil, stacktrace.Propagate(err, "cannot marshal payload for user [%s] and webhook [%s] for event [%s]", webhook.UserID, webhook.ID, event.ID())
 	}
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, webhook.URL, bytes.NewReader(payload))
 	if err != nil {
-		msg := fmt.Sprintf("cannot create request for user [%s] and webhook [%s] for event [%s]", webhook.UserID, webhook.ID, event.ID())
-		return nil, stacktrace.Propagate(err, "%s", msg)
+		return nil, stacktrace.Propagate(err, "cannot create request for user [%s] and webhook [%s] for event [%s]", webhook.UserID, webhook.ID, event.ID())
 	}
 
 	request.Header.Add("X-Event-Type", event.Type())
@@ -281,8 +269,7 @@ func (service *WebhookService) createRequest(ctx context.Context, event cloudeve
 	if strings.TrimSpace(webhook.SigningKey) != "" {
 		token, err := service.getAuthToken(webhook)
 		if err != nil {
-			msg := fmt.Sprintf("cannot generate auth token for user [%s] and webhook [%s]", webhook.UserID, webhook.ID)
-			return nil, stacktrace.Propagate(err, "%s", msg)
+			return nil, stacktrace.Propagate(err, "cannot generate auth token for user [%s] and webhook [%s]", webhook.UserID, webhook.ID)
 		}
 		request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
@@ -303,7 +290,7 @@ func (service *WebhookService) getPayload(ctxLogger telemetry.Logger, event clou
 
 	err := event.DataAs(payload)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload))
 		return event
 	}
 
@@ -382,14 +369,12 @@ func (service *WebhookService) handleWebhookSendFailed(ctx context.Context, even
 
 	event, err = service.createEvent(events.EventTypeWebhookSendFailed, event.Source(), payload)
 	if err != nil {
-		msg := fmt.Sprintf("cannot create event [%s] for user with id [%s]", events.EventTypeWebhookSendFailed, payload.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot create event [%s] for user with id [%s]", events.EventTypeWebhookSendFailed, payload.UserID)))
 		return
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
-		msg := fmt.Sprintf("cannot dispatch event [%s] for user with id [%s]", event.Type(), payload.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot dispatch event [%s] for user with id [%s]", event.Type(), payload.UserID)))
 		return
 	}
 

--- a/api/pkg/services/webhook_service.go
+++ b/api/pkg/services/webhook_service.go
@@ -62,7 +62,7 @@ func (service *WebhookService) DeleteAllForUser(ctx context.Context, userID enti
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
 		msg := fmt.Sprintf("could not delete all [entities.Webhook] for user with ID [%s]", userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted all [entities.Webhook] for user with ID [%s]", userID))
@@ -79,7 +79,7 @@ func (service *WebhookService) Index(ctx context.Context, userID entities.UserID
 	webhooks, err := service.repository.Index(ctx, userID, params)
 	if err != nil {
 		msg := fmt.Sprintf("could not fetch webhooks with params [%+#v]", params)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] webhooks with prams [%+#v]", len(webhooks), params))
@@ -95,12 +95,12 @@ func (service *WebhookService) Delete(ctx context.Context, userID entities.UserI
 
 	if _, err := service.repository.Load(ctx, userID, webhookID); err != nil {
 		msg := fmt.Sprintf("cannot load webhook with userID [%s] and phoneID [%s]", userID, webhookID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	if err := service.repository.Delete(ctx, userID, webhookID); err != nil {
 		msg := fmt.Sprintf("cannot delete webhook with id [%s] and user id [%s]", webhookID, userID)
-		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("deleted webhook with id [%s] and user id [%s]", webhookID, userID))
@@ -136,7 +136,7 @@ func (service *WebhookService) Store(ctx context.Context, params *WebhookStorePa
 
 	if err := service.repository.Save(ctx, webhook); err != nil {
 		msg := fmt.Sprintf("cannot save webhook with id [%s]", webhook.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("webhook saved with id [%s] for user [%s] in the [%T]", webhook.ID, webhook.UserID, service.repository))
@@ -161,7 +161,7 @@ func (service *WebhookService) Update(ctx context.Context, params *WebhookUpdate
 	webhook, err := service.repository.Load(ctx, params.UserID, params.WebhookID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load webhook with userID [%s] and phoneID [%s]", params.UserID, params.WebhookID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	webhook.URL = params.URL
@@ -171,7 +171,7 @@ func (service *WebhookService) Update(ctx context.Context, params *WebhookUpdate
 
 	if err = service.repository.Save(ctx, webhook); err != nil {
 		msg := fmt.Sprintf("cannot save webhook with id [%s] after update", webhook.ID)
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 	}
 
 	ctxLogger.Info(fmt.Sprintf("webhook updated with id [%s] in the [%T]", webhook.ID, service.repository))
@@ -186,7 +186,7 @@ func (service *WebhookService) Send(ctx context.Context, userID entities.UserID,
 	webhooks, err := service.repository.LoadByEvent(ctx, userID, event.Type(), phoneNumber)
 	if err != nil {
 		msg := fmt.Sprintf("cannot load webhooks for userID [%s] and event [%s]", userID, event.Type())
-		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), msg))
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCode(err, stacktrace.GetCode(err), "%s", msg))
 	}
 
 	if len(webhooks) == 0 {
@@ -221,12 +221,12 @@ func (service *WebhookService) sendNotification(ctx context.Context, event cloud
 		request, err := service.createRequest(requestCtx, event, webhook)
 		if err != nil {
 			msg := fmt.Sprintf("cannot create [%s] event to webhook [%s] for user [%s] after [%d] attempts", event.Type(), webhook.URL, webhook.UserID, attempts)
-			return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg))
+			return service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg))
 		}
 
 		response, err := service.client.Do(request)
 		if err != nil {
-			ctxLogger.Warn(stacktrace.Propagate(err, fmt.Sprintf("cannot send [%s] event to webhook [%s] for user [%s] after [%d] attempts", event.Type(), webhook.URL, webhook.UserID, attempts)))
+			ctxLogger.Warn(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot send [%s] event to webhook [%s] for user [%s] after [%d] attempts", event.Type(), webhook.URL, webhook.UserID, attempts)))
 			if attempts == 1 {
 				return err
 			}
@@ -237,16 +237,16 @@ func (service *WebhookService) sendNotification(ctx context.Context, event cloud
 		defer func() {
 			err = response.Body.Close()
 			if err != nil {
-				ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot close response body for [%s] event with ID [%s] after [%d] attempts", event.Type(), event.ID(), attempts)))
+				ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot close response body for [%s] event with ID [%s] after [%d] attempts", event.Type(), event.ID(), attempts)))
 			}
 		}()
 
 		if response.StatusCode >= 400 {
 			ctxLogger.Info(fmt.Sprintf("cannot send [%s] event to webhook [%s] for user [%s] with response code [%d] after [%d] attempts", event.Type(), webhook.URL, webhook.UserID, response.StatusCode, attempts))
 			if attempts == 1 {
-				return stacktrace.NewError(http.StatusText(response.StatusCode))
+				return stacktrace.NewError("%s", http.StatusText(response.StatusCode))
 			}
-			service.handleWebhookSendFailed(ctx, event, webhook, owner, stacktrace.NewError(http.StatusText(response.StatusCode)), response)
+			service.handleWebhookSendFailed(ctx, event, webhook, owner, stacktrace.NewError("%s", http.StatusText(response.StatusCode)), response)
 			return nil
 		}
 
@@ -255,7 +255,7 @@ func (service *WebhookService) sendNotification(ctx context.Context, event cloud
 	})
 	if err != nil {
 		msg := fmt.Sprintf("cannot handle [%s] event to webhook [%s] for user [%s] after [%d] attempts", event.Type(), webhook.URL, webhook.UserID, attempts)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 	}
 }
 
@@ -266,13 +266,13 @@ func (service *WebhookService) createRequest(ctx context.Context, event cloudeve
 	payload, err := json.Marshal(service.getPayload(ctxLogger, event, webhook))
 	if err != nil {
 		msg := fmt.Sprintf("cannot marshal payload for user [%s] and webhook [%s] for event [%s]", webhook.UserID, webhook.ID, event.ID())
-		return nil, stacktrace.Propagate(err, msg)
+		return nil, stacktrace.Propagate(err, "%s", msg)
 	}
 
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, webhook.URL, bytes.NewReader(payload))
 	if err != nil {
 		msg := fmt.Sprintf("cannot create request for user [%s] and webhook [%s] for event [%s]", webhook.UserID, webhook.ID, event.ID())
-		return nil, stacktrace.Propagate(err, msg)
+		return nil, stacktrace.Propagate(err, "%s", msg)
 	}
 
 	request.Header.Add("X-Event-Type", event.Type())
@@ -282,7 +282,7 @@ func (service *WebhookService) createRequest(ctx context.Context, event cloudeve
 		token, err := service.getAuthToken(webhook)
 		if err != nil {
 			msg := fmt.Sprintf("cannot generate auth token for user [%s] and webhook [%s]", webhook.UserID, webhook.ID)
-			return nil, stacktrace.Propagate(err, msg)
+			return nil, stacktrace.Propagate(err, "%s", msg)
 		}
 		request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
@@ -303,7 +303,7 @@ func (service *WebhookService) getPayload(ctxLogger telemetry.Logger, event clou
 
 	err := event.DataAs(payload)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshal event [%s] with ID [%s] into [%T]", event.Type(), event.ID(), payload)))
 		return event
 	}
 
@@ -383,13 +383,13 @@ func (service *WebhookService) handleWebhookSendFailed(ctx context.Context, even
 	event, err = service.createEvent(events.EventTypeWebhookSendFailed, event.Source(), payload)
 	if err != nil {
 		msg := fmt.Sprintf("cannot create event [%s] for user with id [%s]", events.EventTypeWebhookSendFailed, payload.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return
 	}
 
 	if err = service.dispatcher.Dispatch(ctx, event); err != nil {
 		msg := fmt.Sprintf("cannot dispatch event [%s] for user with id [%s]", event.Type(), payload.UserID)
-		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		return
 	}
 

--- a/api/pkg/telemetry/gorm_logger.go
+++ b/api/pkg/telemetry/gorm_logger.go
@@ -46,7 +46,7 @@ func (gorm *gormLogger) Trace(ctx context.Context, begin time.Time, fc func() (s
 	msg := fmt.Sprintf("[ROWS:%d][%s]", rows, sql)
 
 	if err != nil {
-		l.Error(stacktrace.Propagate(err, msg))
+		l.Error(stacktrace.Propagate(err, "%s", msg))
 		return
 	}
 

--- a/api/pkg/telemetry/gorm_logger.go
+++ b/api/pkg/telemetry/gorm_logger.go
@@ -46,7 +46,7 @@ func (gorm *gormLogger) Trace(ctx context.Context, begin time.Time, fc func() (s
 	msg := fmt.Sprintf("[ROWS:%d][%s]", rows, sql)
 
 	if err != nil {
-		l.Error(stacktrace.Propagate(err, "%s", msg))
+		l.Error(stacktrace.Propagate(err, "[ROWS:%d][%s]", rows, sql))
 		return
 	}
 

--- a/api/pkg/validators/bulk_message_handler_validator.go
+++ b/api/pkg/validators/bulk_message_handler_validator.go
@@ -60,7 +60,7 @@ func (v *BulkMessageHandlerValidator) ValidateStore(ctx context.Context, userID 
 	if err != nil {
 		result := url.Values{}
 		result.Add("document", "Cannot load your account. Please try again later or contact support.")
-		ctxLogger.Error(v.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, fmt.Sprintf("cannot load user [%s]", userID))))
+		ctxLogger.Error(v.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load user [%s]", userID))))
 		return nil, nil, result
 	}
 
@@ -104,7 +104,7 @@ func (v *BulkMessageHandlerValidator) parseFile(ctxLogger telemetry.Logger, user
 		return v.parseXlsx(ctxLogger, user, header)
 	}
 
-	ctxLogger.Error(stacktrace.NewError(fmt.Sprintf("cannot parse file [%s] for user [%s] with content type [%s]", header.Filename, user.ID, header.Header.Get("Content-Type"))))
+	ctxLogger.Error(stacktrace.NewError("%s", fmt.Sprintf("cannot parse file [%s] for user [%s] with content type [%s]", header.Filename, user.ID, header.Header.Get("Content-Type"))))
 
 	result := url.Values{}
 	result.Add("document", fmt.Sprintf("The file [%s] is not a valid CSV or Excel file.", header.Filename))
@@ -119,7 +119,7 @@ func (v *BulkMessageHandlerValidator) parseXlsx(ctxLogger telemetry.Logger, user
 
 	excel, err := excelize.OpenReader(bytes.NewReader(content))
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot generate excel file from [%s] for user [%s]", header.Filename, user.ID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot generate excel file from [%s] for user [%s]", header.Filename, user.ID)))
 		result.Add("document", fmt.Sprintf("Cannot parse the uploaded excel file with name [%s].", header.Filename))
 		return nil, result
 	}
@@ -127,7 +127,7 @@ func (v *BulkMessageHandlerValidator) parseXlsx(ctxLogger telemetry.Logger, user
 
 	rows, err := excel.GetRows(excel.GetSheetName(0))
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot get rows from excel file [%s] for user [%s]", header.Filename, user.ID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot get rows from excel file [%s] for user [%s]", header.Filename, user.ID)))
 		result.Add("document", fmt.Sprintf("Cannot parse the uploaded excel file with name [%s].", header.Filename))
 		return nil, result
 	}
@@ -177,19 +177,19 @@ func (v *BulkMessageHandlerValidator) parseBytes(ctxLogger telemetry.Logger, use
 
 	file, err := header.Open()
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot open file [%s] for reading for user [%s]", header.Filename, userID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot open file [%s] for reading for user [%s]", header.Filename, userID)))
 		result.Add("document", fmt.Sprintf("Cannot open the uploaded file with name [%s].", header.Filename))
 		return nil, result
 	}
 	defer func() {
 		if e := file.Close(); e != nil {
-			ctxLogger.Error(stacktrace.Propagate(e, fmt.Sprintf("cannot close file [%s] for user [%s]", header.Filename, userID)))
+			ctxLogger.Error(stacktrace.Propagate(e, "%s", fmt.Sprintf("cannot close file [%s] for user [%s]", header.Filename, userID)))
 		}
 	}()
 
 	b := new(bytes.Buffer)
 	if _, err = io.Copy(b, file); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot copy file [%s] to buffer for user [%s]", header.Filename, userID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot copy file [%s] to buffer for user [%s]", header.Filename, userID)))
 		result.Add("document", fmt.Sprintf("Cannot read the conents of the uploaded file [%s].", header.Filename))
 		return nil, result
 	}
@@ -205,7 +205,7 @@ func (v *BulkMessageHandlerValidator) parseCSV(ctxLogger telemetry.Logger, user 
 
 	var messages []*requests.BulkMessage
 	if err := csvutil.Unmarshal(content, &messages); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("cannot unmarshall contents [%s] into type [%T] for file [%s] and user [%s]", content, messages, header.Filename, user.ID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshall contents [%s] into type [%T] for file [%s] and user [%s]", content, messages, header.Filename, user.ID)))
 		result.Add("document", fmt.Sprintf("Cannot read the contents of the uploaded file [%s].", header.Filename))
 		return nil, result
 	}

--- a/api/pkg/validators/bulk_message_handler_validator.go
+++ b/api/pkg/validators/bulk_message_handler_validator.go
@@ -60,7 +60,7 @@ func (v *BulkMessageHandlerValidator) ValidateStore(ctx context.Context, userID 
 	if err != nil {
 		result := url.Values{}
 		result.Add("document", "Cannot load your account. Please try again later or contact support.")
-		ctxLogger.Error(v.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot load user [%s]", userID))))
+		ctxLogger.Error(v.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot load user [%s]", userID)))
 		return nil, nil, result
 	}
 
@@ -104,7 +104,7 @@ func (v *BulkMessageHandlerValidator) parseFile(ctxLogger telemetry.Logger, user
 		return v.parseXlsx(ctxLogger, user, header)
 	}
 
-	ctxLogger.Error(stacktrace.NewError("%s", fmt.Sprintf("cannot parse file [%s] for user [%s] with content type [%s]", header.Filename, user.ID, header.Header.Get("Content-Type"))))
+	ctxLogger.Error(stacktrace.NewError("cannot parse file [%s] for user [%s] with content type [%s]", header.Filename, user.ID, header.Header.Get("Content-Type")))
 
 	result := url.Values{}
 	result.Add("document", fmt.Sprintf("The file [%s] is not a valid CSV or Excel file.", header.Filename))
@@ -119,7 +119,7 @@ func (v *BulkMessageHandlerValidator) parseXlsx(ctxLogger telemetry.Logger, user
 
 	excel, err := excelize.OpenReader(bytes.NewReader(content))
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot generate excel file from [%s] for user [%s]", header.Filename, user.ID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot generate excel file from [%s] for user [%s]", header.Filename, user.ID))
 		result.Add("document", fmt.Sprintf("Cannot parse the uploaded excel file with name [%s].", header.Filename))
 		return nil, result
 	}
@@ -127,7 +127,7 @@ func (v *BulkMessageHandlerValidator) parseXlsx(ctxLogger telemetry.Logger, user
 
 	rows, err := excel.GetRows(excel.GetSheetName(0))
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot get rows from excel file [%s] for user [%s]", header.Filename, user.ID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot get rows from excel file [%s] for user [%s]", header.Filename, user.ID))
 		result.Add("document", fmt.Sprintf("Cannot parse the uploaded excel file with name [%s].", header.Filename))
 		return nil, result
 	}
@@ -177,19 +177,19 @@ func (v *BulkMessageHandlerValidator) parseBytes(ctxLogger telemetry.Logger, use
 
 	file, err := header.Open()
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot open file [%s] for reading for user [%s]", header.Filename, userID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot open file [%s] for reading for user [%s]", header.Filename, userID))
 		result.Add("document", fmt.Sprintf("Cannot open the uploaded file with name [%s].", header.Filename))
 		return nil, result
 	}
 	defer func() {
 		if e := file.Close(); e != nil {
-			ctxLogger.Error(stacktrace.Propagate(e, "%s", fmt.Sprintf("cannot close file [%s] for user [%s]", header.Filename, userID)))
+			ctxLogger.Error(stacktrace.Propagate(e, "cannot close file [%s] for user [%s]", header.Filename, userID))
 		}
 	}()
 
 	b := new(bytes.Buffer)
 	if _, err = io.Copy(b, file); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot copy file [%s] to buffer for user [%s]", header.Filename, userID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot copy file [%s] to buffer for user [%s]", header.Filename, userID))
 		result.Add("document", fmt.Sprintf("Cannot read the conents of the uploaded file [%s].", header.Filename))
 		return nil, result
 	}
@@ -205,7 +205,7 @@ func (v *BulkMessageHandlerValidator) parseCSV(ctxLogger telemetry.Logger, user 
 
 	var messages []*requests.BulkMessage
 	if err := csvutil.Unmarshal(content, &messages); err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("cannot unmarshall contents [%s] into type [%T] for file [%s] and user [%s]", content, messages, header.Filename, user.ID)))
+		ctxLogger.Error(stacktrace.Propagate(err, "cannot unmarshall contents [%s] into type [%T] for file [%s] and user [%s]", content, messages, header.Filename, user.ID))
 		result.Add("document", fmt.Sprintf("Cannot read the contents of the uploaded file [%s].", header.Filename))
 		return nil, result
 	}

--- a/api/pkg/validators/discord_handler_validator.go
+++ b/api/pkg/validators/discord_handler_validator.go
@@ -92,13 +92,13 @@ func (validator *DiscordHandlerValidator) ValidateStore(ctx context.Context, req
 
 	if _, _, err := validator.client.Channel.Get(ctx, request.IncomingChannelID); err != nil {
 		msg := fmt.Sprintf("cannot fetch discord channel with ID [%s]", request.IncomingChannelID)
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		result.Add("incoming_channel_id", fmt.Sprintf("cannot fetch discord channel with ID [%s] make sure the bot has access to the channel", request.IncomingChannelID))
 	}
 
 	if _, _, err := validator.client.Guild.Get(ctx, request.ServerID); err != nil {
 		msg := fmt.Sprintf("cannot fetch discord channel with ID [%s]", request.IncomingChannelID)
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		result.Add("server_id", fmt.Sprintf("cannot fetch discord server with ID [%s] make sure the bot has access to the channel", request.ServerID))
 	}
 
@@ -142,13 +142,13 @@ func (validator *DiscordHandlerValidator) ValidateUpdate(ctx context.Context, re
 
 	if _, _, err := validator.client.Channel.Get(ctx, request.IncomingChannelID); err != nil {
 		msg := fmt.Sprintf("cannot fetch discord channel with ID [%s]", request.IncomingChannelID)
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		result.Add("incoming_channel_id", fmt.Sprintf("cannot fetch discord channel with ID [%s] make sure the bot has access to the channel", request.IncomingChannelID))
 	}
 
 	if _, _, err := validator.client.Guild.Get(ctx, request.ServerID); err != nil {
 		msg := fmt.Sprintf("cannot fetch discord channel with ID [%s]", request.IncomingChannelID)
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		result.Add("server_id", fmt.Sprintf("cannot fetch discord server with ID [%s] make sure the bot has access to the channel", request.ServerID))
 	}
 

--- a/api/pkg/validators/discord_handler_validator.go
+++ b/api/pkg/validators/discord_handler_validator.go
@@ -96,8 +96,8 @@ func (validator *DiscordHandlerValidator) ValidateStore(ctx context.Context, req
 	}
 
 	if _, _, err := validator.client.Guild.Get(ctx, request.ServerID); err != nil {
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch discord channel with ID [%s]", request.IncomingChannelID)))
-		result.Add("server_id", fmt.Sprintf("cannot fetch discord server with ID [%s] make sure the bot has access to the channel", request.ServerID))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch discord server with ID [%s]", request.ServerID)))
+		result.Add("server_id", fmt.Sprintf("cannot fetch discord server with ID [%s] make sure the bot has access to the server", request.ServerID))
 	}
 
 	return result
@@ -144,8 +144,8 @@ func (validator *DiscordHandlerValidator) ValidateUpdate(ctx context.Context, re
 	}
 
 	if _, _, err := validator.client.Guild.Get(ctx, request.ServerID); err != nil {
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch discord channel with ID [%s]", request.IncomingChannelID)))
-		result.Add("server_id", fmt.Sprintf("cannot fetch discord server with ID [%s] make sure the bot has access to the channel", request.ServerID))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch discord server with ID [%s]", request.ServerID)))
+		result.Add("server_id", fmt.Sprintf("cannot fetch discord server with ID [%s] make sure the bot has access to the server", request.ServerID))
 	}
 
 	return result

--- a/api/pkg/validators/discord_handler_validator.go
+++ b/api/pkg/validators/discord_handler_validator.go
@@ -91,14 +91,12 @@ func (validator *DiscordHandlerValidator) ValidateStore(ctx context.Context, req
 	}
 
 	if _, _, err := validator.client.Channel.Get(ctx, request.IncomingChannelID); err != nil {
-		msg := fmt.Sprintf("cannot fetch discord channel with ID [%s]", request.IncomingChannelID)
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch discord channel with ID [%s]", request.IncomingChannelID)))
 		result.Add("incoming_channel_id", fmt.Sprintf("cannot fetch discord channel with ID [%s] make sure the bot has access to the channel", request.IncomingChannelID))
 	}
 
 	if _, _, err := validator.client.Guild.Get(ctx, request.ServerID); err != nil {
-		msg := fmt.Sprintf("cannot fetch discord channel with ID [%s]", request.IncomingChannelID)
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch discord channel with ID [%s]", request.IncomingChannelID)))
 		result.Add("server_id", fmt.Sprintf("cannot fetch discord server with ID [%s] make sure the bot has access to the channel", request.ServerID))
 	}
 
@@ -141,14 +139,12 @@ func (validator *DiscordHandlerValidator) ValidateUpdate(ctx context.Context, re
 	}
 
 	if _, _, err := validator.client.Channel.Get(ctx, request.IncomingChannelID); err != nil {
-		msg := fmt.Sprintf("cannot fetch discord channel with ID [%s]", request.IncomingChannelID)
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch discord channel with ID [%s]", request.IncomingChannelID)))
 		result.Add("incoming_channel_id", fmt.Sprintf("cannot fetch discord channel with ID [%s] make sure the bot has access to the channel", request.IncomingChannelID))
 	}
 
 	if _, _, err := validator.client.Guild.Get(ctx, request.ServerID); err != nil {
-		msg := fmt.Sprintf("cannot fetch discord channel with ID [%s]", request.IncomingChannelID)
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot fetch discord channel with ID [%s]", request.IncomingChannelID)))
 		result.Add("server_id", fmt.Sprintf("cannot fetch discord server with ID [%s] make sure the bot has access to the channel", request.ServerID))
 	}
 

--- a/api/pkg/validators/message_handler_validator.go
+++ b/api/pkg/validators/message_handler_validator.go
@@ -179,7 +179,7 @@ func (validator MessageHandlerValidator) ValidateMessageSend(ctx context.Context
 	}
 
 	if err != nil {
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("could not load phone for user [%s] and phone [%s]", userID, request.From))))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not load phone for user [%s] and phone [%s]", userID, request.From)))
 		result.Add("from", fmt.Sprintf("could not validate 'from' number [%s], please try again later", request.From))
 	}
 
@@ -229,7 +229,7 @@ func (validator MessageHandlerValidator) ValidateMessageBulkSend(ctx context.Con
 	}
 
 	if err != nil {
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("could not load phone for user [%s] and phone [%s]", userID, request.From))))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "could not load phone for user [%s] and phone [%s]", userID, request.From)))
 		result.Add("from", fmt.Sprintf("could not validate 'from' number [%s], please try again later", request.From))
 	}
 

--- a/api/pkg/validators/message_handler_validator.go
+++ b/api/pkg/validators/message_handler_validator.go
@@ -179,7 +179,7 @@ func (validator MessageHandlerValidator) ValidateMessageSend(ctx context.Context
 	}
 
 	if err != nil {
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, fmt.Sprintf("could not load phone for user [%s] and phone [%s]", userID, request.From))))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("could not load phone for user [%s] and phone [%s]", userID, request.From))))
 		result.Add("from", fmt.Sprintf("could not validate 'from' number [%s], please try again later", request.From))
 	}
 
@@ -229,7 +229,7 @@ func (validator MessageHandlerValidator) ValidateMessageBulkSend(ctx context.Con
 	}
 
 	if err != nil {
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, fmt.Sprintf("could not load phone for user [%s] and phone [%s]", userID, request.From))))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", fmt.Sprintf("could not load phone for user [%s] and phone [%s]", userID, request.From))))
 		result.Add("from", fmt.Sprintf("could not validate 'from' number [%s], please try again later", request.From))
 	}
 

--- a/api/pkg/validators/turnstile_token_validator.go
+++ b/api/pkg/validators/turnstile_token_validator.go
@@ -68,7 +68,7 @@ func (v *TurnstileTokenValidator) ValidateToken(ctx context.Context, ipAddress, 
 	request.Header.Set("Content-Type", "application/json")
 	response, err := v.httpClient.Do(request)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("failed to send http request to [%s]", request.URL.String())))
+		ctxLogger.Error(stacktrace.Propagate(err, "failed to send http request to [%s]", request.URL.String()))
 		return false
 	}
 	defer response.Body.Close()

--- a/api/pkg/validators/turnstile_token_validator.go
+++ b/api/pkg/validators/turnstile_token_validator.go
@@ -68,7 +68,7 @@ func (v *TurnstileTokenValidator) ValidateToken(ctx context.Context, ipAddress, 
 	request.Header.Set("Content-Type", "application/json")
 	response, err := v.httpClient.Do(request)
 	if err != nil {
-		ctxLogger.Error(stacktrace.Propagate(err, fmt.Sprintf("failed to send http request to [%s]", request.URL.String())))
+		ctxLogger.Error(stacktrace.Propagate(err, "%s", fmt.Sprintf("failed to send http request to [%s]", request.URL.String())))
 		return false
 	}
 	defer response.Body.Close()

--- a/api/pkg/validators/user_handler_validator.go
+++ b/api/pkg/validators/user_handler_validator.go
@@ -112,8 +112,7 @@ func (validator *UserHandlerValidator) ValidatePaymentInvoice(ctx context.Contex
 
 	payments, err := validator.service.GetSubscriptionPayments(ctx, userID)
 	if err != nil {
-		msg := fmt.Sprintf("cannot get subscription payments for user with ID [%s]", userID)
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "cannot get subscription payments for user with ID [%s]", userID)))
 		validationErrors.Add("subscriptionInvoiceID", "failed to validate subscription payment invoice ID")
 		return validationErrors
 	}

--- a/api/pkg/validators/user_handler_validator.go
+++ b/api/pkg/validators/user_handler_validator.go
@@ -113,7 +113,7 @@ func (validator *UserHandlerValidator) ValidatePaymentInvoice(ctx context.Contex
 	payments, err := validator.service.GetSubscriptionPayments(ctx, userID)
 	if err != nil {
 		msg := fmt.Sprintf("cannot get subscription payments for user with ID [%s]", userID)
-		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, msg)))
+		ctxLogger.Error(validator.tracer.WrapErrorSpan(span, stacktrace.Propagate(err, "%s", msg)))
 		validationErrors.Add("subscriptionInvoiceID", "failed to validate subscription payment invoice ID")
 		return validationErrors
 	}

--- a/api/pkg/validators/validator.go
+++ b/api/pkg/validators/validator.go
@@ -198,14 +198,14 @@ func validateAttachmentURL(ctx context.Context, c cache.Cache, attachmentURL str
 
 	req, err := http.NewRequest(http.MethodHead, attachmentURL, nil)
 	if err != nil {
-		errMsg := fmt.Sprintf("invalid url format")
+		errMsg := "invalid url format"
 		saveToCache(ctx, c, cacheKey, errMsg)
 		return errors.New(errMsg)
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		errMsg := fmt.Sprintf("could not reach the url")
+		errMsg := "could not reach the url"
 		saveToCache(ctx, c, cacheKey, errMsg)
 		return errors.New(errMsg)
 	}

--- a/api/pkg/validators/validator.go
+++ b/api/pkg/validators/validator.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -188,7 +189,7 @@ func validateAttachmentURL(ctx context.Context, c cache.Cache, attachmentURL str
 		if cachedVal == "valid" {
 			return nil
 		}
-		return fmt.Errorf(cachedVal)
+		return errors.New(cachedVal)
 	}
 
 	client := &http.Client{
@@ -199,21 +200,21 @@ func validateAttachmentURL(ctx context.Context, c cache.Cache, attachmentURL str
 	if err != nil {
 		errMsg := fmt.Sprintf("invalid url format")
 		saveToCache(ctx, c, cacheKey, errMsg)
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
 		errMsg := fmt.Sprintf("could not reach the url")
 		saveToCache(ctx, c, cacheKey, errMsg)
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		errMsg := fmt.Sprintf("url returned an error status code: %d", resp.StatusCode)
 		saveToCache(ctx, c, cacheKey, errMsg)
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 
 	const maxSizeBytes = 1.5 * 1024 * 1024
@@ -221,7 +222,7 @@ func validateAttachmentURL(ctx context.Context, c cache.Cache, attachmentURL str
 	if resp.ContentLength > int64(maxSizeBytes) {
 		errMsg := fmt.Sprintf("file size (%.2f MB) exceeds the 1.5 MB carrier limit", float64(resp.ContentLength)/(1024*1024))
 		saveToCache(ctx, c, cacheKey, errMsg)
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 
 	saveToCache(ctx, c, cacheKey, "valid")


### PR DESCRIPTION
## Summary
- use palantir stacktrace format strings directly instead of preformatting messages
- use keyed BSON elements and fix genuine format-string and protobuf lock-copy diagnostics
- mark localhost-dependent handler tests as integration-only

## Testing
- `cd api && go vet ./...`
- `cd api && go test ./...`