### PR TITLE
feat: add contacts management and thread resolution

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,27 +1,9 @@
 {
   "mcpServers": {
-    "playwright": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-playwright",
-        "--base-url",
-        "http://localhost:3000"
-      ],
-      "env": {
-        "BROWSER": "chromium"
-      }
-    },
     "context7": {
       "type": "stdio",
       "command": "npx",
       "args": ["@upstash/context7-mcp@latest"]
-    },
-    "axiom": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.axiom.co/mcp"]
     }
   }
 }

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -794,6 +794,12 @@ const docTemplate = `{
                         "description": "number of messages to return",
                         "name": "limit",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "include matching contact details",
+                        "name": "contacts",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -3401,6 +3407,66 @@ const docTemplate = `{
                 }
             }
         },
+        "entities.Contact": {
+            "type": "object",
+            "required": [
+                "created_at",
+                "emails",
+                "id",
+                "name",
+                "phone_numbers",
+                "properties",
+                "updated_at",
+                "user_id"
+            ],
+            "properties": {
+                "created_at": {
+                    "type": "string",
+                    "example": "2022-06-05T14:26:02.302718+03:00"
+                },
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "alice@example.com"
+                    ]
+                },
+                "id": {
+                    "type": "string",
+                    "example": "32343a19-da5e-4b1b-a767-3298a73703cb"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Alice Smith"
+                },
+                "phone_numbers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "+18005550199",
+                        "+18005550100"
+                    ]
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2022-06-05T14:26:02.302718+03:00"
+                },
+                "user_id": {
+                    "type": "string",
+                    "example": "WB7DRDWrJZRGbYrv2CKGkqbzvqdC"
+                }
+            }
+        },
         "entities.Discord": {
             "type": "object",
             "required": [
@@ -3714,6 +3780,14 @@ const docTemplate = `{
                 "contact": {
                     "type": "string",
                     "example": "+18005550100"
+                },
+                "contact_details": {
+                    "description": "ContactDetails is resolved at read time and never persisted.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/entities.Contact"
+                        }
+                    ]
                 },
                 "created_at": {
                     "type": "string",

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -4495,10 +4495,8 @@ const docTemplate = `{
         "requests.ContactItem": {
             "type": "object",
             "required": [
-                "emails",
                 "name",
-                "phone_numbers",
-                "properties"
+                "phone_numbers"
             ],
             "properties": {
                 "emails": {
@@ -4542,10 +4540,8 @@ const docTemplate = `{
         "requests.ContactUpdateRequest": {
             "type": "object",
             "required": [
-                "emails",
                 "name",
-                "phone_numbers",
-                "properties"
+                "phone_numbers"
             ],
             "properties": {
                 "emails": {

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -242,6 +242,344 @@ const docTemplate = `{
                 }
             }
         },
+        "/contacts": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns the paginated list of contacts for the authenticated user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contacts"
+                ],
+                "summary": "List contacts",
+                "parameters": [
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "description": "number of contacts to skip",
+                        "name": "skip",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "filter contacts containing query",
+                        "name": "query",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 100,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "number of contacts to return",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ContactsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.BadRequest"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/responses.Unauthorized"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/responses.UnprocessableEntity"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.InternalServerError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Creates a single contact or a batch of contacts. Accepts a JSON array or an object with a \"contacts\" array.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contacts"
+                ],
+                "summary": "Create one or many contacts",
+                "parameters": [
+                    {
+                        "description": "Contact(s) to create",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/requests.ContactStoreRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ContactsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.BadRequest"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/responses.Unauthorized"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/responses.UnprocessableEntity"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.InternalServerError"
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/upload": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Uploads a CSV file (multipart field \"document\") of contacts. Columns: Name, Emails, PhoneNumbers (multi-values separated by \";\").",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contacts"
+                ],
+                "summary": "Import contacts from CSV",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "CSV file of contacts",
+                        "name": "document",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ContactsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.BadRequest"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/responses.Unauthorized"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/responses.UnprocessableEntity"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.InternalServerError"
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{contactID}": {
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Updates the details of a single contact.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contacts"
+                ],
+                "summary": "Update a contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the contact",
+                        "name": "contactID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Contact details to update",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/requests.ContactUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ContactResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.BadRequest"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/responses.Unauthorized"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.NotFound"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/responses.UnprocessableEntity"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.InternalServerError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Deletes a single contact from the database.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contacts"
+                ],
+                "summary": "Delete a contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the contact",
+                        "name": "contactID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/responses.NoContent"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.BadRequest"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/responses.Unauthorized"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.NotFound"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/responses.UnprocessableEntity"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.InternalServerError"
+                        }
+                    }
+                }
+            }
+        },
         "/discord-integrations": {
             "get": {
                 "security": [
@@ -4154,6 +4492,86 @@ const docTemplate = `{
                 }
             }
         },
+        "requests.ContactItem": {
+            "type": "object",
+            "required": [
+                "emails",
+                "name",
+                "phone_numbers",
+                "properties"
+            ],
+            "properties": {
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Alice Smith"
+                },
+                "phone_numbers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "requests.ContactStoreRequest": {
+            "type": "object",
+            "required": [
+                "contacts"
+            ],
+            "properties": {
+                "contacts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/requests.ContactItem"
+                    }
+                }
+            }
+        },
+        "requests.ContactUpdateRequest": {
+            "type": "object",
+            "required": [
+                "emails",
+                "name",
+                "phone_numbers",
+                "properties"
+            ],
+            "properties": {
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Alice Smith"
+                },
+                "phone_numbers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "requests.DiscordStore": {
             "type": "object",
             "required": [
@@ -4805,6 +5223,51 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/entities.BulkMessage"
+                    }
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Request handled successfully"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "success"
+                }
+            }
+        },
+        "responses.ContactResponse": {
+            "type": "object",
+            "required": [
+                "data",
+                "message",
+                "status"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/entities.Contact"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Request handled successfully"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "success"
+                }
+            }
+        },
+        "responses.ContactsResponse": {
+            "type": "object",
+            "required": [
+                "data",
+                "message",
+                "status"
+            ],
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/entities.Contact"
                     }
                 },
                 "message": {

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -249,7 +249,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Returns the paginated list of contacts for the authenticated user.",
+                "description": "Returns the paginated list of contacts for the authenticated user. The top-level \"total\" field is the number of contacts matching the query filter, independent of skip/limit, so clients can drive server-side pagination.",
                 "consumes": [
                     "application/json"
                 ],
@@ -5257,7 +5257,8 @@ const docTemplate = `{
             "required": [
                 "data",
                 "message",
-                "status"
+                "status",
+                "total"
             ],
             "properties": {
                 "data": {
@@ -5273,6 +5274,11 @@ const docTemplate = `{
                 "status": {
                     "type": "string",
                     "example": "success"
+                },
+                "total": {
+                    "description": "Total is the number of contacts matching the request filter for the\nuser, independent of the pagination skip/limit applied to Data.",
+                    "type": "integer",
+                    "example": 57
                 }
             }
         },

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -363,6 +363,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/responses.Unauthorized"
                         }
                     },
+                    "402": {
+                        "description": "Payment Required",
+                        "schema": {
+                            "$ref": "#/definitions/responses.PaymentRequired"
+                        }
+                    },
                     "422": {
                         "description": "Unprocessable Entity",
                         "schema": {
@@ -422,6 +428,12 @@ const docTemplate = `{
                         "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/responses.Unauthorized"
+                        }
+                    },
+                    "402": {
+                        "description": "Payment Required",
+                        "schema": {
+                            "$ref": "#/definitions/responses.PaymentRequired"
                         }
                     },
                     "422": {

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -275,6 +275,22 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "name",
+                            "updated_at"
+                        ],
+                        "type": "string",
+                        "description": "field to sort contacts by",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "sort contacts in descending order",
+                        "name": "sort_descending",
+                        "in": "query"
+                    },
+                    {
                         "maximum": 100,
                         "minimum": 1,
                         "type": "integer",

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -364,7 +364,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.ContactsResponse"
+                            "$ref": "#/definitions/responses.ContactsCreatedResponse"
                         }
                     },
                     "400": {
@@ -431,7 +431,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.ContactsResponse"
+                            "$ref": "#/definitions/responses.ContactsCreatedResponse"
                         }
                     },
                     "400": {
@@ -5269,6 +5269,30 @@ const docTemplate = `{
             "properties": {
                 "data": {
                     "$ref": "#/definitions/entities.Contact"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Request handled successfully"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "success"
+                }
+            }
+        },
+        "responses.ContactsCreatedResponse": {
+            "type": "object",
+            "required": [
+                "data",
+                "message",
+                "status"
+            ],
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/entities.Contact"
+                    }
                 },
                 "message": {
                     "type": "string",

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -246,7 +246,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Returns the paginated list of contacts for the authenticated user.",
+                "description": "Returns the paginated list of contacts for the authenticated user. The top-level \"total\" field is the number of contacts matching the query filter, independent of skip/limit, so clients can drive server-side pagination.",
                 "consumes": [
                     "application/json"
                 ],
@@ -5254,7 +5254,8 @@
             "required": [
                 "data",
                 "message",
-                "status"
+                "status",
+                "total"
             ],
             "properties": {
                 "data": {
@@ -5270,6 +5271,11 @@
                 "status": {
                     "type": "string",
                     "example": "success"
+                },
+                "total": {
+                    "description": "Total is the number of contacts matching the request filter for the\nuser, independent of the pagination skip/limit applied to Data.",
+                    "type": "integer",
+                    "example": 57
                 }
             }
         },

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -239,6 +239,344 @@
                 }
             }
         },
+        "/contacts": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns the paginated list of contacts for the authenticated user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contacts"
+                ],
+                "summary": "List contacts",
+                "parameters": [
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "description": "number of contacts to skip",
+                        "name": "skip",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "filter contacts containing query",
+                        "name": "query",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 100,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "number of contacts to return",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ContactsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.BadRequest"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/responses.Unauthorized"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/responses.UnprocessableEntity"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.InternalServerError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Creates a single contact or a batch of contacts. Accepts a JSON array or an object with a \"contacts\" array.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contacts"
+                ],
+                "summary": "Create one or many contacts",
+                "parameters": [
+                    {
+                        "description": "Contact(s) to create",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/requests.ContactStoreRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ContactsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.BadRequest"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/responses.Unauthorized"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/responses.UnprocessableEntity"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.InternalServerError"
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/upload": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Uploads a CSV file (multipart field \"document\") of contacts. Columns: Name, Emails, PhoneNumbers (multi-values separated by \";\").",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contacts"
+                ],
+                "summary": "Import contacts from CSV",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "CSV file of contacts",
+                        "name": "document",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ContactsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.BadRequest"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/responses.Unauthorized"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/responses.UnprocessableEntity"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.InternalServerError"
+                        }
+                    }
+                }
+            }
+        },
+        "/contacts/{contactID}": {
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Updates the details of a single contact.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contacts"
+                ],
+                "summary": "Update a contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the contact",
+                        "name": "contactID",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Contact details to update",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/requests.ContactUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ContactResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.BadRequest"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/responses.Unauthorized"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.NotFound"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/responses.UnprocessableEntity"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.InternalServerError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Deletes a single contact from the database.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contacts"
+                ],
+                "summary": "Delete a contact",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID of the contact",
+                        "name": "contactID",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/responses.NoContent"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/responses.BadRequest"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/responses.Unauthorized"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.NotFound"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/responses.UnprocessableEntity"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/responses.InternalServerError"
+                        }
+                    }
+                }
+            }
+        },
         "/discord-integrations": {
             "get": {
                 "security": [
@@ -4151,6 +4489,86 @@
                 }
             }
         },
+        "requests.ContactItem": {
+            "type": "object",
+            "required": [
+                "emails",
+                "name",
+                "phone_numbers",
+                "properties"
+            ],
+            "properties": {
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Alice Smith"
+                },
+                "phone_numbers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "requests.ContactStoreRequest": {
+            "type": "object",
+            "required": [
+                "contacts"
+            ],
+            "properties": {
+                "contacts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/requests.ContactItem"
+                    }
+                }
+            }
+        },
+        "requests.ContactUpdateRequest": {
+            "type": "object",
+            "required": [
+                "emails",
+                "name",
+                "phone_numbers",
+                "properties"
+            ],
+            "properties": {
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Alice Smith"
+                },
+                "phone_numbers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "requests.DiscordStore": {
             "type": "object",
             "required": [
@@ -4802,6 +5220,51 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/entities.BulkMessage"
+                    }
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Request handled successfully"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "success"
+                }
+            }
+        },
+        "responses.ContactResponse": {
+            "type": "object",
+            "required": [
+                "data",
+                "message",
+                "status"
+            ],
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/entities.Contact"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Request handled successfully"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "success"
+                }
+            }
+        },
+        "responses.ContactsResponse": {
+            "type": "object",
+            "required": [
+                "data",
+                "message",
+                "status"
+            ],
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/entities.Contact"
                     }
                 },
                 "message": {

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -4492,10 +4492,8 @@
         "requests.ContactItem": {
             "type": "object",
             "required": [
-                "emails",
                 "name",
-                "phone_numbers",
-                "properties"
+                "phone_numbers"
             ],
             "properties": {
                 "emails": {
@@ -4539,10 +4537,8 @@
         "requests.ContactUpdateRequest": {
             "type": "object",
             "required": [
-                "emails",
                 "name",
-                "phone_numbers",
-                "properties"
+                "phone_numbers"
             ],
             "properties": {
                 "emails": {

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -791,6 +791,12 @@
                         "description": "number of messages to return",
                         "name": "limit",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "include matching contact details",
+                        "name": "contacts",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -3398,6 +3404,66 @@
                 }
             }
         },
+        "entities.Contact": {
+            "type": "object",
+            "required": [
+                "created_at",
+                "emails",
+                "id",
+                "name",
+                "phone_numbers",
+                "properties",
+                "updated_at",
+                "user_id"
+            ],
+            "properties": {
+                "created_at": {
+                    "type": "string",
+                    "example": "2022-06-05T14:26:02.302718+03:00"
+                },
+                "emails": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "alice@example.com"
+                    ]
+                },
+                "id": {
+                    "type": "string",
+                    "example": "32343a19-da5e-4b1b-a767-3298a73703cb"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Alice Smith"
+                },
+                "phone_numbers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "+18005550199",
+                        "+18005550100"
+                    ]
+                },
+                "properties": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2022-06-05T14:26:02.302718+03:00"
+                },
+                "user_id": {
+                    "type": "string",
+                    "example": "WB7DRDWrJZRGbYrv2CKGkqbzvqdC"
+                }
+            }
+        },
         "entities.Discord": {
             "type": "object",
             "required": [
@@ -3711,6 +3777,14 @@
                 "contact": {
                     "type": "string",
                     "example": "+18005550100"
+                },
+                "contact_details": {
+                    "description": "ContactDetails is resolved at read time and never persisted.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/entities.Contact"
+                        }
+                    ]
                 },
                 "created_at": {
                     "type": "string",

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -361,7 +361,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.ContactsResponse"
+                            "$ref": "#/definitions/responses.ContactsCreatedResponse"
                         }
                     },
                     "400": {
@@ -428,7 +428,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/responses.ContactsResponse"
+                            "$ref": "#/definitions/responses.ContactsCreatedResponse"
                         }
                     },
                     "400": {
@@ -5266,6 +5266,30 @@
             "properties": {
                 "data": {
                     "$ref": "#/definitions/entities.Contact"
+                },
+                "message": {
+                    "type": "string",
+                    "example": "Request handled successfully"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "success"
+                }
+            }
+        },
+        "responses.ContactsCreatedResponse": {
+            "type": "object",
+            "required": [
+                "data",
+                "message",
+                "status"
+            ],
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/entities.Contact"
+                    }
                 },
                 "message": {
                     "type": "string",

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -272,6 +272,22 @@
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "name",
+                            "updated_at"
+                        ],
+                        "type": "string",
+                        "description": "field to sort contacts by",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "sort contacts in descending order",
+                        "name": "sort_descending",
+                        "in": "query"
+                    },
+                    {
                         "maximum": 100,
                         "minimum": 1,
                         "type": "integer",

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -360,6 +360,12 @@
                             "$ref": "#/definitions/responses.Unauthorized"
                         }
                     },
+                    "402": {
+                        "description": "Payment Required",
+                        "schema": {
+                            "$ref": "#/definitions/responses.PaymentRequired"
+                        }
+                    },
                     "422": {
                         "description": "Unprocessable Entity",
                         "schema": {
@@ -419,6 +425,12 @@
                         "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/responses.Unauthorized"
+                        }
+                    },
+                    "402": {
+                        "description": "Payment Required",
+                        "schema": {
+                            "$ref": "#/definitions/responses.PaymentRequired"
                         }
                     },
                     "422": {

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -80,6 +80,50 @@ definitions:
     - sent_count
     - total
     type: object
+  entities.Contact:
+    properties:
+      created_at:
+        example: "2022-06-05T14:26:02.302718+03:00"
+        type: string
+      emails:
+        example:
+        - alice@example.com
+        items:
+          type: string
+        type: array
+      id:
+        example: 32343a19-da5e-4b1b-a767-3298a73703cb
+        type: string
+      name:
+        example: Alice Smith
+        type: string
+      phone_numbers:
+        example:
+        - "+18005550199"
+        - "+18005550100"
+        items:
+          type: string
+        type: array
+      properties:
+        additionalProperties:
+          type: string
+        type: object
+      updated_at:
+        example: "2022-06-05T14:26:02.302718+03:00"
+        type: string
+      user_id:
+        example: WB7DRDWrJZRGbYrv2CKGkqbzvqdC
+        type: string
+    required:
+    - created_at
+    - emails
+    - id
+    - name
+    - phone_numbers
+    - properties
+    - updated_at
+    - user_id
+    type: object
   entities.Discord:
     properties:
       created_at:
@@ -310,6 +354,10 @@ definitions:
       contact:
         example: "+18005550100"
         type: string
+      contact_details:
+        allOf:
+        - $ref: '#/definitions/entities.Contact'
+        description: ContactDetails is resolved at read time and never persisted.
       created_at:
         example: "2022-06-05T14:26:09.527976+03:00"
         type: string
@@ -2106,6 +2154,10 @@ paths:
         minimum: 1
         name: limit
         type: integer
+      - description: include matching contact details
+        in: query
+        name: contacts
+        type: boolean
       produces:
       - application/json
       responses:

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -671,10 +671,8 @@ definitions:
           type: string
         type: object
     required:
-    - emails
     - name
     - phone_numbers
-    - properties
     type: object
   requests.ContactStoreRequest:
     properties:
@@ -703,10 +701,8 @@ definitions:
           type: string
         type: object
     required:
-    - emails
     - name
     - phone_numbers
-    - properties
     type: object
   requests.DiscordStore:
     properties:

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -653,6 +653,61 @@ definitions:
     - url
     - user_id
     type: object
+  requests.ContactItem:
+    properties:
+      emails:
+        items:
+          type: string
+        type: array
+      name:
+        example: Alice Smith
+        type: string
+      phone_numbers:
+        items:
+          type: string
+        type: array
+      properties:
+        additionalProperties:
+          type: string
+        type: object
+    required:
+    - emails
+    - name
+    - phone_numbers
+    - properties
+    type: object
+  requests.ContactStoreRequest:
+    properties:
+      contacts:
+        items:
+          $ref: '#/definitions/requests.ContactItem'
+        type: array
+    required:
+    - contacts
+    type: object
+  requests.ContactUpdateRequest:
+    properties:
+      emails:
+        items:
+          type: string
+        type: array
+      name:
+        example: Alice Smith
+        type: string
+      phone_numbers:
+        items:
+          type: string
+        type: array
+      properties:
+        additionalProperties:
+          type: string
+        type: object
+    required:
+    - emails
+    - name
+    - phone_numbers
+    - properties
+    type: object
   requests.DiscordStore:
     properties:
       incoming_channel_id:
@@ -1145,6 +1200,38 @@ definitions:
       data:
         items:
           $ref: '#/definitions/entities.BulkMessage'
+        type: array
+      message:
+        example: Request handled successfully
+        type: string
+      status:
+        example: success
+        type: string
+    required:
+    - data
+    - message
+    - status
+    type: object
+  responses.ContactResponse:
+    properties:
+      data:
+        $ref: '#/definitions/entities.Contact'
+      message:
+        example: Request handled successfully
+        type: string
+      status:
+        example: success
+        type: string
+    required:
+    - data
+    - message
+    - status
+    type: object
+  responses.ContactsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/entities.Contact'
         type: array
       message:
         example: Request handled successfully
@@ -1795,6 +1882,226 @@ paths:
       summary: Store bulk SMS file
       tags:
       - BulkSMS
+  /contacts:
+    get:
+      consumes:
+      - application/json
+      description: Returns the paginated list of contacts for the authenticated user.
+      parameters:
+      - description: number of contacts to skip
+        in: query
+        minimum: 0
+        name: skip
+        type: integer
+      - description: filter contacts containing query
+        in: query
+        name: query
+        type: string
+      - description: number of contacts to return
+        in: query
+        maximum: 100
+        minimum: 1
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/responses.ContactsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/responses.BadRequest'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/responses.Unauthorized'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/responses.UnprocessableEntity'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/responses.InternalServerError'
+      security:
+      - ApiKeyAuth: []
+      summary: List contacts
+      tags:
+      - Contacts
+    post:
+      consumes:
+      - application/json
+      description: Creates a single contact or a batch of contacts. Accepts a JSON
+        array or an object with a "contacts" array.
+      parameters:
+      - description: Contact(s) to create
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/requests.ContactStoreRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/responses.ContactsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/responses.BadRequest'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/responses.Unauthorized'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/responses.UnprocessableEntity'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/responses.InternalServerError'
+      security:
+      - ApiKeyAuth: []
+      summary: Create one or many contacts
+      tags:
+      - Contacts
+  /contacts/{contactID}:
+    delete:
+      consumes:
+      - application/json
+      description: Deletes a single contact from the database.
+      parameters:
+      - description: ID of the contact
+        in: path
+        name: contactID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/responses.NoContent'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/responses.BadRequest'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/responses.Unauthorized'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/responses.NotFound'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/responses.UnprocessableEntity'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/responses.InternalServerError'
+      security:
+      - ApiKeyAuth: []
+      summary: Delete a contact
+      tags:
+      - Contacts
+    put:
+      consumes:
+      - application/json
+      description: Updates the details of a single contact.
+      parameters:
+      - description: ID of the contact
+        in: path
+        name: contactID
+        required: true
+        type: string
+      - description: Contact details to update
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/requests.ContactUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/responses.ContactResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/responses.BadRequest'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/responses.Unauthorized'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/responses.NotFound'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/responses.UnprocessableEntity'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/responses.InternalServerError'
+      security:
+      - ApiKeyAuth: []
+      summary: Update a contact
+      tags:
+      - Contacts
+  /contacts/upload:
+    post:
+      consumes:
+      - multipart/form-data
+      description: 'Uploads a CSV file (multipart field "document") of contacts. Columns:
+        Name, Emails, PhoneNumbers (multi-values separated by ";").'
+      parameters:
+      - description: CSV file of contacts
+        in: formData
+        name: document
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/responses.ContactsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/responses.BadRequest'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/responses.Unauthorized'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/responses.UnprocessableEntity'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/responses.InternalServerError'
+      security:
+      - ApiKeyAuth: []
+      summary: Import contacts from CSV
+      tags:
+      - Contacts
   /discord-integrations:
     get:
       consumes:

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -1235,10 +1235,17 @@ definitions:
       status:
         example: success
         type: string
+      total:
+        description: |-
+          Total is the number of contacts matching the request filter for the
+          user, independent of the pagination skip/limit applied to Data.
+        example: 57
+        type: integer
     required:
     - data
     - message
     - status
+    - total
     type: object
   responses.DiscordResponse:
     properties:
@@ -1883,6 +1890,8 @@ paths:
       consumes:
       - application/json
       description: Returns the paginated list of contacts for the authenticated user.
+        The top-level "total" field is the number of contacts matching the query filter,
+        independent of skip/limit, so clients can drive server-side pagination.
       parameters:
       - description: number of contacts to skip
         in: query

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -1223,6 +1223,23 @@ definitions:
     - message
     - status
     type: object
+  responses.ContactsCreatedResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/entities.Contact'
+        type: array
+      message:
+        example: Request handled successfully
+        type: string
+      status:
+        example: success
+        type: string
+    required:
+    - data
+    - message
+    - status
+    type: object
   responses.ContactsResponse:
     properties:
       data:
@@ -1965,7 +1982,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/responses.ContactsResponse'
+            $ref: '#/definitions/responses.ContactsCreatedResponse'
         "400":
           description: Bad Request
           schema:
@@ -2100,7 +2117,7 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/responses.ContactsResponse'
+            $ref: '#/definitions/responses.ContactsCreatedResponse'
         "400":
           description: Bad Request
           schema:

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -1963,6 +1963,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/responses.Unauthorized'
+        "402":
+          description: Payment Required
+          schema:
+            $ref: '#/definitions/responses.PaymentRequired'
         "422":
           description: Unprocessable Entity
           schema:
@@ -2094,6 +2098,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/responses.Unauthorized'
+        "402":
+          description: Payment Required
+          schema:
+            $ref: '#/definitions/responses.PaymentRequired'
         "422":
           description: Unprocessable Entity
           schema:

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -1902,6 +1902,17 @@ paths:
         in: query
         name: query
         type: string
+      - description: field to sort contacts by
+        enum:
+        - name
+        - updated_at
+        in: query
+        name: sort_by
+        type: string
+      - description: sort contacts in descending order
+        in: query
+        name: sort_descending
+        type: boolean
       - description: number of contacts to return
         in: query
         maximum: 100

--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -414,6 +414,10 @@ ALTER TABLE discords ADD CONSTRAINT IF NOT EXISTS uni_discords_server_id CHECK (
 		container.logger.Fatal(stacktrace.Propagatef(err, "cannot migrate %T", &entities.PhoneAPIKey{}))
 	}
 
+	if err = db.AutoMigrate(&entities.Contact{}); err != nil {
+		container.logger.Fatal(stacktrace.Propagatef(err, "cannot migrate %T", &entities.Contact{}))
+	}
+
 	return container.db
 }
 

--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -1114,6 +1114,7 @@ func (container *Container) MessageThreadService() (service *services.MessageThr
 		container.MessageThreadRepository(),
 		container.PhoneRepository(),
 		container.EventDispatcher(),
+		nil,
 	)
 }
 

--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -123,6 +123,8 @@ func NewContainer(projectID string, version string) (container *Container) {
 	container.RegisterMessageThreadRoutes()
 	container.RegisterMessageThreadListeners()
 
+	container.RegisterContactRoutes()
+
 	container.RegisterHeartbeatRoutes()
 	container.RegisterHeartbeatListeners()
 
@@ -701,6 +703,26 @@ func (container *Container) MessageThreadHandlerValidator() (validator *validato
 	)
 }
 
+// ContactHandlerValidator creates a new instance of validators.ContactHandlerValidator
+func (container *Container) ContactHandlerValidator() (validator *validators.ContactHandlerValidator) {
+	container.logger.Debug(fmt.Sprintf("creating %T", validator))
+	return validators.NewContactHandlerValidator(
+		container.Logger(),
+		container.Tracer(),
+	)
+}
+
+// ContactHandler creates a new instance of handlers.ContactHandler
+func (container *Container) ContactHandler() (h *handlers.ContactHandler) {
+	container.logger.Debug(fmt.Sprintf("creating %T", h))
+	return handlers.NewContactHandler(
+		container.Logger(),
+		container.Tracer(),
+		container.ContactHandlerValidator(),
+		container.ContactService(),
+	)
+}
+
 // PhoneHandlerValidator creates a new instance of validators.PhoneHandlerValidator
 func (container *Container) PhoneHandlerValidator() (validator *validators.PhoneHandlerValidator) {
 	container.logger.Debug(fmt.Sprintf("creating %T", validator))
@@ -893,6 +915,16 @@ func (container *Container) PhoneNotificationRepository() (repository repositori
 func (container *Container) MessageThreadRepository() (repository repositories.MessageThreadRepository) {
 	container.logger.Debug("creating GORM repositories.MessageThreadRepository")
 	return repositories.NewGormMessageThreadRepository(
+		container.Logger(),
+		container.Tracer(),
+		container.DB(),
+	)
+}
+
+// ContactRepository creates a new instance of repositories.ContactRepository
+func (container *Container) ContactRepository() (repository repositories.ContactRepository) {
+	container.logger.Debug("creating GORM repositories.ContactRepository")
+	return repositories.NewGormContactRepository(
 		container.Logger(),
 		container.Tracer(),
 		container.DB(),
@@ -1114,7 +1146,18 @@ func (container *Container) MessageThreadService() (service *services.MessageThr
 		container.MessageThreadRepository(),
 		container.PhoneRepository(),
 		container.EventDispatcher(),
-		nil,
+		container.ContactService(),
+	)
+}
+
+// ContactService creates a new instance of services.ContactService
+func (container *Container) ContactService() (service *services.ContactService) {
+	container.logger.Debug(fmt.Sprintf("creating %T", service))
+	return services.NewContactService(
+		container.Logger(),
+		container.Tracer(),
+		container.ContactRepository(),
+		container.Cache(),
 	)
 }
 
@@ -1667,6 +1710,12 @@ func (container *Container) RegisterBulkMessageRoutes() {
 func (container *Container) RegisterMessageThreadRoutes() {
 	container.logger.Debug(fmt.Sprintf("registering %T routes", &handlers.MessageThreadHandler{}))
 	container.MessageThreadHandler().RegisterRoutes(container.App(), container.AuthenticatedMiddleware())
+}
+
+// RegisterContactRoutes registers routes for the /contacts prefix
+func (container *Container) RegisterContactRoutes() {
+	container.logger.Debug(fmt.Sprintf("registering %T routes", &handlers.ContactHandler{}))
+	container.ContactHandler().RegisterRoutes(container.App(), container.AuthenticatedMiddleware())
 }
 
 // RegisterHeartbeatRoutes registers routes for the /heartbeats prefix

--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -124,6 +124,7 @@ func NewContainer(projectID string, version string) (container *Container) {
 	container.RegisterMessageThreadListeners()
 
 	container.RegisterContactRoutes()
+	container.RegisterContactListeners()
 
 	container.RegisterHeartbeatRoutes()
 	container.RegisterHeartbeatListeners()
@@ -1414,6 +1415,20 @@ func (container *Container) RegisterMessageThreadListeners() {
 		container.Logger(),
 		container.Tracer(),
 		container.MessageThreadService(),
+	)
+
+	for event, handler := range routes {
+		container.EventDispatcher().Subscribe(event, handler)
+	}
+}
+
+// RegisterContactListeners registers event listeners for listeners.ContactListener.
+func (container *Container) RegisterContactListeners() {
+	container.logger.Debug(fmt.Sprintf("registering listeners for %T", listeners.ContactListener{}))
+	_, routes := listeners.NewContactListener(
+		container.Logger(),
+		container.Tracer(),
+		container.ContactService(),
 	)
 
 	for event, handler := range routes {

--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -585,7 +585,6 @@ func (container *Container) MessageHandlerValidator() (validator *validators.Mes
 		container.Tracer(),
 		container.PhoneService(),
 		container.TurnstileTokenValidator(),
-		container.Cache(),
 	)
 }
 
@@ -608,7 +607,6 @@ func (container *Container) BulkMessageHandlerValidator() (validator *validators
 		container.Tracer(),
 		container.PhoneService(),
 		container.UserService(),
-		container.Cache(),
 	)
 }
 
@@ -1158,7 +1156,7 @@ func (container *Container) ContactService() (service *services.ContactService) 
 		container.Logger(),
 		container.Tracer(),
 		container.ContactRepository(),
-		container.Cache(),
+		container.InMemoryCache(),
 	)
 }
 

--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -925,12 +925,22 @@ func (container *Container) MessageThreadRepository() (repository repositories.M
 
 // ContactRepository creates a new instance of repositories.ContactRepository
 func (container *Container) ContactRepository() (repository repositories.ContactRepository) {
-	container.logger.Debug("creating GORM repositories.ContactRepository")
-	return repositories.NewGormContactRepository(
-		container.Logger(),
-		container.Tracer(),
-		container.DB(),
-	)
+	switch os.Getenv("CONTACT_DB_BACKEND") {
+	case "mongodb":
+		container.logger.Debug("creating MongoDB repositories.ContactRepository")
+		return repositories.NewMongoContactRepository(
+			container.Logger(),
+			container.Tracer(),
+			container.MongoDB(),
+		)
+	default:
+		container.logger.Debug("creating GORM repositories.ContactRepository")
+		return repositories.NewGormContactRepository(
+			container.Logger(),
+			container.Tracer(),
+			container.DB(),
+		)
+	}
 }
 
 // HeartbeatMonitorRepository creates a new instance of repositories.HeartbeatMonitorRepository

--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -84,18 +84,20 @@ import (
 
 // Container is used to resolve services at runtime
 type Container struct {
-	projectID            string
-	db                   *gorm.DB
-	dedicatedDB          *gorm.DB
-	mongoDB              *mongoDriver.Database
-	version              string
-	app                  *fiber.App
-	eventDispatcher      *services.EventDispatcher
-	logger               telemetry.Logger
-	attachmentRepository repositories.AttachmentRepository
-	userRistrettoCache   *ristretto.Cache[string, entities.AuthContext]
-	phoneRistrettoCache  *ristretto.Cache[string, *entities.Phone]
-	inMemoryCache        cache.Cache
+	projectID             string
+	db                    *gorm.DB
+	dedicatedDB           *gorm.DB
+	mongoDB               *mongoDriver.Database
+	version               string
+	app                   *fiber.App
+	eventDispatcher       *services.EventDispatcher
+	logger                telemetry.Logger
+	attachmentRepository  repositories.AttachmentRepository
+	contactService        *services.ContactService
+	userRistrettoCache    *ristretto.Cache[string, entities.AuthContext]
+	phoneRistrettoCache   *ristretto.Cache[string, *entities.Phone]
+	contactRistrettoCache *ristretto.Cache[string, services.ContactCacheEntry]
+	inMemoryCache         cache.Cache
 }
 
 // NewLiteContainer creates a Container without any routes or listeners
@@ -1152,13 +1154,17 @@ func (container *Container) MessageThreadService() (service *services.MessageThr
 
 // ContactService creates a new instance of services.ContactService
 func (container *Container) ContactService() (service *services.ContactService) {
+	if container.contactService != nil {
+		return container.contactService
+	}
 	container.logger.Debug(fmt.Sprintf("creating %T", service))
-	return services.NewContactService(
+	container.contactService = services.NewContactService(
 		container.Logger(),
 		container.Tracer(),
 		container.ContactRepository(),
-		container.InMemoryCache(),
+		container.ContactRistrettoCache(),
 	)
+	return container.contactService
 }
 
 // EmailNotificationService creates a new instance of services.EmailNotificationService
@@ -1839,6 +1845,24 @@ func (container *Container) PhoneRistrettoCache() *ristretto.Cache[string, *enti
 	}
 	container.phoneRistrettoCache = ristrettoCache
 	return container.phoneRistrettoCache
+}
+
+// ContactRistrettoCache creates an in-memory cache keyed by user and phone number.
+func (container *Container) ContactRistrettoCache() *ristretto.Cache[string, services.ContactCacheEntry] {
+	if container.contactRistrettoCache != nil {
+		return container.contactRistrettoCache
+	}
+	container.logger.Debug(fmt.Sprintf("creating %T", container.contactRistrettoCache))
+	ristrettoCache, err := ristretto.NewCache[string, services.ContactCacheEntry](&ristretto.Config[string, services.ContactCacheEntry]{
+		MaxCost:     5000,
+		NumCounters: 5000 * 10,
+		BufferItems: 64,
+	})
+	if err != nil {
+		container.logger.Fatal(stacktrace.Propagatef(err, "cannot create contact ristretto cache"))
+	}
+	container.contactRistrettoCache = ristrettoCache
+	return container.contactRistrettoCache
 }
 
 // UserRistrettoCache creates an in-memory *ristretto.Cache[string, entities.AuthContext]

--- a/api/pkg/di/container.go
+++ b/api/pkg/di/container.go
@@ -720,6 +720,7 @@ func (container *Container) ContactHandler() (h *handlers.ContactHandler) {
 		container.Tracer(),
 		container.ContactHandlerValidator(),
 		container.ContactService(),
+		container.EntitlementService(),
 	)
 }
 

--- a/api/pkg/entities/contact.go
+++ b/api/pkg/entities/contact.go
@@ -1,0 +1,76 @@
+package entities
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+)
+
+// ContactProperties is a free-form key/value map persisted as a jsonb column.
+type ContactProperties map[string]string
+
+// Value implements driver.Valuer, serializing the map to JSON bytes.
+func (p ContactProperties) Value() (driver.Value, error) {
+	if p == nil {
+		return []byte("{}"), nil
+	}
+
+	data, err := json.Marshal(p)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// Scan implements sql.Scanner, deserializing jsonb bytes/string into the map.
+func (p *ContactProperties) Scan(src any) error {
+	if src == nil {
+		*p = ContactProperties{}
+		return nil
+	}
+
+	var data []byte
+	switch value := src.(type) {
+	case []byte:
+		data = value
+	case string:
+		data = []byte(value)
+	default:
+		return fmt.Errorf("unsupported type [%T] for ContactProperties", src)
+	}
+
+	if len(data) == 0 {
+		*p = ContactProperties{}
+		return nil
+	}
+
+	result := ContactProperties{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return err
+	}
+
+	*p = result
+	return nil
+}
+
+// Contact represents a saved contact belonging to a user.
+type Contact struct {
+	ID           uuid.UUID         `json:"id" gorm:"primaryKey;type:uuid;" example:"32343a19-da5e-4b1b-a767-3298a73703cb"`
+	UserID       UserID            `json:"user_id" gorm:"index" example:"WB7DRDWrJZRGbYrv2CKGkqbzvqdC"`
+	Name         string            `json:"name" example:"Alice Smith"`
+	Emails       pq.StringArray    `json:"emails" gorm:"type:text[]" swaggertype:"array,string" example:"alice@example.com"`
+	PhoneNumbers pq.StringArray    `json:"phone_numbers" gorm:"type:text[]" swaggertype:"array,string" example:"+18005550199,+18005550100"`
+	Properties   ContactProperties `json:"properties" gorm:"type:jsonb" swaggertype:"object,string"`
+	CreatedAt    time.Time         `json:"created_at" example:"2022-06-05T14:26:02.302718+03:00"`
+	UpdatedAt    time.Time         `json:"updated_at" example:"2022-06-05T14:26:02.302718+03:00"`
+}
+
+// TableName overrides the table name used by Contact.
+func (Contact) TableName() string {
+	return "contacts"
+}

--- a/api/pkg/entities/contact.go
+++ b/api/pkg/entities/contact.go
@@ -3,9 +3,9 @@ package entities
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"fmt"
 	"time"
 
+	"github.com/NdoleStudio/stacktrace"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 )
@@ -21,7 +21,7 @@ func (p ContactProperties) Value() (driver.Value, error) {
 
 	data, err := json.Marshal(p)
 	if err != nil {
-		return nil, err
+		return nil, stacktrace.Propagatef(err, "cannot marshal ContactProperties")
 	}
 
 	return data, nil
@@ -41,7 +41,7 @@ func (p *ContactProperties) Scan(src any) error {
 	case string:
 		data = []byte(value)
 	default:
-		return fmt.Errorf("unsupported type [%T] for ContactProperties", src)
+		return stacktrace.NewErrorf("unsupported type [%T] for ContactProperties", src)
 	}
 
 	if len(data) == 0 {
@@ -51,7 +51,7 @@ func (p *ContactProperties) Scan(src any) error {
 
 	result := ContactProperties{}
 	if err := json.Unmarshal(data, &result); err != nil {
-		return err
+		return stacktrace.Propagatef(err, "cannot unmarshal ContactProperties")
 	}
 
 	*p = result
@@ -60,7 +60,7 @@ func (p *ContactProperties) Scan(src any) error {
 
 // Contact represents a saved contact belonging to a user.
 type Contact struct {
-	ID           uuid.UUID         `json:"id" gorm:"primaryKey;type:uuid;" example:"32343a19-da5e-4b1b-a767-3298a73703cb"`
+	ID           uuid.UUID         `json:"id" gorm:"primaryKey;type:uuid" example:"32343a19-da5e-4b1b-a767-3298a73703cb"`
 	UserID       UserID            `json:"user_id" gorm:"index" example:"WB7DRDWrJZRGbYrv2CKGkqbzvqdC"`
 	Name         string            `json:"name" example:"Alice Smith"`
 	Emails       pq.StringArray    `json:"emails" gorm:"type:text[]" swaggertype:"array,string" example:"alice@example.com"`

--- a/api/pkg/entities/contact.go
+++ b/api/pkg/entities/contact.go
@@ -63,14 +63,14 @@ func (p *ContactProperties) Scan(src any) error {
 
 // Contact represents a saved contact belonging to a user.
 type Contact struct {
-	ID           uuid.UUID         `json:"id" gorm:"primaryKey;type:uuid" example:"32343a19-da5e-4b1b-a767-3298a73703cb"`
-	UserID       UserID            `json:"user_id" gorm:"index" example:"WB7DRDWrJZRGbYrv2CKGkqbzvqdC"`
-	Name         string            `json:"name" example:"Alice Smith"`
-	Emails       pq.StringArray    `json:"emails" gorm:"type:text[]" swaggertype:"array,string" example:"alice@example.com"`
-	PhoneNumbers pq.StringArray    `json:"phone_numbers" gorm:"type:text[]" swaggertype:"array,string" example:"+18005550199,+18005550100"`
-	Properties   ContactProperties `json:"properties" gorm:"type:jsonb" swaggertype:"object,string"`
-	CreatedAt    time.Time         `json:"created_at" example:"2022-06-05T14:26:02.302718+03:00"`
-	UpdatedAt    time.Time         `json:"updated_at" example:"2022-06-05T14:26:02.302718+03:00"`
+	ID           uuid.UUID         `json:"id" gorm:"primaryKey;type:uuid" bson:"_id" example:"32343a19-da5e-4b1b-a767-3298a73703cb"`
+	UserID       UserID            `json:"user_id" gorm:"index" bson:"user_id" example:"WB7DRDWrJZRGbYrv2CKGkqbzvqdC"`
+	Name         string            `json:"name" bson:"name" example:"Alice Smith"`
+	Emails       pq.StringArray    `json:"emails" gorm:"type:text[]" bson:"emails" swaggertype:"array,string" example:"alice@example.com"`
+	PhoneNumbers pq.StringArray    `json:"phone_numbers" gorm:"type:text[]" bson:"phone_numbers" swaggertype:"array,string" example:"+18005550199,+18005550100"`
+	Properties   ContactProperties `json:"properties" gorm:"type:jsonb" bson:"properties" swaggertype:"object,string"`
+	CreatedAt    time.Time         `json:"created_at" bson:"created_at" example:"2022-06-05T14:26:02.302718+03:00"`
+	UpdatedAt    time.Time         `json:"updated_at" bson:"updated_at" example:"2022-06-05T14:26:02.302718+03:00"`
 }
 
 // TableName overrides the table name used by Contact.

--- a/api/pkg/entities/contact.go
+++ b/api/pkg/entities/contact.go
@@ -10,6 +10,9 @@ import (
 	"github.com/lib/pq"
 )
 
+// EntityNameContact is the entitlement entity name for contacts.
+const EntityNameContact = "Contact"
+
 // ContactProperties is a free-form key/value map persisted as a jsonb column.
 type ContactProperties map[string]string
 

--- a/api/pkg/entities/contact_test.go
+++ b/api/pkg/entities/contact_test.go
@@ -1,6 +1,7 @@
 package entities
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,4 +39,14 @@ func TestContactProperties_ScanNil(t *testing.T) {
 	var scanned ContactProperties
 	assert.Nil(t, scanned.Scan(nil))
 	assert.Equal(t, 0, len(scanned))
+}
+
+func TestContactProperties_ScanUnsupportedType(t *testing.T) {
+	var scanned ContactProperties
+
+	err := scanned.Scan(123)
+
+	assert.Error(t, err)
+	assert.Equal(t, "*stacktrace.stacktrace", reflect.TypeOf(err).String())
+	assert.Contains(t, err.Error(), "unsupported type [int] for ContactProperties")
 }

--- a/api/pkg/entities/contact_test.go
+++ b/api/pkg/entities/contact_test.go
@@ -1,7 +1,6 @@
 package entities
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,6 +46,5 @@ func TestContactProperties_ScanUnsupportedType(t *testing.T) {
 	err := scanned.Scan(123)
 
 	assert.Error(t, err)
-	assert.Equal(t, "*stacktrace.stacktrace", reflect.TypeOf(err).String())
 	assert.Contains(t, err.Error(), "unsupported type [int] for ContactProperties")
 }

--- a/api/pkg/entities/contact_test.go
+++ b/api/pkg/entities/contact_test.go
@@ -1,0 +1,41 @@
+package entities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContactProperties_ValueScanRoundTrip(t *testing.T) {
+	cases := []ContactProperties{
+		nil,
+		{},
+		{"company": "Acme", "role": "CTO"},
+	}
+
+	for _, original := range cases {
+		value, err := original.Value()
+		assert.Nil(t, err)
+
+		var scanned ContactProperties
+		assert.Nil(t, scanned.Scan(value))
+
+		if len(original) == 0 {
+			assert.Equal(t, 0, len(scanned))
+			continue
+		}
+		assert.Equal(t, original, scanned)
+	}
+}
+
+func TestContactProperties_ScanFromString(t *testing.T) {
+	var scanned ContactProperties
+	assert.Nil(t, scanned.Scan(`{"k":"v"}`))
+	assert.Equal(t, ContactProperties{"k": "v"}, scanned)
+}
+
+func TestContactProperties_ScanNil(t *testing.T) {
+	var scanned ContactProperties
+	assert.Nil(t, scanned.Scan(nil))
+	assert.Equal(t, 0, len(scanned))
+}

--- a/api/pkg/entities/contact_test.go
+++ b/api/pkg/entities/contact_test.go
@@ -1,10 +1,31 @@
 package entities
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestContact_BSONFieldNames(t *testing.T) {
+	contactType := reflect.TypeOf(Contact{})
+	expected := map[string]string{
+		"ID":           "_id",
+		"UserID":       "user_id",
+		"Name":         "name",
+		"Emails":       "emails",
+		"PhoneNumbers": "phone_numbers",
+		"Properties":   "properties",
+		"CreatedAt":    "created_at",
+		"UpdatedAt":    "updated_at",
+	}
+
+	for fieldName, bsonName := range expected {
+		field, found := contactType.FieldByName(fieldName)
+		assert.True(t, found)
+		assert.Equal(t, bsonName, field.Tag.Get("bson"))
+	}
+}
 
 func TestContactProperties_ValueScanRoundTrip(t *testing.T) {
 	cases := []ContactProperties{

--- a/api/pkg/entities/message_thread.go
+++ b/api/pkg/entities/message_thread.go
@@ -22,6 +22,8 @@ type MessageThread struct {
 	CreatedAt          time.Time     `json:"created_at" example:"2022-06-05T14:26:09.527976+03:00"`
 	UpdatedAt          time.Time     `json:"updated_at" example:"2022-06-05T14:26:09.527976+03:00"`
 	OrderTimestamp     time.Time     `json:"order_timestamp" example:"2022-06-05T14:26:09.527976+03:00"`
+	// ContactDetails is resolved at read time and never persisted.
+	ContactDetails *Contact `json:"contact_details,omitempty" gorm:"-"`
 }
 
 // Update a message thread after a message event

--- a/api/pkg/entities/message_thread_test.go
+++ b/api/pkg/entities/message_thread_test.go
@@ -1,6 +1,7 @@
 package entities
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -22,4 +23,21 @@ func TestMessageThreadReadFieldsHaveBackwardCompatibleDefaults(t *testing.T) {
 	assert.Contains(t, lastReadAt.Tag.Get("gorm"), "not null")
 	assert.Contains(t, lastReadAt.Tag.Get("gorm"), "default:CURRENT_TIMESTAMP")
 	assert.Equal(t, "-", lastReadAt.Tag.Get("json"))
+}
+
+func TestMessageThreadContactDetailsAreTransientAndOmittedWhenNil(t *testing.T) {
+	threadType := reflect.TypeOf(MessageThread{})
+
+	contactDetails, ok := threadType.FieldByName("ContactDetails")
+	require.True(t, ok)
+	assert.Equal(t, "*entities.Contact", contactDetails.Type.String())
+	assert.Equal(t, "contact_details,omitempty", contactDetails.Tag.Get("json"))
+	assert.Equal(t, "-", contactDetails.Tag.Get("gorm"))
+
+	data, err := json.Marshal(MessageThread{})
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(data, &payload))
+	assert.NotContains(t, payload, "contact_details")
 }

--- a/api/pkg/handlers/contact_handler.go
+++ b/api/pkg/handlers/contact_handler.go
@@ -1,0 +1,274 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/requests"
+	"github.com/NdoleStudio/httpsms/pkg/services"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/httpsms/pkg/validators"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+)
+
+// ContactHandler handles contact http requests.
+type ContactHandler struct {
+	handler
+	logger    telemetry.Logger
+	tracer    telemetry.Tracer
+	validator *validators.ContactHandlerValidator
+	service   *services.ContactService
+}
+
+// NewContactHandler creates a new ContactHandler.
+func NewContactHandler(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+	validator *validators.ContactHandlerValidator,
+	service *services.ContactService,
+) (h *ContactHandler) {
+	return &ContactHandler{
+		logger:    logger.WithService(fmt.Sprintf("%T", h)),
+		tracer:    tracer,
+		validator: validator,
+		service:   service,
+	}
+}
+
+// RegisterRoutes registers the routes for the ContactHandler.
+func (h *ContactHandler) RegisterRoutes(router fiber.Router, middlewares ...fiber.Handler) {
+	h.register(router, fiber.MethodGet, "/v1/contacts", middlewares, h.Index)
+	h.register(router, fiber.MethodPost, "/v1/contacts", middlewares, h.Store)
+	h.register(router, fiber.MethodPost, "/v1/contacts/upload", middlewares, h.Upload)
+	h.register(router, fiber.MethodPut, "/v1/contacts/:contactID", middlewares, h.Update)
+	h.register(router, fiber.MethodDelete, "/v1/contacts/:contactID", middlewares, h.Delete)
+}
+
+// Index lists contacts for the authenticated user.
+// @Summary      List contacts
+// @Description  Returns the paginated list of contacts for the authenticated user.
+// @Security	 ApiKeyAuth
+// @Tags         Contacts
+// @Accept       json
+// @Produce      json
+// @Param        skip	query  int  	false	"number of contacts to skip"	minimum(0)
+// @Param        query	query  string  	false 	"filter contacts containing query"
+// @Param        limit	query  int  	false	"number of contacts to return"	minimum(1)	maximum(100)
+// @Success      200 	{object}	responses.ContactsResponse
+// @Failure      400	{object}	responses.BadRequest
+// @Failure 	 401    {object}	responses.Unauthorized
+// @Failure      422	{object}	responses.UnprocessableEntity
+// @Failure      500	{object}	responses.InternalServerError
+// @Router       /contacts [get]
+func (h *ContactHandler) Index(c fiber.Ctx) error {
+	ctx, span, ctxLogger := h.tracer.StartFromFiberCtxWithLogger(c, h.logger)
+	defer span.End()
+
+	var request requests.ContactIndex
+	if err := c.Bind().Query(&request); err != nil {
+		ctxLogger.Warn(stacktrace.Propagatef(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
+		return h.responseBadRequest(c, err)
+	}
+
+	sanitized := request.Sanitize()
+	if errors := h.validator.ValidateIndex(ctx, sanitized); len(errors) != 0 {
+		ctxLogger.Warn(stacktrace.NewErrorf("validation errors [%s], while listing contacts [%+#v]", spew.Sdump(errors), sanitized))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while listing contacts")
+	}
+
+	userID := h.userIDFomContext(c)
+	contacts, err := h.service.Index(ctx, userID, sanitized.ToIndexParams())
+	if err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot list contacts for user [%s]", userID))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseOK(c, fmt.Sprintf("fetched %d %s", len(*contacts), h.pluralize("contact", len(*contacts))), contacts)
+}
+
+// Store creates one or many contacts.
+// @Summary      Create one or many contacts
+// @Description  Creates a single contact or a batch of contacts. Accepts a JSON array or an object with a "contacts" array.
+// @Security	 ApiKeyAuth
+// @Tags         Contacts
+// @Accept       json
+// @Produce      json
+// @Param        payload   body 		requests.ContactStoreRequest 	true 	"Contact(s) to create"
+// @Success      201 	{object}	responses.ContactsResponse
+// @Failure      400	{object}	responses.BadRequest
+// @Failure 	 401    {object}	responses.Unauthorized
+// @Failure      422	{object}	responses.UnprocessableEntity
+// @Failure      500	{object}	responses.InternalServerError
+// @Router       /contacts [post]
+func (h *ContactHandler) Store(c fiber.Ctx) error {
+	ctx, span, ctxLogger := h.tracer.StartFromFiberCtxWithLogger(c, h.logger)
+	defer span.End()
+
+	var request requests.ContactStoreRequest
+	if err := c.Bind().Body(&request); err != nil {
+		ctxLogger.Warn(stacktrace.Propagatef(err, "cannot marshall body [%s] into %T", c.Body(), request))
+		return h.responseBadRequest(c, err)
+	}
+
+	sanitized := request.Sanitize()
+	if errors := h.validator.ValidateStore(ctx, sanitized); len(errors) != 0 {
+		ctxLogger.Warn(stacktrace.NewErrorf("validation errors [%s], while creating contacts", spew.Sdump(errors)))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while creating contacts")
+	}
+
+	userID := h.userIDFomContext(c)
+	contacts := sanitized.ToContacts(userID)
+	if err := h.service.CreateMany(ctx, userID, contacts); err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot create [%d] contacts for user [%s]", len(contacts), userID))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseCreated(c, fmt.Sprintf("created %d %s", len(contacts), h.pluralize("contact", len(contacts))), contacts)
+}
+
+// Upload imports contacts from a CSV file.
+// @Summary      Import contacts from CSV
+// @Description  Uploads a CSV file (multipart field "document") of contacts. Columns: Name, Emails, PhoneNumbers (multi-values separated by ";").
+// @Security	 ApiKeyAuth
+// @Tags         Contacts
+// @Accept       multipart/form-data
+// @Produce      json
+// @Param        document	formData	file	true	"CSV file of contacts"
+// @Success      201 	{object}	responses.ContactsResponse
+// @Failure      400	{object}	responses.BadRequest
+// @Failure 	 401    {object}	responses.Unauthorized
+// @Failure      422	{object}	responses.UnprocessableEntity
+// @Failure      500	{object}	responses.InternalServerError
+// @Router       /contacts/upload [post]
+func (h *ContactHandler) Upload(c fiber.Ctx) error {
+	ctx, span, ctxLogger := h.tracer.StartFromFiberCtxWithLogger(c, h.logger)
+	defer span.End()
+
+	file, err := c.FormFile("document")
+	if err != nil {
+		ctxLogger.Warn(stacktrace.Propagatef(err, "cannot fetch file with name [%s] from request", "document"))
+		return h.responseBadRequest(c, err)
+	}
+
+	userID := h.userIDFomContext(c)
+	items, errors := h.validator.ValidateUpload(ctx, userID, file)
+	if len(errors) != 0 {
+		ctxLogger.Warn(stacktrace.NewErrorf("validation errors [%s], while importing contacts from CSV [%s]", spew.Sdump(errors), file.Filename))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while importing contacts")
+	}
+
+	request := (requests.ContactStoreRequest{Contacts: items}).Sanitize()
+	contacts := request.ToContacts(userID)
+	if err = h.service.CreateMany(ctx, userID, contacts); err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot import [%d] contacts for user [%s]", len(contacts), userID))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseCreated(c, fmt.Sprintf("imported %d %s", len(contacts), h.pluralize("contact", len(contacts))), contacts)
+}
+
+// Update updates a single contact.
+// @Summary      Update a contact
+// @Description  Updates the details of a single contact.
+// @Security	 ApiKeyAuth
+// @Tags         Contacts
+// @Accept       json
+// @Produce      json
+// @Param 		 contactID	path		string 							true 	"ID of the contact"
+// @Param        payload   	body 		requests.ContactUpdateRequest 	true 	"Contact details to update"
+// @Success      200 		{object}	responses.ContactResponse
+// @Failure      400		{object}	responses.BadRequest
+// @Failure 	 401    	{object}	responses.Unauthorized
+// @Failure      404		{object}	responses.NotFound
+// @Failure      422		{object}	responses.UnprocessableEntity
+// @Failure      500		{object}	responses.InternalServerError
+// @Router       /contacts/{contactID} [put]
+func (h *ContactHandler) Update(c fiber.Ctx) error {
+	ctx, span, ctxLogger := h.tracer.StartFromFiberCtxWithLogger(c, h.logger)
+	defer span.End()
+
+	contactID := c.Params("contactID")
+	if errors := h.validator.ValidateUUID(contactID, "contactID"); len(errors) != 0 {
+		ctxLogger.Warn(stacktrace.NewErrorf("validation errors [%s], while updating contact [%s]", spew.Sdump(errors), contactID))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while updating contact")
+	}
+
+	var request requests.ContactUpdateRequest
+	if err := c.Bind().Body(&request); err != nil {
+		ctxLogger.Warn(stacktrace.Propagatef(err, "cannot marshall body into %T", request))
+		return h.responseBadRequest(c, err)
+	}
+
+	sanitized := request.Sanitize()
+	if errors := h.validator.ValidateUpdate(ctx, sanitized); len(errors) != 0 {
+		ctxLogger.Warn(stacktrace.NewErrorf("validation errors [%s], while updating contact [%s]", spew.Sdump(errors), contactID))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while updating contact")
+	}
+
+	userID := h.userIDFomContext(c)
+	contact, err := h.service.Get(ctx, userID, uuid.MustParse(contactID))
+	if stacktrace.GetCode(err) == repositories.ErrCodeNotFound {
+		return h.responseNotFound(c, fmt.Sprintf("cannot find contact with ID [%s]", contactID))
+	}
+	if err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot load contact [%s] for user [%s]", contactID, userID))
+		return h.responseInternalServerError(c)
+	}
+
+	sanitized.ApplyTo(contact)
+	if err = h.service.Update(ctx, contact); err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot update contact [%s] for user [%s]", contactID, userID))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseOK(c, "contact updated successfully", contact)
+}
+
+// Delete removes a single contact.
+// @Summary      Delete a contact
+// @Description  Deletes a single contact from the database.
+// @Security	 ApiKeyAuth
+// @Tags         Contacts
+// @Accept       json
+// @Produce      json
+// @Param 		 contactID	path		string 	true	"ID of the contact"
+// @Success      204  	{object} 	responses.NoContent
+// @Failure      400  	{object}  	responses.BadRequest
+// @Failure 	 401    {object}	responses.Unauthorized
+// @Failure 	 404	{object}	responses.NotFound
+// @Failure      422  	{object} 	responses.UnprocessableEntity
+// @Failure      500  	{object}  	responses.InternalServerError
+// @Router       /contacts/{contactID} [delete]
+func (h *ContactHandler) Delete(c fiber.Ctx) error {
+	ctx, span, ctxLogger := h.tracer.StartFromFiberCtxWithLogger(c, h.logger)
+	defer span.End()
+
+	contactID := c.Params("contactID")
+	if errors := h.validator.ValidateUUID(contactID, "contactID"); len(errors) != 0 {
+		ctxLogger.Warn(stacktrace.NewErrorf("validation errors [%s], while deleting contact [%s]", spew.Sdump(errors), contactID))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while deleting contact")
+	}
+
+	userID := h.userIDFomContext(c)
+
+	// Load first so a missing contact for the authenticated user returns 404
+	// instead of silently succeeding via a 0-row DELETE. This also prevents
+	// leaking whether another user's contact exists.
+	if _, err := h.service.Get(ctx, userID, uuid.MustParse(contactID)); err != nil {
+		if stacktrace.GetCode(err) == repositories.ErrCodeNotFound {
+			return h.responseNotFound(c, fmt.Sprintf("cannot find contact with ID [%s]", contactID))
+		}
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot load contact [%s] for user [%s]", contactID, userID))
+		return h.responseInternalServerError(c)
+	}
+
+	if err := h.service.Delete(ctx, userID, uuid.MustParse(contactID)); err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot delete contact [%s] for user [%s]", contactID, userID))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseNoContent(c, "contact deleted successfully")
+}

--- a/api/pkg/handlers/contact_handler.go
+++ b/api/pkg/handlers/contact_handler.go
@@ -49,7 +49,7 @@ func (h *ContactHandler) RegisterRoutes(router fiber.Router, middlewares ...fibe
 
 // Index lists contacts for the authenticated user.
 // @Summary      List contacts
-// @Description  Returns the paginated list of contacts for the authenticated user.
+// @Description  Returns the paginated list of contacts for the authenticated user. The top-level "total" field is the number of contacts matching the query filter, independent of skip/limit, so clients can drive server-side pagination.
 // @Security	 ApiKeyAuth
 // @Tags         Contacts
 // @Accept       json
@@ -80,13 +80,20 @@ func (h *ContactHandler) Index(c fiber.Ctx) error {
 	}
 
 	userID := h.userIDFomContext(c)
-	contacts, err := h.service.Index(ctx, userID, sanitized.ToIndexParams())
+	params := sanitized.ToIndexParams()
+	contacts, err := h.service.Index(ctx, userID, params)
 	if err != nil {
 		ctxLogger.Error(stacktrace.Propagatef(err, "cannot list contacts for user [%s]", userID))
 		return h.responseInternalServerError(c)
 	}
 
-	return h.responseOK(c, fmt.Sprintf("fetched %d %s", len(*contacts), h.pluralize("contact", len(*contacts))), contacts)
+	total, err := h.service.Count(ctx, userID, params)
+	if err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot count contacts for user [%s]", userID))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseOKWithTotal(c, fmt.Sprintf("fetched %d %s", len(*contacts), h.pluralize("contact", len(*contacts))), contacts, total)
 }
 
 // Store creates one or many contacts.
@@ -160,7 +167,9 @@ func (h *ContactHandler) Upload(c fiber.Ctx) error {
 		return h.responseUnprocessableEntity(c, errors, "validation errors while importing contacts")
 	}
 
-	request := (requests.ContactStoreRequest{Contacts: items}).Sanitize()
+	// items are already sanitized by ValidateUpload (SanitizeContactItem), so
+	// build the persistable records directly without re-sanitizing.
+	request := requests.ContactStoreRequest{Contacts: items}
 	contacts := request.ToContacts(userID)
 	if err = h.service.CreateMany(ctx, userID, contacts); err != nil {
 		ctxLogger.Error(stacktrace.Propagatef(err, "cannot import [%d] contacts for user [%s]", len(contacts), userID))

--- a/api/pkg/handlers/contact_handler.go
+++ b/api/pkg/handlers/contact_handler.go
@@ -61,6 +61,8 @@ func (h *ContactHandler) RegisterRoutes(router fiber.Router, middlewares ...fibe
 // @Produce      json
 // @Param        skip	query  int  	false	"number of contacts to skip"	minimum(0)
 // @Param        query	query  string  	false 	"filter contacts containing query"
+// @Param        sort_by	query  string  	false 	"field to sort contacts by" Enums(name, updated_at)
+// @Param        sort_descending	query  bool  	false 	"sort contacts in descending order"
 // @Param        limit	query  int  	false	"number of contacts to return"	minimum(1)	maximum(100)
 // @Success      200 	{object}	responses.ContactsResponse
 // @Failure      400	{object}	responses.BadRequest

--- a/api/pkg/handlers/contact_handler.go
+++ b/api/pkg/handlers/contact_handler.go
@@ -111,7 +111,7 @@ func (h *ContactHandler) Index(c fiber.Ctx) error {
 // @Accept       json
 // @Produce      json
 // @Param        payload   body 		requests.ContactStoreRequest 	true 	"Contact(s) to create"
-// @Success      201 	{object}	responses.ContactsResponse
+// @Success      201 	{object}	responses.ContactsCreatedResponse
 // @Failure      400	{object}	responses.BadRequest
 // @Failure 	 401    {object}	responses.Unauthorized
 // @Failure 	 402	{object}	responses.PaymentRequired
@@ -161,7 +161,7 @@ func (h *ContactHandler) Store(c fiber.Ctx) error {
 // @Accept       multipart/form-data
 // @Produce      json
 // @Param        document	formData	file	true	"CSV file of contacts"
-// @Success      201 	{object}	responses.ContactsResponse
+// @Success      201 	{object}	responses.ContactsCreatedResponse
 // @Failure      400	{object}	responses.BadRequest
 // @Failure 	 401    {object}	responses.Unauthorized
 // @Failure 	 402	{object}	responses.PaymentRequired

--- a/api/pkg/handlers/contact_handler.go
+++ b/api/pkg/handlers/contact_handler.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/NdoleStudio/httpsms/pkg/entities"
 	"github.com/NdoleStudio/httpsms/pkg/repositories"
 	"github.com/NdoleStudio/httpsms/pkg/requests"
 	"github.com/NdoleStudio/httpsms/pkg/services"
@@ -17,10 +19,11 @@ import (
 // ContactHandler handles contact http requests.
 type ContactHandler struct {
 	handler
-	logger    telemetry.Logger
-	tracer    telemetry.Tracer
-	validator *validators.ContactHandlerValidator
-	service   *services.ContactService
+	logger             telemetry.Logger
+	tracer             telemetry.Tracer
+	validator          *validators.ContactHandlerValidator
+	service            *services.ContactService
+	entitlementService *services.EntitlementService
 }
 
 // NewContactHandler creates a new ContactHandler.
@@ -29,12 +32,14 @@ func NewContactHandler(
 	tracer telemetry.Tracer,
 	validator *validators.ContactHandlerValidator,
 	service *services.ContactService,
+	entitlementService *services.EntitlementService,
 ) (h *ContactHandler) {
 	return &ContactHandler{
-		logger:    logger.WithService(fmt.Sprintf("%T", h)),
-		tracer:    tracer,
-		validator: validator,
-		service:   service,
+		logger:             logger.WithService(fmt.Sprintf("%T", h)),
+		tracer:             tracer,
+		validator:          validator,
+		service:            service,
+		entitlementService: entitlementService,
 	}
 }
 
@@ -107,6 +112,7 @@ func (h *ContactHandler) Index(c fiber.Ctx) error {
 // @Success      201 	{object}	responses.ContactsResponse
 // @Failure      400	{object}	responses.BadRequest
 // @Failure 	 401    {object}	responses.Unauthorized
+// @Failure 	 402	{object}	responses.PaymentRequired
 // @Failure      422	{object}	responses.UnprocessableEntity
 // @Failure      500	{object}	responses.InternalServerError
 // @Router       /contacts [post]
@@ -128,6 +134,15 @@ func (h *ContactHandler) Store(c fiber.Ctx) error {
 
 	userID := h.userIDFomContext(c)
 	contacts := sanitized.ToContacts(userID)
+	result, err := h.checkCreateEntitlement(ctx, userID, len(contacts))
+	if err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot check contact entitlement for user [%s]", userID))
+		return h.responseInternalServerError(c)
+	}
+	if !result.Allowed {
+		return h.responsePaymentRequired(c, result.Message)
+	}
+
 	if err := h.service.CreateMany(ctx, userID, contacts); err != nil {
 		ctxLogger.Error(stacktrace.Propagatef(err, "cannot create [%d] contacts for user [%s]", len(contacts), userID))
 		return h.responseInternalServerError(c)
@@ -147,6 +162,7 @@ func (h *ContactHandler) Store(c fiber.Ctx) error {
 // @Success      201 	{object}	responses.ContactsResponse
 // @Failure      400	{object}	responses.BadRequest
 // @Failure 	 401    {object}	responses.Unauthorized
+// @Failure 	 402	{object}	responses.PaymentRequired
 // @Failure      422	{object}	responses.UnprocessableEntity
 // @Failure      500	{object}	responses.InternalServerError
 // @Router       /contacts/upload [post]
@@ -171,6 +187,15 @@ func (h *ContactHandler) Upload(c fiber.Ctx) error {
 	// build the persistable records directly without re-sanitizing.
 	request := requests.ContactStoreRequest{Contacts: items}
 	contacts := request.ToContacts(userID)
+	result, err := h.checkCreateEntitlement(ctx, userID, len(contacts))
+	if err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot check contact entitlement for user [%s]", userID))
+		return h.responseInternalServerError(c)
+	}
+	if !result.Allowed {
+		return h.responsePaymentRequired(c, result.Message)
+	}
+
 	if err = h.service.CreateMany(ctx, userID, contacts); err != nil {
 		ctxLogger.Error(stacktrace.Propagatef(err, "cannot import [%d] contacts for user [%s]", len(contacts), userID))
 		return h.responseInternalServerError(c)
@@ -280,4 +305,15 @@ func (h *ContactHandler) Delete(c fiber.Ctx) error {
 	}
 
 	return h.responseNoContent(c, "contact deleted successfully")
+}
+
+func (h *ContactHandler) checkCreateEntitlement(
+	ctx context.Context,
+	userID entities.UserID,
+	additionalCount int,
+) (*services.EntitlementCheckResult, error) {
+	return h.entitlementService.CheckAdditional(ctx, userID, entities.EntityNameContact, additionalCount, func() (int, error) {
+		count, err := h.service.Count(ctx, userID, repositories.IndexParams{})
+		return int(count), err
+	})
 }

--- a/api/pkg/handlers/contact_handler.go
+++ b/api/pkg/handlers/contact_handler.go
@@ -254,8 +254,9 @@ func (h *ContactHandler) Update(c fiber.Ctx) error {
 		return h.responseInternalServerError(c)
 	}
 
+	previousPhoneNumbers := append([]string{}, contact.PhoneNumbers...)
 	sanitized.ApplyTo(contact)
-	if err = h.service.Update(ctx, contact); err != nil {
+	if err = h.service.Update(ctx, contact, previousPhoneNumbers); err != nil {
 		ctxLogger.Error(stacktrace.Propagatef(err, "cannot update contact [%s] for user [%s]", contactID, userID))
 		return h.responseInternalServerError(c)
 	}

--- a/api/pkg/handlers/contact_handler_test.go
+++ b/api/pkg/handlers/contact_handler_test.go
@@ -1,0 +1,509 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/cache"
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/middlewares"
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/services"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/httpsms/pkg/validators"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	ttlCache "github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// contactHandlerFakeRepo is a shared, thread-safe ContactRepository stub that
+// records the effects of Store/Update/Delete and returns configurable Load/Index
+// results so handler tests can assert real service→repository behaviour.
+type contactHandlerFakeRepo struct {
+	mu sync.Mutex
+
+	stored      [][]*entities.Contact
+	updated     []*entities.Contact
+	deleted     []deletedContact
+	indexParams []repositories.IndexParams
+	loadCalls   []loadedContact
+
+	loadResult  *entities.Contact
+	loadErr     error
+	indexResult []entities.Contact
+	indexErr    error
+	storeErr    error
+	updateErr   error
+	deleteErr   error
+}
+
+type deletedContact struct {
+	userID entities.UserID
+	id     uuid.UUID
+}
+
+type loadedContact struct {
+	userID entities.UserID
+	id     uuid.UUID
+}
+
+func (r *contactHandlerFakeRepo) Store(_ context.Context, contacts []*entities.Contact) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.storeErr != nil {
+		return r.storeErr
+	}
+	r.stored = append(r.stored, contacts)
+	return nil
+}
+
+func (r *contactHandlerFakeRepo) Update(_ context.Context, contact *entities.Contact) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	r.updated = append(r.updated, contact)
+	return nil
+}
+
+func (r *contactHandlerFakeRepo) Load(_ context.Context, userID entities.UserID, id uuid.UUID) (*entities.Contact, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.loadCalls = append(r.loadCalls, loadedContact{userID: userID, id: id})
+	if r.loadErr != nil {
+		return nil, r.loadErr
+	}
+	if r.loadResult == nil {
+		return nil, nil
+	}
+	// Return a copy so handler mutations don't corrupt the fixture.
+	clone := *r.loadResult
+	return &clone, nil
+}
+
+func (r *contactHandlerFakeRepo) Index(_ context.Context, _ entities.UserID, params repositories.IndexParams) (*[]entities.Contact, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.indexParams = append(r.indexParams, params)
+	if r.indexErr != nil {
+		return nil, r.indexErr
+	}
+	out := make([]entities.Contact, len(r.indexResult))
+	copy(out, r.indexResult)
+	return &out, nil
+}
+
+func (r *contactHandlerFakeRepo) FetchAll(context.Context, entities.UserID) (*[]entities.Contact, error) {
+	out := []entities.Contact{}
+	return &out, nil
+}
+
+func (r *contactHandlerFakeRepo) Delete(_ context.Context, userID entities.UserID, id uuid.UUID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+	r.deleted = append(r.deleted, deletedContact{userID: userID, id: id})
+	return nil
+}
+
+func (r *contactHandlerFakeRepo) DeleteAllForUser(context.Context, entities.UserID) error {
+	return nil
+}
+
+// snapshot returns a safe read of the recorded effects.
+func (r *contactHandlerFakeRepo) snapshot() ([][]*entities.Contact, []*entities.Contact, []deletedContact, []repositories.IndexParams) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.stored, r.updated, r.deleted, r.indexParams
+}
+
+const contactHandlerTestUserID = entities.UserID("user-id")
+
+func newContactHandlerTestApp(repo repositories.ContactRepository) *fiber.App {
+	logger := &messageThreadHandlerNoopLogger{}
+	tracer := telemetry.NewOtelLogger("test", logger)
+	appCache := cache.NewMemoryCache(tracer, ttlCache.New(time.Minute, time.Minute))
+	service := services.NewContactService(logger, tracer, repo, appCache)
+	handler := NewContactHandler(logger, tracer, validators.NewContactHandlerValidator(logger, tracer), service)
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Locals(middlewares.ContextKeyAuthUserID, entities.AuthContext{ID: contactHandlerTestUserID, Email: "user@example.com"})
+		return c.Next()
+	})
+	handler.RegisterRoutes(app)
+	return app
+}
+
+type contactHandlerPayload struct {
+	Status  string          `json:"status"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+func decodeContactHandlerPayload(t *testing.T, resp *http.Response) contactHandlerPayload {
+	t.Helper()
+	var payload contactHandlerPayload
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	return payload
+}
+
+func TestContactHandler_Store_CreatesSingleContact(t *testing.T) {
+	repo := &contactHandlerFakeRepo{}
+	app := newContactHandlerTestApp(repo)
+
+	body := `[{"name":"Alice","phone_numbers":["+18005550199"],"emails":["alice@example.com"]}]`
+	req := httptest.NewRequest(http.MethodPost, "/v1/contacts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	stored, _, _, _ := repo.snapshot()
+	require.Len(t, stored, 1)
+	require.Len(t, stored[0], 1)
+	require.Equal(t, "Alice", stored[0][0].Name)
+	require.Equal(t, contactHandlerTestUserID, stored[0][0].UserID)
+	require.Equal(t, pq.StringArray{"+18005550199"}, stored[0][0].PhoneNumbers)
+}
+
+func TestContactHandler_Store_CreatesManyContactsFromObjectShape(t *testing.T) {
+	repo := &contactHandlerFakeRepo{}
+	app := newContactHandlerTestApp(repo)
+
+	body := `{"contacts":[
+		{"name":"Alice","phone_numbers":["+18005550199"]},
+		{"name":"Bob","phone_numbers":["+18005550100"]}
+	]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/contacts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	stored, _, _, _ := repo.snapshot()
+	require.Len(t, stored, 1)
+	require.Len(t, stored[0], 2)
+	assert.Equal(t, "Alice", stored[0][0].Name)
+	assert.Equal(t, "Bob", stored[0][1].Name)
+}
+
+func TestContactHandler_Store_ValidationError_ReturnsUnprocessableEntity(t *testing.T) {
+	repo := &contactHandlerFakeRepo{}
+	app := newContactHandlerTestApp(repo)
+
+	body := `[{"name":"","phone_numbers":[]}]`
+	req := httptest.NewRequest(http.MethodPost, "/v1/contacts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+
+	stored, _, _, _ := repo.snapshot()
+	require.Empty(t, stored, "no contact should be stored on validation failure")
+}
+
+func TestContactHandler_Store_MalformedJSON_ReturnsBadRequest(t *testing.T) {
+	app := newContactHandlerTestApp(&contactHandlerFakeRepo{})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/contacts", bytes.NewBufferString("{not json"))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func buildContactCSVUpload(t *testing.T, filename string, contentType string, body string) (*bytes.Buffer, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	header := make(textproto.MIMEHeader)
+	header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="document"; filename="%s"`, filename))
+	header.Set("Content-Type", contentType)
+	part, err := writer.CreatePart(header)
+	require.NoError(t, err)
+	_, err = part.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return &buf, writer.FormDataContentType()
+}
+
+func TestContactHandler_Upload_CSVSuccess(t *testing.T) {
+	repo := &contactHandlerFakeRepo{}
+	app := newContactHandlerTestApp(repo)
+
+	csv := "Name,Emails,PhoneNumbers\nAlice,alice@example.com,+18005550199\nBob,,+18005550100\n"
+	body, contentType := buildContactCSVUpload(t, "contacts.csv", "text/csv", csv)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/contacts/upload", body)
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	stored, _, _, _ := repo.snapshot()
+	require.Len(t, stored, 1)
+	require.Len(t, stored[0], 2)
+	assert.Equal(t, "Alice", stored[0][0].Name)
+	assert.Equal(t, "Bob", stored[0][1].Name)
+	for _, c := range stored[0] {
+		assert.Equal(t, contactHandlerTestUserID, c.UserID)
+	}
+}
+
+func TestContactHandler_Upload_NonCSVFile_ReturnsUnprocessableEntity(t *testing.T) {
+	repo := &contactHandlerFakeRepo{}
+	app := newContactHandlerTestApp(repo)
+
+	body, contentType := buildContactCSVUpload(t, "contacts.txt", "text/plain", "junk")
+	req := httptest.NewRequest(http.MethodPost, "/v1/contacts/upload", body)
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+
+	stored, _, _, _ := repo.snapshot()
+	require.Empty(t, stored)
+}
+
+func TestContactHandler_Upload_MissingDocument_ReturnsBadRequest(t *testing.T) {
+	app := newContactHandlerTestApp(&contactHandlerFakeRepo{})
+
+	// multipart body without the "document" field.
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	require.NoError(t, writer.WriteField("other", "value"))
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/contacts/upload", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestContactHandler_Update_Success(t *testing.T) {
+	contactID := uuid.New()
+	repo := &contactHandlerFakeRepo{
+		loadResult: &entities.Contact{
+			ID:           contactID,
+			UserID:       contactHandlerTestUserID,
+			Name:         "Old Name",
+			PhoneNumbers: pq.StringArray{"+18005550100"},
+		},
+	}
+	app := newContactHandlerTestApp(repo)
+
+	body := `{"name":"New Name","phone_numbers":["+18005550199"],"emails":["new@example.com"]}`
+	req := httptest.NewRequest(http.MethodPut, "/v1/contacts/"+contactID.String(), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_, updated, _, _ := repo.snapshot()
+	require.Len(t, updated, 1)
+	assert.Equal(t, "New Name", updated[0].Name)
+	assert.Equal(t, contactID, updated[0].ID)
+	assert.Equal(t, contactHandlerTestUserID, updated[0].UserID)
+	assert.Equal(t, pq.StringArray{"+18005550199"}, updated[0].PhoneNumbers)
+
+	// The repo Load call must have been user-scoped.
+	require.Len(t, repo.loadCalls, 1)
+	assert.Equal(t, contactHandlerTestUserID, repo.loadCalls[0].userID)
+	assert.Equal(t, contactID, repo.loadCalls[0].id)
+}
+
+func TestContactHandler_Update_NotFound_ReturnsNotFound(t *testing.T) {
+	contactID := uuid.New()
+	repo := &contactHandlerFakeRepo{
+		loadErr: stacktrace.PropagateWithCodef(gorm.ErrRecordNotFound, repositories.ErrCodeNotFound, "not found"),
+	}
+	app := newContactHandlerTestApp(repo)
+
+	body := `{"name":"New Name","phone_numbers":["+18005550199"]}`
+	req := httptest.NewRequest(http.MethodPut, "/v1/contacts/"+contactID.String(), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	payload := decodeContactHandlerPayload(t, resp)
+	assert.Contains(t, payload.Message, contactID.String())
+
+	_, updated, _, _ := repo.snapshot()
+	assert.Empty(t, updated)
+}
+
+func TestContactHandler_Update_InvalidID_ReturnsUnprocessableEntity(t *testing.T) {
+	app := newContactHandlerTestApp(&contactHandlerFakeRepo{})
+
+	body := `{"name":"Alice","phone_numbers":["+18005550199"]}`
+	req := httptest.NewRequest(http.MethodPut, "/v1/contacts/not-a-uuid", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+}
+
+func TestContactHandler_Update_ValidationError_ReturnsUnprocessableEntity(t *testing.T) {
+	contactID := uuid.New()
+	app := newContactHandlerTestApp(&contactHandlerFakeRepo{})
+
+	body := `{"name":"","phone_numbers":[]}`
+	req := httptest.NewRequest(http.MethodPut, "/v1/contacts/"+contactID.String(), bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+}
+
+func TestContactHandler_Delete_Success(t *testing.T) {
+	contactID := uuid.New()
+	repo := &contactHandlerFakeRepo{
+		loadResult: &entities.Contact{
+			ID:     contactID,
+			UserID: contactHandlerTestUserID,
+			Name:   "Alice",
+		},
+	}
+	app := newContactHandlerTestApp(repo)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/contacts/"+contactID.String(), nil)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	_, _, deleted, _ := repo.snapshot()
+	require.Len(t, deleted, 1)
+	assert.Equal(t, contactHandlerTestUserID, deleted[0].userID)
+	assert.Equal(t, contactID, deleted[0].id)
+}
+
+func TestContactHandler_Delete_NotFound_ReturnsNotFound(t *testing.T) {
+	contactID := uuid.New()
+	repo := &contactHandlerFakeRepo{
+		loadErr: stacktrace.PropagateWithCodef(gorm.ErrRecordNotFound, repositories.ErrCodeNotFound, "not found"),
+	}
+	app := newContactHandlerTestApp(repo)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/contacts/"+contactID.String(), nil)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	// Ensure we did not delete another user's contact silently.
+	_, _, deleted, _ := repo.snapshot()
+	assert.Empty(t, deleted)
+}
+
+func TestContactHandler_Delete_InvalidID_ReturnsUnprocessableEntity(t *testing.T) {
+	app := newContactHandlerTestApp(&contactHandlerFakeRepo{})
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/contacts/not-a-uuid", nil)
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+}
+
+func TestContactHandler_Index_ConvertsQueryAndScopesToUser(t *testing.T) {
+	repo := &contactHandlerFakeRepo{
+		indexResult: []entities.Contact{
+			{ID: uuid.New(), UserID: contactHandlerTestUserID, Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}},
+		},
+	}
+	app := newContactHandlerTestApp(repo)
+
+	values := url.Values{}
+	values.Set("skip", "5")
+	values.Set("limit", "25")
+	values.Set("query", "ali")
+	req := httptest.NewRequest(http.MethodGet, "/v1/contacts?"+values.Encode(), nil)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_, _, _, indexParams := repo.snapshot()
+	require.Len(t, indexParams, 1)
+	assert.Equal(t, 5, indexParams[0].Skip)
+	assert.Equal(t, 25, indexParams[0].Limit)
+	assert.Equal(t, "ali", indexParams[0].Query)
+
+	payload := decodeContactHandlerPayload(t, resp)
+	assert.Equal(t, "success", payload.Status)
+	assert.Contains(t, payload.Message, "1")
+}
+
+func TestContactHandler_Index_DefaultsAppliedWhenParamsMissing(t *testing.T) {
+	repo := &contactHandlerFakeRepo{}
+	app := newContactHandlerTestApp(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/contacts", nil)
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_, _, _, indexParams := repo.snapshot()
+	require.Len(t, indexParams, 1)
+	assert.Equal(t, 0, indexParams[0].Skip)
+	assert.Equal(t, 20, indexParams[0].Limit)
+	assert.Equal(t, "", indexParams[0].Query)
+}
+
+func TestContactHandler_Index_InvalidLimit_ReturnsUnprocessableEntity(t *testing.T) {
+	app := newContactHandlerTestApp(&contactHandlerFakeRepo{})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/contacts?limit=notanumber", nil)
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+}
+
+// TestContactService_WiresIntoMessageThreadService is a compile-time guard that
+// pins the DI wiring change: ContactService must satisfy the contactMapProvider
+// interface consumed by MessageThreadService, so container.MessageThreadService()
+// can be constructed with container.ContactService() instead of nil.
+func TestContactService_WiresIntoMessageThreadService(t *testing.T) {
+	logger := &messageThreadHandlerNoopLogger{}
+	tracer := telemetry.NewOtelLogger("test", logger)
+	appCache := cache.NewMemoryCache(tracer, ttlCache.New(time.Minute, time.Minute))
+	contactService := services.NewContactService(logger, tracer, &contactHandlerFakeRepo{}, appCache)
+
+	// If this compiles and runs, the ContactService satisfies the
+	// contactMapProvider interface expected by NewMessageThreadService.
+	threadService := services.NewMessageThreadService(logger, tracer, nil, nil, nil, contactService)
+	require.NotNil(t, threadService)
+}

--- a/api/pkg/handlers/contact_handler_test.go
+++ b/api/pkg/handlers/contact_handler_test.go
@@ -41,12 +41,15 @@ type contactHandlerFakeRepo struct {
 	updated     []*entities.Contact
 	deleted     []deletedContact
 	indexParams []repositories.IndexParams
+	countParams []repositories.IndexParams
 	loadCalls   []loadedContact
 
 	loadResult  *entities.Contact
 	loadErr     error
 	indexResult []entities.Contact
 	indexErr    error
+	countResult int64
+	countErr    error
 	storeErr    error
 	updateErr   error
 	deleteErr   error
@@ -109,6 +112,16 @@ func (r *contactHandlerFakeRepo) Index(_ context.Context, _ entities.UserID, par
 	return &out, nil
 }
 
+func (r *contactHandlerFakeRepo) Count(_ context.Context, _ entities.UserID, params repositories.IndexParams) (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.countParams = append(r.countParams, params)
+	if r.countErr != nil {
+		return 0, r.countErr
+	}
+	return r.countResult, nil
+}
+
 func (r *contactHandlerFakeRepo) FetchAll(context.Context, entities.UserID) (*[]entities.Contact, error) {
 	out := []entities.Contact{}
 	return &out, nil
@@ -157,6 +170,7 @@ type contactHandlerPayload struct {
 	Status  string          `json:"status"`
 	Message string          `json:"message"`
 	Data    json.RawMessage `json:"data"`
+	Total   int64           `json:"total"`
 }
 
 func decodeContactHandlerPayload(t *testing.T, resp *http.Response) contactHandlerPayload {
@@ -465,6 +479,54 @@ func TestContactHandler_Index_ConvertsQueryAndScopesToUser(t *testing.T) {
 	payload := decodeContactHandlerPayload(t, resp)
 	assert.Equal(t, "success", payload.Status)
 	assert.Contains(t, payload.Message, "1")
+}
+
+func TestContactHandler_Index_ReturnsServerTotalIndependentOfPageLength(t *testing.T) {
+	repo := &contactHandlerFakeRepo{
+		indexResult: []entities.Contact{
+			{ID: uuid.New(), UserID: contactHandlerTestUserID, Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}},
+			{ID: uuid.New(), UserID: contactHandlerTestUserID, Name: "Bob", PhoneNumbers: pq.StringArray{"+18005550100"}},
+		},
+		countResult: 57,
+	}
+	app := newContactHandlerTestApp(repo)
+
+	values := url.Values{}
+	values.Set("skip", "5")
+	values.Set("limit", "25")
+	values.Set("query", "ali")
+	req := httptest.NewRequest(http.MethodGet, "/v1/contacts?"+values.Encode(), nil)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	payload := decodeContactHandlerPayload(t, resp)
+	assert.Equal(t, "success", payload.Status)
+	// total must be the server count, not the length of the returned page.
+	assert.Equal(t, int64(57), payload.Total)
+
+	var data []entities.Contact
+	require.NoError(t, json.Unmarshal(payload.Data, &data))
+	assert.Len(t, data, 2)
+
+	// Count must run with the exact same filter/pagination params as Index.
+	require.Len(t, repo.indexParams, 1)
+	require.Len(t, repo.countParams, 1)
+	assert.Equal(t, repo.indexParams[0], repo.countParams[0])
+	assert.Equal(t, 5, repo.countParams[0].Skip)
+	assert.Equal(t, 25, repo.countParams[0].Limit)
+	assert.Equal(t, "ali", repo.countParams[0].Query)
+}
+
+func TestContactHandler_Index_CountErrorReturnsInternalServerError(t *testing.T) {
+	repo := &contactHandlerFakeRepo{countErr: assert.AnError}
+	app := newContactHandlerTestApp(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/contacts", nil)
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 }
 
 func TestContactHandler_Index_DefaultsAppliedWhenParamsMissing(t *testing.T) {

--- a/api/pkg/handlers/contact_handler_test.go
+++ b/api/pkg/handlers/contact_handler_test.go
@@ -539,6 +539,8 @@ func TestContactHandler_Index_ConvertsQueryAndScopesToUser(t *testing.T) {
 	values.Set("skip", "5")
 	values.Set("limit", "25")
 	values.Set("query", "ali")
+	values.Set("sort_by", "name")
+	values.Set("sort_descending", "true")
 	req := httptest.NewRequest(http.MethodGet, "/v1/contacts?"+values.Encode(), nil)
 
 	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
@@ -550,6 +552,8 @@ func TestContactHandler_Index_ConvertsQueryAndScopesToUser(t *testing.T) {
 	assert.Equal(t, 5, indexParams[0].Skip)
 	assert.Equal(t, 25, indexParams[0].Limit)
 	assert.Equal(t, "ali", indexParams[0].Query)
+	assert.Equal(t, "name", indexParams[0].SortBy)
+	assert.True(t, indexParams[0].SortDescending)
 
 	payload := decodeContactHandlerPayload(t, resp)
 	assert.Equal(t, "success", payload.Status)

--- a/api/pkg/handlers/contact_handler_test.go
+++ b/api/pkg/handlers/contact_handler_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NdoleStudio/httpsms/pkg/cache"
 	"github.com/NdoleStudio/httpsms/pkg/entities"
 	"github.com/NdoleStudio/httpsms/pkg/middlewares"
 	"github.com/NdoleStudio/httpsms/pkg/repositories"
@@ -22,10 +21,10 @@ import (
 	"github.com/NdoleStudio/httpsms/pkg/telemetry"
 	"github.com/NdoleStudio/httpsms/pkg/validators"
 	"github.com/NdoleStudio/stacktrace"
+	"github.com/dgraph-io/ristretto/v2"
 	"github.com/gofiber/fiber/v3"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
-	ttlCache "github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
@@ -122,7 +121,7 @@ func (r *contactHandlerFakeRepo) Count(_ context.Context, _ entities.UserID, par
 	return r.countResult, nil
 }
 
-func (r *contactHandlerFakeRepo) FetchAll(context.Context, entities.UserID) (*[]entities.Contact, error) {
+func (r *contactHandlerFakeRepo) FetchByPhoneNumbers(context.Context, entities.UserID, []string) (*[]entities.Contact, error) {
 	out := []entities.Contact{}
 	return &out, nil
 }
@@ -170,8 +169,13 @@ func newContactHandlerTestAppWithEntitlements(
 ) *fiber.App {
 	logger := &messageThreadHandlerNoopLogger{}
 	tracer := telemetry.NewOtelLogger("test", logger)
-	appCache := cache.NewMemoryCache(tracer, ttlCache.New(time.Minute, time.Minute))
-	service := services.NewContactService(logger, tracer, repo, appCache)
+	contactCache, err := ristretto.NewCache[string, services.ContactCacheEntry](&ristretto.Config[string, services.ContactCacheEntry]{
+		MaxCost: 100, NumCounters: 1_000, BufferItems: 64,
+	})
+	if err != nil {
+		panic(err)
+	}
+	service := services.NewContactService(logger, tracer, repo, contactCache)
 	entitlementService := services.NewEntitlementService(
 		logger,
 		tracer,
@@ -640,8 +644,12 @@ func TestContactHandler_Index_InvalidLimit_ReturnsUnprocessableEntity(t *testing
 func TestContactService_WiresIntoMessageThreadService(t *testing.T) {
 	logger := &messageThreadHandlerNoopLogger{}
 	tracer := telemetry.NewOtelLogger("test", logger)
-	appCache := cache.NewMemoryCache(tracer, ttlCache.New(time.Minute, time.Minute))
-	contactService := services.NewContactService(logger, tracer, &contactHandlerFakeRepo{}, appCache)
+	contactCache, err := ristretto.NewCache[string, services.ContactCacheEntry](&ristretto.Config[string, services.ContactCacheEntry]{
+		MaxCost: 100, NumCounters: 1_000, BufferItems: 64,
+	})
+	require.NoError(t, err)
+	t.Cleanup(contactCache.Close)
+	contactService := services.NewContactService(logger, tracer, &contactHandlerFakeRepo{}, contactCache)
 
 	// If this compiles and runs, the ContactService satisfies the
 	// contactMapProvider interface expected by NewMessageThreadService.

--- a/api/pkg/handlers/contact_handler_test.go
+++ b/api/pkg/handlers/contact_handler_test.go
@@ -150,12 +150,35 @@ func (r *contactHandlerFakeRepo) snapshot() ([][]*entities.Contact, []*entities.
 
 const contactHandlerTestUserID = entities.UserID("user-id")
 
+type contactHandlerEntitlementUserRepo struct {
+	repositories.UserRepository
+	subscriptionName entities.SubscriptionName
+}
+
+func (repository *contactHandlerEntitlementUserRepo) Load(_ context.Context, userID entities.UserID) (*entities.User, error) {
+	return &entities.User{ID: userID, SubscriptionName: repository.subscriptionName}, nil
+}
+
 func newContactHandlerTestApp(repo repositories.ContactRepository) *fiber.App {
+	return newContactHandlerTestAppWithEntitlements(repo, false, entities.SubscriptionNameFree)
+}
+
+func newContactHandlerTestAppWithEntitlements(
+	repo repositories.ContactRepository,
+	entitlementsEnabled bool,
+	subscriptionName entities.SubscriptionName,
+) *fiber.App {
 	logger := &messageThreadHandlerNoopLogger{}
 	tracer := telemetry.NewOtelLogger("test", logger)
 	appCache := cache.NewMemoryCache(tracer, ttlCache.New(time.Minute, time.Minute))
 	service := services.NewContactService(logger, tracer, repo, appCache)
-	handler := NewContactHandler(logger, tracer, validators.NewContactHandlerValidator(logger, tracer), service)
+	entitlementService := services.NewEntitlementService(
+		logger,
+		tracer,
+		entitlementsEnabled,
+		&contactHandlerEntitlementUserRepo{subscriptionName: subscriptionName},
+	)
+	handler := NewContactHandler(logger, tracer, validators.NewContactHandlerValidator(logger, tracer), service, entitlementService)
 
 	app := fiber.New()
 	app.Use(func(c fiber.Ctx) error {
@@ -220,6 +243,41 @@ func TestContactHandler_Store_CreatesManyContactsFromObjectShape(t *testing.T) {
 	require.Len(t, stored[0], 2)
 	assert.Equal(t, "Alice", stored[0][0].Name)
 	assert.Equal(t, "Bob", stored[0][1].Name)
+}
+
+func TestContactHandler_Store_RejectsBatchExceedingContactLimit(t *testing.T) {
+	repo := &contactHandlerFakeRepo{countResult: 199}
+	app := newContactHandlerTestAppWithEntitlements(repo, true, entities.SubscriptionNameFree)
+
+	body := `{"contacts":[
+		{"name":"Alice","phone_numbers":["+18005550199"]},
+		{"name":"Bob","phone_numbers":["+18005550100"]}
+	]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/contacts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusPaymentRequired, resp.StatusCode)
+
+	stored, _, _, _ := repo.snapshot()
+	assert.Empty(t, stored)
+}
+
+func TestContactHandler_Store_DisabledEntitlementsDoNotLimitContacts(t *testing.T) {
+	repo := &contactHandlerFakeRepo{countResult: 200}
+	app := newContactHandlerTestAppWithEntitlements(repo, false, entities.SubscriptionNameFree)
+
+	body := `[{"name":"Alice","phone_numbers":["+18005550199"]}]`
+	req := httptest.NewRequest(http.MethodPost, "/v1/contacts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	stored, _, _, _ := repo.snapshot()
+	require.Len(t, stored, 1)
 }
 
 func TestContactHandler_Store_ValidationError_ReturnsUnprocessableEntity(t *testing.T) {
@@ -287,6 +345,23 @@ func TestContactHandler_Upload_CSVSuccess(t *testing.T) {
 	for _, c := range stored[0] {
 		assert.Equal(t, contactHandlerTestUserID, c.UserID)
 	}
+}
+
+func TestContactHandler_Upload_RejectsBatchExceedingContactLimit(t *testing.T) {
+	repo := &contactHandlerFakeRepo{countResult: 199}
+	app := newContactHandlerTestAppWithEntitlements(repo, true, entities.SubscriptionNameFree)
+
+	csv := "Name,Emails,PhoneNumbers\nAlice,alice@example.com,+18005550199\nBob,,+18005550100\n"
+	body, contentType := buildContactCSVUpload(t, "contacts.csv", "text/csv", csv)
+	req := httptest.NewRequest(http.MethodPost, "/v1/contacts/upload", body)
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusPaymentRequired, resp.StatusCode)
+
+	stored, _, _, _ := repo.snapshot()
+	assert.Empty(t, stored)
 }
 
 func TestContactHandler_Upload_NonCSVFile_ReturnsUnprocessableEntity(t *testing.T) {

--- a/api/pkg/handlers/handler.go
+++ b/api/pkg/handlers/handler.go
@@ -97,6 +97,15 @@ func (h *handler) responseOK(c fiber.Ctx, message string, data interface{}) erro
 	})
 }
 
+func (h *handler) responseOKWithTotal(c fiber.Ctx, message string, data interface{}, total int64) error {
+	return c.Status(fiber.StatusOK).JSON(fiber.Map{
+		"status":  "success",
+		"message": message,
+		"data":    data,
+		"total":   total,
+	})
+}
+
 func (h *handler) responseCreated(c fiber.Ctx, message string, data interface{}) error {
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{
 		"status":  "success",

--- a/api/pkg/handlers/message_thread_handler.go
+++ b/api/pkg/handlers/message_thread_handler.go
@@ -57,6 +57,7 @@ func (h *MessageThreadHandler) RegisterRoutes(router fiber.Router, middlewares .
 // @Param        skip	query  int  	false	"number of messages to skip"				minimum(0)
 // @Param        query	query  string  	false 	"filter message threads containing query"
 // @Param        limit	query  int  	false	"number of messages to return"				minimum(1)	maximum(20)
+// @Param        contacts	query  bool  	false	"include matching contact details"
 // @Success      200 	{object}	responses.MessageThreadsResponse
 // @Failure      400	{object}	responses.BadRequest
 // @Failure 	 401    {object}	responses.Unauthorized

--- a/api/pkg/handlers/message_thread_handler_contacts_test.go
+++ b/api/pkg/handlers/message_thread_handler_contacts_test.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/middlewares"
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/services"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/httpsms/pkg/validators"
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type messageThreadHandlerIndexRepositoryStub struct {
+	repositories.MessageThreadRepository
+	threads []entities.MessageThread
+}
+
+func (stub *messageThreadHandlerIndexRepositoryStub) Index(context.Context, entities.UserID, string, bool, repositories.IndexParams) (*[]entities.MessageThread, error) {
+	threads := make([]entities.MessageThread, len(stub.threads))
+	copy(threads, stub.threads)
+	return &threads, nil
+}
+
+type messageThreadHandlerContactProviderStub struct {
+	contacts map[string]*entities.Contact
+	calls    int
+}
+
+func (stub *messageThreadHandlerContactProviderStub) GetContactMap(context.Context, entities.UserID) (map[string]*entities.Contact, error) {
+	stub.calls++
+	return stub.contacts, nil
+}
+
+func TestMessageThreadHandlerIndex_ParsesContactsQuery(t *testing.T) {
+	contact := &entities.Contact{ID: uuid.New(), Name: "Alice", PhoneNumbers: []string{"+18005550100"}}
+	repository := &messageThreadHandlerIndexRepositoryStub{threads: []entities.MessageThread{{Contact: "+18005550100"}}}
+	provider := &messageThreadHandlerContactProviderStub{contacts: map[string]*entities.Contact{"+18005550100": contact}}
+	logger := &messageThreadHandlerNoopLogger{}
+	tracer := telemetry.NewOtelLogger("test", logger)
+	service := services.NewMessageThreadService(logger, tracer, repository, nil, nil, provider)
+	handler := NewMessageThreadHandler(logger, tracer, validators.NewMessageThreadHandlerValidator(logger, tracer), service)
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Locals(middlewares.ContextKeyAuthUserID, entities.AuthContext{ID: entities.UserID("user-id"), Email: "user@example.com"})
+		return c.Next()
+	})
+	handler.RegisterRoutes(app)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/message-threads?owner=%2B18005550199&contacts=true", nil)
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, provider.calls)
+
+	var payload struct {
+		Data []entities.MessageThread `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	require.Len(t, payload.Data, 1)
+	require.NotNil(t, payload.Data[0].ContactDetails)
+	assert.Equal(t, contact.ID, payload.Data[0].ContactDetails.ID)
+	assert.Equal(t, "Alice", payload.Data[0].ContactDetails.Name)
+}

--- a/api/pkg/handlers/message_thread_handler_contacts_test.go
+++ b/api/pkg/handlers/message_thread_handler_contacts_test.go
@@ -36,7 +36,7 @@ type messageThreadHandlerContactProviderStub struct {
 	calls    int
 }
 
-func (stub *messageThreadHandlerContactProviderStub) GetContactMap(context.Context, entities.UserID) (map[string]*entities.Contact, error) {
+func (stub *messageThreadHandlerContactProviderStub) GetContactMap(context.Context, entities.UserID, []string) (map[string]*entities.Contact, error) {
 	stub.calls++
 	return stub.contacts, nil
 }

--- a/api/pkg/handlers/message_thread_handler_test.go
+++ b/api/pkg/handlers/message_thread_handler_test.go
@@ -64,7 +64,7 @@ func (stub *messageThreadHandlerRepositoryStub) DeleteAllForUser(context.Context
 func TestMessageThreadHandlerUpdate_ReturnsNotFoundWhenThreadIsMissing(t *testing.T) {
 	logger := &messageThreadHandlerNoopLogger{}
 	tracer := telemetry.NewOtelLogger("test", logger)
-	service := services.NewMessageThreadService(logger, tracer, &messageThreadHandlerRepositoryStub{}, nil, nil)
+	service := services.NewMessageThreadService(logger, tracer, &messageThreadHandlerRepositoryStub{}, nil, nil, nil)
 	handler := NewMessageThreadHandler(logger, tracer, validators.NewMessageThreadHandlerValidator(logger, tracer), service)
 
 	app := fiber.New()

--- a/api/pkg/listeners/contact_listener.go
+++ b/api/pkg/listeners/contact_listener.go
@@ -1,0 +1,57 @@
+package listeners
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/events"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/stacktrace"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+// ContactDeletionService removes contacts belonging to a deleted user.
+type ContactDeletionService interface {
+	DeleteAllForUser(ctx context.Context, userID entities.UserID) error
+}
+
+// ContactListener handles contact-related cloud events.
+type ContactListener struct {
+	logger  telemetry.Logger
+	tracer  telemetry.Tracer
+	service ContactDeletionService
+}
+
+// NewContactListener creates a new ContactListener.
+func NewContactListener(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+	service ContactDeletionService,
+) (l *ContactListener, routes map[string]events.EventListener) {
+	l = &ContactListener{
+		logger:  logger.WithService(fmt.Sprintf("%T", l)),
+		tracer:  tracer,
+		service: service,
+	}
+
+	return l, map[string]events.EventListener{
+		events.UserAccountDeleted: l.onUserAccountDeleted,
+	}
+}
+
+func (listener *ContactListener) onUserAccountDeleted(ctx context.Context, event cloudevents.Event) error {
+	ctx, span := listener.tracer.Start(ctx)
+	defer span.End()
+
+	var payload events.UserAccountDeletedPayload
+	if err := event.DataAs(&payload); err != nil {
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot decode [%s] into [%T]", event.Data(), payload))
+	}
+
+	if err := listener.service.DeleteAllForUser(ctx, payload.UserID); err != nil {
+		return listener.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot delete [entities.Contact] for user [%s] on [%s] event with ID [%s]", payload.UserID, event.Type(), event.ID()))
+	}
+
+	return nil
+}

--- a/api/pkg/listeners/contact_listener_test.go
+++ b/api/pkg/listeners/contact_listener_test.go
@@ -1,0 +1,70 @@
+package listeners
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/events"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type contactDeletionServiceStub struct {
+	userIDs []entities.UserID
+	err     error
+}
+
+func (service *contactDeletionServiceStub) DeleteAllForUser(_ context.Context, userID entities.UserID) error {
+	service.userIDs = append(service.userIDs, userID)
+	return service.err
+}
+
+func TestContactListenerDeletesContactsForDeletedUser(t *testing.T) {
+	service := &contactDeletionServiceStub{}
+	routes := newContactListenerRoutes(t, service)
+	event := deletedUserContactEvent(t, entities.UserID("user-id"))
+
+	err := routes[events.UserAccountDeleted](context.Background(), event)
+
+	require.NoError(t, err)
+	assert.Equal(t, []entities.UserID{"user-id"}, service.userIDs)
+}
+
+func TestContactListenerWrapsDeleteError(t *testing.T) {
+	service := &contactDeletionServiceStub{err: errors.New("delete contacts boom")}
+	routes := newContactListenerRoutes(t, service)
+	event := deletedUserContactEvent(t, entities.UserID("user-id"))
+
+	err := routes[events.UserAccountDeleted](context.Background(), event)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete contacts boom")
+}
+
+func newContactListenerRoutes(t *testing.T, service *contactDeletionServiceStub) map[string]events.EventListener {
+	t.Helper()
+
+	logger := &noopListenerLogger{}
+	tracer := telemetry.NewOtelLogger("test", logger)
+	_, routes := NewContactListener(logger, tracer, service)
+	require.Contains(t, routes, events.UserAccountDeleted)
+	return routes
+}
+
+func deletedUserContactEvent(t *testing.T, userID entities.UserID) cloudevents.Event {
+	t.Helper()
+
+	event := cloudevents.NewEvent()
+	event.SetID(uuid.NewString())
+	event.SetSource("/v1/users")
+	event.SetType(events.UserAccountDeleted)
+	require.NoError(t, event.SetData(cloudevents.ApplicationJSON, events.UserAccountDeletedPayload{
+		UserID: userID,
+	}))
+	return event
+}

--- a/api/pkg/listeners/message_thread_listener_test.go
+++ b/api/pkg/listeners/message_thread_listener_test.go
@@ -66,7 +66,7 @@ func newMessageThreadListenerForTest() (*listenerMessageThreadRepository, map[st
 	repository := &listenerMessageThreadRepository{}
 	logger := &noopListenerLogger{}
 	tracer := telemetry.NewOtelLogger("test", logger)
-	service := services.NewMessageThreadService(logger, tracer, repository, nil, nil)
+	service := services.NewMessageThreadService(logger, tracer, repository, nil, nil, nil)
 	_, routes := NewMessageThreadListener(logger, tracer, service)
 	return repository, routes
 }

--- a/api/pkg/repositories/contact_repository.go
+++ b/api/pkg/repositories/contact_repository.go
@@ -21,6 +21,10 @@ type ContactRepository interface {
 	// Index contacts for a user with optional search.
 	Index(ctx context.Context, userID entities.UserID, params IndexParams) (*[]entities.Contact, error)
 
+	// Count returns the number of contacts for a user matching the same
+	// name/emails/phone_numbers filter as Index, ignoring pagination.
+	Count(ctx context.Context, userID entities.UserID, params IndexParams) (int64, error)
+
 	// FetchAll returns every contact for a user ordered by updated_at ascending.
 	FetchAll(ctx context.Context, userID entities.UserID) (*[]entities.Contact, error)
 

--- a/api/pkg/repositories/contact_repository.go
+++ b/api/pkg/repositories/contact_repository.go
@@ -1,0 +1,32 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/google/uuid"
+)
+
+// ContactRepository loads and persists an entities.Contact.
+type ContactRepository interface {
+	// Store one or many new entities.Contact.
+	Store(ctx context.Context, contacts []*entities.Contact) error
+
+	// Update an existing entities.Contact.
+	Update(ctx context.Context, contact *entities.Contact) error
+
+	// Load a contact by ID for a user.
+	Load(ctx context.Context, userID entities.UserID, contactID uuid.UUID) (*entities.Contact, error)
+
+	// Index contacts for a user with optional search.
+	Index(ctx context.Context, userID entities.UserID, params IndexParams) (*[]entities.Contact, error)
+
+	// FetchAll returns every contact for a user ordered by updated_at ascending.
+	FetchAll(ctx context.Context, userID entities.UserID) (*[]entities.Contact, error)
+
+	// Delete a contact by ID for a user.
+	Delete(ctx context.Context, userID entities.UserID, contactID uuid.UUID) error
+
+	// DeleteAllForUser deletes all contacts for a user.
+	DeleteAllForUser(ctx context.Context, userID entities.UserID) error
+}

--- a/api/pkg/repositories/contact_repository.go
+++ b/api/pkg/repositories/contact_repository.go
@@ -25,8 +25,9 @@ type ContactRepository interface {
 	// name/emails/phone_numbers filter as Index, ignoring pagination.
 	Count(ctx context.Context, userID entities.UserID, params IndexParams) (int64, error)
 
-	// FetchAll returns every contact for a user ordered by updated_at ascending.
-	FetchAll(ctx context.Context, userID entities.UserID) (*[]entities.Contact, error)
+	// FetchByPhoneNumbers returns contacts containing at least one requested
+	// phone number, ordered by updated_at ascending.
+	FetchByPhoneNumbers(ctx context.Context, userID entities.UserID, phoneNumbers []string) (*[]entities.Contact, error)
 
 	// Delete a contact by ID for a user.
 	Delete(ctx context.Context, userID entities.UserID, contactID uuid.UUID) error

--- a/api/pkg/repositories/gorm_contact_repository.go
+++ b/api/pkg/repositories/gorm_contact_repository.go
@@ -78,26 +78,49 @@ func (repository *gormContactRepository) Load(ctx context.Context, userID entiti
 	return contact, nil
 }
 
-func (repository *gormContactRepository) Index(ctx context.Context, userID entities.UserID, params IndexParams) (*[]entities.Contact, error) {
-	ctx, span := repository.tracer.Start(ctx)
-	defer span.End()
-
-	query := repository.db.WithContext(ctx).Where("user_id = ?", userID)
-	if len(params.Query) > 0 {
-		queryPattern := "%" + params.Query + "%"
-		query = query.Where(
+// scopedContactQuery builds the shared query that scopes contacts to a user and
+// applies the optional name/emails/phone_numbers search filter. Index and Count
+// both build on it so their filters can never drift apart. It sets the model so
+// callers can chain Find or Count without repeating the table.
+func (repository *gormContactRepository) scopedContactQuery(ctx context.Context, userID entities.UserID, query string) *gorm.DB {
+	scoped := repository.db.WithContext(ctx).Model(&entities.Contact{}).Where("user_id = ?", userID)
+	if len(query) > 0 {
+		queryPattern := "%" + query + "%"
+		scoped = scoped.Where(
 			repository.db.WithContext(ctx).Where("name ILIKE ?", queryPattern).
 				Or("array_to_string(emails, ',') ILIKE ?", queryPattern).
 				Or("array_to_string(phone_numbers, ',') ILIKE ?", queryPattern),
 		)
 	}
+	return scoped
+}
+
+func (repository *gormContactRepository) Index(ctx context.Context, userID entities.UserID, params IndexParams) (*[]entities.Contact, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
 
 	contacts := new([]entities.Contact)
-	if err := query.Order("updated_at DESC").Limit(params.Limit).Offset(params.Skip).Find(contacts).Error; err != nil {
+	if err := repository.scopedContactQuery(ctx, userID, params.Query).
+		Order("updated_at DESC").
+		Limit(params.Limit).
+		Offset(params.Skip).
+		Find(contacts).Error; err != nil {
 		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot index contacts for user [%s] with params [%+#v]", userID, params))
 	}
 
 	return contacts, nil
+}
+
+func (repository *gormContactRepository) Count(ctx context.Context, userID entities.UserID, params IndexParams) (int64, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	var count int64
+	if err := repository.scopedContactQuery(ctx, userID, params.Query).Count(&count).Error; err != nil {
+		return 0, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot count contacts for user [%s] with query [%s]", userID, params.Query))
+	}
+
+	return count, nil
 }
 
 func (repository *gormContactRepository) FetchAll(ctx context.Context, userID entities.UserID) (*[]entities.Contact, error) {

--- a/api/pkg/repositories/gorm_contact_repository.go
+++ b/api/pkg/repositories/gorm_contact_repository.go
@@ -1,0 +1,142 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// gormContactRepository is responsible for persisting entities.Contact.
+type gormContactRepository struct {
+	logger telemetry.Logger
+	tracer telemetry.Tracer
+	db     *gorm.DB
+}
+
+// NewGormContactRepository creates the GORM version of the ContactRepository.
+func NewGormContactRepository(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+	db *gorm.DB,
+) ContactRepository {
+	return &gormContactRepository{
+		logger: logger.WithService(fmt.Sprintf("%T", &gormContactRepository{})),
+		tracer: tracer,
+		db:     db,
+	}
+}
+
+func (repository *gormContactRepository) Store(ctx context.Context, contacts []*entities.Contact) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	if len(contacts) == 0 {
+		return nil
+	}
+
+	if err := repository.db.WithContext(ctx).Create(&contacts).Error; err != nil {
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot store [%d] contacts", len(contacts)))
+	}
+
+	return nil
+}
+
+func (repository *gormContactRepository) Update(ctx context.Context, contact *entities.Contact) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	if err := repository.db.WithContext(ctx).Save(contact).Error; err != nil {
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot update contact with ID [%s]", contact.ID))
+	}
+
+	return nil
+}
+
+func (repository *gormContactRepository) Load(ctx context.Context, userID entities.UserID, contactID uuid.UUID) (*entities.Contact, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	contact := new(entities.Contact)
+	err := repository.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Where("id = ?", contactID).
+		First(contact).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCodef(err, ErrCodeNotFound, "contact with ID [%s] for user [%s] does not exist", contactID, userID))
+	}
+
+	if err != nil {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot load contact with ID [%s] for user [%s]", contactID, userID))
+	}
+
+	return contact, nil
+}
+
+func (repository *gormContactRepository) Index(ctx context.Context, userID entities.UserID, params IndexParams) (*[]entities.Contact, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	query := repository.db.WithContext(ctx).Where("user_id = ?", userID)
+	if len(params.Query) > 0 {
+		queryPattern := "%" + params.Query + "%"
+		query = query.Where(
+			repository.db.WithContext(ctx).Where("name ILIKE ?", queryPattern).
+				Or("array_to_string(emails, ',') ILIKE ?", queryPattern).
+				Or("array_to_string(phone_numbers, ',') ILIKE ?", queryPattern),
+		)
+	}
+
+	contacts := new([]entities.Contact)
+	if err := query.Order("updated_at DESC").Limit(params.Limit).Offset(params.Skip).Find(contacts).Error; err != nil {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot index contacts for user [%s] with params [%+#v]", userID, params))
+	}
+
+	return contacts, nil
+}
+
+func (repository *gormContactRepository) FetchAll(ctx context.Context, userID entities.UserID) (*[]entities.Contact, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	contacts := new([]entities.Contact)
+	if err := repository.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("updated_at ASC").
+		Find(contacts).Error; err != nil {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot fetch all contacts for user [%s]", userID))
+	}
+
+	return contacts, nil
+}
+
+func (repository *gormContactRepository) Delete(ctx context.Context, userID entities.UserID, contactID uuid.UUID) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	err := repository.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Where("id = ?", contactID).
+		Delete(&entities.Contact{}).Error
+	if err != nil {
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot delete contact with ID [%s] for user [%s]", contactID, userID))
+	}
+
+	return nil
+}
+
+func (repository *gormContactRepository) DeleteAllForUser(ctx context.Context, userID entities.UserID) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	if err := repository.db.WithContext(ctx).Where("user_id = ?", userID).Delete(&entities.Contact{}).Error; err != nil {
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot delete all contacts for user [%s]", userID))
+	}
+
+	return nil
+}

--- a/api/pkg/repositories/gorm_contact_repository.go
+++ b/api/pkg/repositories/gorm_contact_repository.go
@@ -10,6 +10,7 @@ import (
 	"github.com/NdoleStudio/httpsms/pkg/telemetry"
 	"github.com/NdoleStudio/stacktrace"
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"gorm.io/gorm"
 )
 
@@ -143,16 +144,17 @@ func (repository *gormContactRepository) Count(ctx context.Context, userID entit
 	return count, nil
 }
 
-func (repository *gormContactRepository) FetchAll(ctx context.Context, userID entities.UserID) (*[]entities.Contact, error) {
+func (repository *gormContactRepository) FetchByPhoneNumbers(ctx context.Context, userID entities.UserID, phoneNumbers []string) (*[]entities.Contact, error) {
 	ctx, span := repository.tracer.Start(ctx)
 	defer span.End()
 
 	contacts := new([]entities.Contact)
 	if err := repository.db.WithContext(ctx).
 		Where("user_id = ?", userID).
+		Where("phone_numbers && ?", pq.Array(phoneNumbers)).
 		Order("updated_at ASC").
 		Find(contacts).Error; err != nil {
-		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot fetch all contacts for user [%s]", userID))
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot fetch contacts for user [%s] by phone numbers [%v]", userID, phoneNumbers))
 	}
 
 	return contacts, nil

--- a/api/pkg/repositories/gorm_contact_repository.go
+++ b/api/pkg/repositories/gorm_contact_repository.go
@@ -85,7 +85,8 @@ func (repository *gormContactRepository) Load(ctx context.Context, userID entiti
 func (repository *gormContactRepository) scopedContactQuery(ctx context.Context, userID entities.UserID, query string) *gorm.DB {
 	scoped := repository.db.WithContext(ctx).Model(&entities.Contact{}).Where("user_id = ?", userID)
 	if len(query) > 0 {
-		queryPattern := "%" + query + "%"
+		escaped := strings.NewReplacer(`%`, `\%`, `_`, `\_`).Replace(query)
+		queryPattern := "%" + escaped + "%"
 		scoped = scoped.Where(
 			repository.db.WithContext(ctx).Where("name ILIKE ?", queryPattern).
 				Or("array_to_string(emails, ',') ILIKE ?", queryPattern).

--- a/api/pkg/repositories/gorm_contact_repository.go
+++ b/api/pkg/repositories/gorm_contact_repository.go
@@ -116,7 +116,7 @@ func (repository *gormContactRepository) Index(ctx context.Context, userID entit
 
 func (repository *gormContactRepository) contactOrder(params IndexParams) string {
 	if params.SortBy == "" {
-		return "updated_at DESC"
+		return "updated_at DESC, id DESC"
 	}
 
 	sortBy := "updated_at"
@@ -129,7 +129,7 @@ func (repository *gormContactRepository) contactOrder(params IndexParams) string
 		direction = "DESC"
 	}
 
-	return fmt.Sprintf("%s %s", sortBy, direction)
+	return fmt.Sprintf("%s %s, id %s", sortBy, direction, direction)
 }
 
 func (repository *gormContactRepository) Count(ctx context.Context, userID entities.UserID, params IndexParams) (int64, error) {
@@ -152,7 +152,7 @@ func (repository *gormContactRepository) FetchByPhoneNumbers(ctx context.Context
 	if err := repository.db.WithContext(ctx).
 		Where("user_id = ?", userID).
 		Where("phone_numbers && ?", pq.Array(phoneNumbers)).
-		Order("updated_at ASC").
+		Order("updated_at ASC, id ASC").
 		Find(contacts).Error; err != nil {
 		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot fetch contacts for user [%s] by phone numbers [%v]", userID, phoneNumbers))
 	}

--- a/api/pkg/repositories/gorm_contact_repository.go
+++ b/api/pkg/repositories/gorm_contact_repository.go
@@ -101,7 +101,7 @@ func (repository *gormContactRepository) Index(ctx context.Context, userID entit
 
 	contacts := new([]entities.Contact)
 	if err := repository.scopedContactQuery(ctx, userID, params.Query).
-		Order("updated_at DESC").
+		Order(repository.contactOrder(params)).
 		Limit(params.Limit).
 		Offset(params.Skip).
 		Find(contacts).Error; err != nil {
@@ -109,6 +109,24 @@ func (repository *gormContactRepository) Index(ctx context.Context, userID entit
 	}
 
 	return contacts, nil
+}
+
+func (repository *gormContactRepository) contactOrder(params IndexParams) string {
+	if params.SortBy == "" {
+		return "updated_at DESC"
+	}
+
+	sortBy := "updated_at"
+	if params.SortBy == "name" {
+		sortBy = "name"
+	}
+
+	direction := "ASC"
+	if params.SortDescending {
+		direction = "DESC"
+	}
+
+	return fmt.Sprintf("%s %s", sortBy, direction)
 }
 
 func (repository *gormContactRepository) Count(ctx context.Context, userID entities.UserID, params IndexParams) (int64, error) {

--- a/api/pkg/repositories/gorm_contact_repository.go
+++ b/api/pkg/repositories/gorm_contact_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/NdoleStudio/httpsms/pkg/entities"
 	"github.com/NdoleStudio/httpsms/pkg/telemetry"

--- a/api/pkg/repositories/gorm_contact_repository_test.go
+++ b/api/pkg/repositories/gorm_contact_repository_test.go
@@ -1,0 +1,280 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"io"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func normalizeContactSQL(query string) string {
+	return strings.Join(strings.Fields(query), " ")
+}
+
+type contactTestConnPool struct {
+	messageThreadTestConnPool
+}
+
+func (pool *contactTestConnPool) QueryContext(_ context.Context, query string, args ...any) (*sql.Rows, error) {
+	pool.statements = append(pool.statements, messageThreadTestStatement{
+		query: query,
+		args:  append([]any(nil), args...),
+	})
+
+	db := sql.OpenDB(contactTestRowsConnector{})
+	return db.QueryContext(context.Background(), "SELECT 1")
+}
+
+func (pool *contactTestConnPool) BeginTx(context.Context, *sql.TxOptions) (gorm.ConnPool, error) {
+	return pool, nil
+}
+
+type contactTestRowsConnector struct{}
+
+func (contactTestRowsConnector) Connect(context.Context) (driver.Conn, error) {
+	return contactTestRowsConn{}, nil
+}
+
+func (contactTestRowsConnector) Driver() driver.Driver {
+	return contactTestRowsDriver{}
+}
+
+type contactTestRowsDriver struct{}
+
+func (contactTestRowsDriver) Open(string) (driver.Conn, error) {
+	return contactTestRowsConn{}, nil
+}
+
+type contactTestRowsConn struct{}
+
+func (contactTestRowsConn) Prepare(string) (driver.Stmt, error) {
+	return nil, assert.AnError
+}
+
+func (contactTestRowsConn) Close() error {
+	return nil
+}
+
+func (contactTestRowsConn) Begin() (driver.Tx, error) {
+	return nil, assert.AnError
+}
+
+func (contactTestRowsConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return contactTestRows{}, nil
+}
+
+type contactTestRows struct{}
+
+func (contactTestRows) Columns() []string {
+	return []string{"id", "user_id", "name", "emails", "phone_numbers", "properties", "created_at", "updated_at"}
+}
+
+func (contactTestRows) Close() error {
+	return nil
+}
+
+func (contactTestRows) Next([]driver.Value) error {
+	return io.EOF
+}
+
+func lastContactStatement(t *testing.T, pool *contactTestConnPool) messageThreadTestStatement {
+	t.Helper()
+	require.NotEmpty(t, pool.statements)
+
+	statement := pool.statements[len(pool.statements)-1]
+	statement.query = normalizeContactSQL(statement.query)
+	return statement
+}
+
+func newContactTestRepo(t *testing.T) (ContactRepository, *contactTestConnPool) {
+	t.Helper()
+
+	pool := &contactTestConnPool{}
+	db, err := gorm.Open(
+		postgres.New(postgres.Config{
+			Conn:             pool,
+			WithoutReturning: true,
+		}),
+		&gorm.Config{
+			DisableAutomaticPing: true,
+			NowFunc: func() time.Time {
+				return time.Date(2026, 7, 19, 18, 0, 0, 0, time.UTC)
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	logger := &messageThreadTestLogger{}
+	return NewGormContactRepository(logger, telemetry.NewOtelLogger("test", logger), db), pool
+}
+
+func TestGormContactRepository_Store_BatchInsertsContacts(t *testing.T) {
+	repository, recorder := newContactTestRepo(t)
+	firstID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	secondID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	err := repository.Store(context.Background(), []*entities.Contact{
+		{
+			ID:           firstID,
+			UserID:       entities.UserID("user-1"),
+			Name:         "Alice",
+			Emails:       pq.StringArray{"alice@example.com"},
+			PhoneNumbers: pq.StringArray{"+18005550199"},
+			Properties:   entities.ContactProperties{"source": "phone"},
+		},
+		{
+			ID:           secondID,
+			UserID:       entities.UserID("user-1"),
+			Name:         "Bob",
+			Emails:       pq.StringArray{"bob@example.com"},
+			PhoneNumbers: pq.StringArray{"+18005550200"},
+			Properties:   entities.ContactProperties{"source": "import"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, recorder.statements, 1)
+	statement := lastContactStatement(t, recorder)
+	assert.True(t, strings.HasPrefix(statement.query, `INSERT INTO "contacts"`))
+	assert.Contains(t, statement.query, `("id","user_id","name","emails","phone_numbers","properties","created_at","updated_at")`)
+	assert.Regexp(t, regexp.MustCompile(`VALUES \(\$1,\$2,\$3,\$4,\$5,\$6,\$7,\$8\),\(\$9,\$10,\$11,\$12,\$13,\$14,\$15,\$16\)`), statement.query)
+	require.Len(t, statement.args, 16)
+	assert.Equal(t, firstID, statement.args[0])
+	assert.Equal(t, entities.UserID("user-1"), statement.args[1])
+	assert.Equal(t, "Alice", statement.args[2])
+	assert.Equal(t, pq.StringArray{"alice@example.com"}, statement.args[3])
+	assert.Equal(t, pq.StringArray{"+18005550199"}, statement.args[4])
+	assert.Equal(t, entities.ContactProperties{"source": "phone"}, statement.args[5])
+	assert.Equal(t, secondID, statement.args[8])
+	assert.Equal(t, entities.UserID("user-1"), statement.args[9])
+	assert.Equal(t, "Bob", statement.args[10])
+	assert.Equal(t, pq.StringArray{"bob@example.com"}, statement.args[11])
+	assert.Equal(t, pq.StringArray{"+18005550200"}, statement.args[12])
+	assert.Equal(t, entities.ContactProperties{"source": "import"}, statement.args[13])
+}
+
+func TestGormContactRepository_Update_SavesContact(t *testing.T) {
+	repository, recorder := newContactTestRepo(t)
+	contactID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+
+	err := repository.Update(context.Background(), &entities.Contact{
+		ID:           contactID,
+		UserID:       entities.UserID("user-1"),
+		Name:         "Updated Alice",
+		Emails:       pq.StringArray{"updated@example.com"},
+		PhoneNumbers: pq.StringArray{"+18005550199"},
+		Properties:   entities.ContactProperties{"group": "friends"},
+	})
+
+	require.NoError(t, err)
+	statement := lastContactStatement(t, recorder)
+	assert.True(t, strings.HasPrefix(statement.query, `UPDATE "contacts"`))
+	assert.Contains(t, statement.query, `"user_id"=$1`)
+	assert.Contains(t, statement.query, `"name"=$2`)
+	assert.Contains(t, statement.query, `"emails"=$3`)
+	assert.Contains(t, statement.query, `"phone_numbers"=$4`)
+	assert.Contains(t, statement.query, `"properties"=$5`)
+	assert.Contains(t, statement.query, `"created_at"=$6`)
+	assert.Contains(t, statement.query, `"updated_at"=$7`)
+	assert.Contains(t, statement.query, `WHERE "id" = $8`)
+	require.Len(t, statement.args, 8)
+	assert.Equal(t, entities.UserID("user-1"), statement.args[0])
+	assert.Equal(t, "Updated Alice", statement.args[1])
+	assert.Equal(t, pq.StringArray{"updated@example.com"}, statement.args[2])
+	assert.Equal(t, pq.StringArray{"+18005550199"}, statement.args[3])
+	assert.Equal(t, entities.ContactProperties{"group": "friends"}, statement.args[4])
+	assert.Equal(t, contactID, statement.args[7])
+}
+
+func TestGormContactRepository_Load_ScopesByUserAndContactID(t *testing.T) {
+	repository, recorder := newContactTestRepo(t)
+	contactID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+
+	_, err := repository.Load(context.Background(), entities.UserID("user-1"), contactID)
+
+	require.Error(t, err)
+	assert.Equal(t, ErrCodeNotFound, stacktrace.GetCode(err))
+	statement := lastContactStatement(t, recorder)
+	assert.True(t, strings.HasPrefix(statement.query, `SELECT * FROM "contacts"`))
+	assert.Contains(t, statement.query, `WHERE user_id = $1 AND id = $2`)
+	assert.Contains(t, statement.query, `ORDER BY "contacts"."id" LIMIT $3`)
+	require.Len(t, statement.args, 3)
+	assert.Equal(t, entities.UserID("user-1"), statement.args[0])
+	assert.Equal(t, contactID, statement.args[1])
+	assert.Equal(t, 1, statement.args[2])
+}
+
+func TestGormContactRepository_Index_FiltersByUserAndQueryAcrossContactFields(t *testing.T) {
+	repository, recorder := newContactTestRepo(t)
+
+	_, err := repository.Index(context.Background(), entities.UserID("user-1"), IndexParams{
+		Query: "alice",
+		Limit: 20,
+		Skip:  40,
+	})
+
+	require.NoError(t, err)
+	statement := lastContactStatement(t, recorder)
+	assert.True(t, strings.HasPrefix(statement.query, `SELECT * FROM "contacts"`))
+	assert.Contains(t, statement.query, `WHERE user_id = $1 AND (name ILIKE $2 OR array_to_string(emails, ',') ILIKE $3 OR array_to_string(phone_numbers, ',') ILIKE $4)`)
+	assert.Contains(t, statement.query, `ORDER BY updated_at DESC LIMIT $5 OFFSET $6`)
+	require.Len(t, statement.args, 6)
+	assert.Equal(t, entities.UserID("user-1"), statement.args[0])
+	assert.Equal(t, "%alice%", statement.args[1])
+	assert.Equal(t, "%alice%", statement.args[2])
+	assert.Equal(t, "%alice%", statement.args[3])
+	assert.Equal(t, 20, statement.args[4])
+	assert.Equal(t, 40, statement.args[5])
+}
+
+func TestGormContactRepository_FetchAll_ScopesByUserAndOrdersUpdatedAtAsc(t *testing.T) {
+	repository, recorder := newContactTestRepo(t)
+
+	_, err := repository.FetchAll(context.Background(), entities.UserID("user-1"))
+
+	require.NoError(t, err)
+	statement := lastContactStatement(t, recorder)
+	assert.Equal(t, `SELECT * FROM "contacts" WHERE user_id = $1 ORDER BY updated_at ASC`, statement.query)
+	require.Len(t, statement.args, 1)
+	assert.Equal(t, entities.UserID("user-1"), statement.args[0])
+}
+
+func TestGormContactRepository_Delete_ScopesByUserAndContactID(t *testing.T) {
+	repository, recorder := newContactTestRepo(t)
+	contactID := uuid.MustParse("55555555-5555-5555-5555-555555555555")
+
+	err := repository.Delete(context.Background(), entities.UserID("user-1"), contactID)
+
+	require.NoError(t, err)
+	statement := lastContactStatement(t, recorder)
+	assert.Equal(t, `DELETE FROM "contacts" WHERE user_id = $1 AND id = $2`, statement.query)
+	require.Len(t, statement.args, 2)
+	assert.Equal(t, entities.UserID("user-1"), statement.args[0])
+	assert.Equal(t, contactID, statement.args[1])
+}
+
+func TestGormContactRepository_DeleteAllForUser_ScopesByUserOnly(t *testing.T) {
+	repository, recorder := newContactTestRepo(t)
+
+	err := repository.DeleteAllForUser(context.Background(), entities.UserID("user-1"))
+
+	require.NoError(t, err)
+	statement := lastContactStatement(t, recorder)
+	assert.Equal(t, `DELETE FROM "contacts" WHERE user_id = $1`, statement.query)
+	require.Len(t, statement.args, 1)
+	assert.Equal(t, entities.UserID("user-1"), statement.args[0])
+}

--- a/api/pkg/repositories/gorm_contact_repository_test.go
+++ b/api/pkg/repositories/gorm_contact_repository_test.go
@@ -218,6 +218,45 @@ func TestGormContactRepository_Load_ScopesByUserAndContactID(t *testing.T) {
 	assert.Equal(t, 1, statement.args[2])
 }
 
+func TestGormContactRepository_Count_ReusesIndexFilterWithoutPagination(t *testing.T) {
+	repository, recorder := newContactTestRepo(t)
+
+	total, err := repository.Count(context.Background(), entities.UserID("user-1"), IndexParams{
+		Query: "alice",
+		// Limit/Skip must be ignored by Count.
+		Limit: 20,
+		Skip:  40,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), total)
+
+	statement := lastContactStatement(t, recorder)
+	assert.True(t, strings.HasPrefix(statement.query, `SELECT count(*) FROM "contacts"`))
+	// Count must apply the exact same user + name/emails/phone_numbers filter as Index.
+	assert.Contains(t, statement.query, `WHERE user_id = $1 AND (name ILIKE $2 OR array_to_string(emails, ',') ILIKE $3 OR array_to_string(phone_numbers, ',') ILIKE $4)`)
+	// Count must ignore pagination.
+	assert.NotContains(t, statement.query, "LIMIT")
+	assert.NotContains(t, statement.query, "OFFSET")
+	require.Len(t, statement.args, 4)
+	assert.Equal(t, entities.UserID("user-1"), statement.args[0])
+	assert.Equal(t, "%alice%", statement.args[1])
+	assert.Equal(t, "%alice%", statement.args[2])
+	assert.Equal(t, "%alice%", statement.args[3])
+}
+
+func TestGormContactRepository_Count_ScopesByUserWithoutQuery(t *testing.T) {
+	repository, recorder := newContactTestRepo(t)
+
+	_, err := repository.Count(context.Background(), entities.UserID("user-1"), IndexParams{})
+
+	require.NoError(t, err)
+	statement := lastContactStatement(t, recorder)
+	assert.Equal(t, `SELECT count(*) FROM "contacts" WHERE user_id = $1`, statement.query)
+	require.Len(t, statement.args, 1)
+	assert.Equal(t, entities.UserID("user-1"), statement.args[0])
+}
+
 func TestGormContactRepository_Index_FiltersByUserAndQueryAcrossContactFields(t *testing.T) {
 	repository, recorder := newContactTestRepo(t)
 

--- a/api/pkg/repositories/gorm_contact_repository_test.go
+++ b/api/pkg/repositories/gorm_contact_repository_test.go
@@ -270,7 +270,7 @@ func TestGormContactRepository_Index_FiltersByUserAndQueryAcrossContactFields(t 
 	statement := lastContactStatement(t, recorder)
 	assert.True(t, strings.HasPrefix(statement.query, `SELECT * FROM "contacts"`))
 	assert.Contains(t, statement.query, `WHERE user_id = $1 AND (name ILIKE $2 OR array_to_string(emails, ',') ILIKE $3 OR array_to_string(phone_numbers, ',') ILIKE $4)`)
-	assert.Contains(t, statement.query, `ORDER BY updated_at DESC LIMIT $5 OFFSET $6`)
+	assert.Contains(t, statement.query, `ORDER BY updated_at DESC, id DESC LIMIT $5 OFFSET $6`)
 	require.Len(t, statement.args, 6)
 	assert.Equal(t, entities.UserID("user-1"), statement.args[0])
 	assert.Equal(t, "%alice%", statement.args[1])
@@ -289,22 +289,22 @@ func TestGormContactRepository_Index_OrdersByRequestedFieldAndDirection(t *testi
 		{
 			name:            "name ascending",
 			params:          IndexParams{SortBy: "name"},
-			expectedOrderBy: "ORDER BY name ASC",
+			expectedOrderBy: "ORDER BY name ASC, id ASC",
 		},
 		{
 			name:            "name descending",
 			params:          IndexParams{SortBy: "name", SortDescending: true},
-			expectedOrderBy: "ORDER BY name DESC",
+			expectedOrderBy: "ORDER BY name DESC, id DESC",
 		},
 		{
 			name:            "updated descending",
 			params:          IndexParams{SortBy: "updated_at", SortDescending: true},
-			expectedOrderBy: "ORDER BY updated_at DESC",
+			expectedOrderBy: "ORDER BY updated_at DESC, id DESC",
 		},
 		{
 			name:            "default",
 			params:          IndexParams{},
-			expectedOrderBy: "ORDER BY updated_at DESC",
+			expectedOrderBy: "ORDER BY updated_at DESC, id DESC",
 		},
 	}
 
@@ -332,7 +332,7 @@ func TestGormContactRepository_FetchByPhoneNumbers_ScopesByUserAndRequestedNumbe
 
 	require.NoError(t, err)
 	statement := lastContactStatement(t, recorder)
-	assert.Equal(t, `SELECT * FROM "contacts" WHERE user_id = $1 AND phone_numbers && $2 ORDER BY updated_at ASC`, statement.query)
+	assert.Equal(t, `SELECT * FROM "contacts" WHERE user_id = $1 AND phone_numbers && $2 ORDER BY updated_at ASC, id ASC`, statement.query)
 	require.Len(t, statement.args, 2)
 	assert.Equal(t, entities.UserID("user-1"), statement.args[0])
 	assert.Equal(t, &pq.StringArray{"+18005550199", "+18005550100"}, statement.args[1])

--- a/api/pkg/repositories/gorm_contact_repository_test.go
+++ b/api/pkg/repositories/gorm_contact_repository_test.go
@@ -321,16 +321,21 @@ func TestGormContactRepository_Index_OrdersByRequestedFieldAndDirection(t *testi
 	}
 }
 
-func TestGormContactRepository_FetchAll_ScopesByUserAndOrdersUpdatedAtAsc(t *testing.T) {
+func TestGormContactRepository_FetchByPhoneNumbers_ScopesByUserAndRequestedNumbers(t *testing.T) {
 	repository, recorder := newContactTestRepo(t)
 
-	_, err := repository.FetchAll(context.Background(), entities.UserID("user-1"))
+	_, err := repository.FetchByPhoneNumbers(
+		context.Background(),
+		entities.UserID("user-1"),
+		[]string{"+18005550199", "+18005550100"},
+	)
 
 	require.NoError(t, err)
 	statement := lastContactStatement(t, recorder)
-	assert.Equal(t, `SELECT * FROM "contacts" WHERE user_id = $1 ORDER BY updated_at ASC`, statement.query)
-	require.Len(t, statement.args, 1)
+	assert.Equal(t, `SELECT * FROM "contacts" WHERE user_id = $1 AND phone_numbers && $2 ORDER BY updated_at ASC`, statement.query)
+	require.Len(t, statement.args, 2)
 	assert.Equal(t, entities.UserID("user-1"), statement.args[0])
+	assert.Equal(t, &pq.StringArray{"+18005550199", "+18005550100"}, statement.args[1])
 }
 
 func TestGormContactRepository_Delete_ScopesByUserAndContactID(t *testing.T) {

--- a/api/pkg/repositories/gorm_contact_repository_test.go
+++ b/api/pkg/repositories/gorm_contact_repository_test.go
@@ -280,6 +280,47 @@ func TestGormContactRepository_Index_FiltersByUserAndQueryAcrossContactFields(t 
 	assert.Equal(t, 40, statement.args[5])
 }
 
+func TestGormContactRepository_Index_OrdersByRequestedFieldAndDirection(t *testing.T) {
+	tests := []struct {
+		name            string
+		params          IndexParams
+		expectedOrderBy string
+	}{
+		{
+			name:            "name ascending",
+			params:          IndexParams{SortBy: "name"},
+			expectedOrderBy: "ORDER BY name ASC",
+		},
+		{
+			name:            "name descending",
+			params:          IndexParams{SortBy: "name", SortDescending: true},
+			expectedOrderBy: "ORDER BY name DESC",
+		},
+		{
+			name:            "updated descending",
+			params:          IndexParams{SortBy: "updated_at", SortDescending: true},
+			expectedOrderBy: "ORDER BY updated_at DESC",
+		},
+		{
+			name:            "default",
+			params:          IndexParams{},
+			expectedOrderBy: "ORDER BY updated_at DESC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repository, recorder := newContactTestRepo(t)
+
+			_, err := repository.Index(context.Background(), entities.UserID("user-1"), tt.params)
+
+			require.NoError(t, err)
+			statement := lastContactStatement(t, recorder)
+			assert.Contains(t, statement.query, tt.expectedOrderBy)
+		})
+	}
+}
+
 func TestGormContactRepository_FetchAll_ScopesByUserAndOrdersUpdatedAtAsc(t *testing.T) {
 	repository, recorder := newContactTestRepo(t)
 

--- a/api/pkg/repositories/mongo_contact_repository.go
+++ b/api/pkg/repositories/mongo_contact_repository.go
@@ -1,0 +1,239 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/google/uuid"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+// mongoContactRepository is responsible for persisting entities.Contact in MongoDB.
+type mongoContactRepository struct {
+	logger     telemetry.Logger
+	tracer     telemetry.Tracer
+	collection *mongo.Collection
+}
+
+// NewMongoContactRepository creates the MongoDB version of the ContactRepository.
+func NewMongoContactRepository(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+	db *mongo.Database,
+) ContactRepository {
+	return &mongoContactRepository{
+		logger:     logger.WithService(fmt.Sprintf("%T", &mongoContactRepository{})),
+		tracer:     tracer,
+		collection: db.Collection(collectionContacts),
+	}
+}
+
+func (repository *mongoContactRepository) Store(ctx context.Context, contacts []*entities.Contact) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	if len(contacts) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, dbOperationDuration)
+	defer cancel()
+
+	documents := make([]any, len(contacts))
+	for index, contact := range contacts {
+		documents[index] = contact
+	}
+
+	session, err := repository.collection.Database().Client().StartSession()
+	if err != nil {
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot start transaction to store [%d] contacts", len(contacts)))
+	}
+	defer session.EndSession(ctx)
+
+	_, err = session.WithTransaction(ctx, func(transactionCtx context.Context) (any, error) {
+		return repository.collection.InsertMany(transactionCtx, documents)
+	})
+	if err != nil {
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot store [%d] contacts", len(contacts)))
+	}
+
+	return nil
+}
+
+func (repository *mongoContactRepository) Update(ctx context.Context, contact *entities.Contact) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, dbOperationDuration)
+	defer cancel()
+
+	filter := mongoContactIDFilter(contact.UserID, contact.ID)
+	if _, err := repository.collection.ReplaceOne(ctx, filter, contact); err != nil {
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot update contact with ID [%s]", contact.ID))
+	}
+
+	return nil
+}
+
+func (repository *mongoContactRepository) Load(ctx context.Context, userID entities.UserID, contactID uuid.UUID) (*entities.Contact, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, dbOperationDuration)
+	defer cancel()
+
+	contact := new(entities.Contact)
+	err := repository.collection.FindOne(ctx, mongoContactIDFilter(userID, contactID)).Decode(contact)
+	if err == mongo.ErrNoDocuments {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCodef(err, ErrCodeNotFound, "contact with ID [%s] for user [%s] does not exist", contactID, userID))
+	}
+	if err != nil {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot load contact with ID [%s] for user [%s]", contactID, userID))
+	}
+
+	return contact, nil
+}
+
+func (repository *mongoContactRepository) Index(ctx context.Context, userID entities.UserID, params IndexParams) (*[]entities.Contact, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, dbOperationDuration)
+	defer cancel()
+
+	findOptions := options.Find().
+		SetSort(mongoContactSort(params)).
+		SetSkip(int64(params.Skip)).
+		SetLimit(int64(params.Limit))
+	cursor, err := repository.collection.Find(ctx, mongoContactFilter(userID, params.Query), findOptions)
+	if err != nil {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot index contacts for user [%s] with params [%+#v]", userID, params))
+	}
+	defer cursor.Close(ctx)
+
+	contacts := make([]entities.Contact, 0)
+	if err = cursor.All(ctx, &contacts); err != nil {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot decode contacts for user [%s]", userID))
+	}
+
+	return &contacts, nil
+}
+
+func (repository *mongoContactRepository) Count(ctx context.Context, userID entities.UserID, params IndexParams) (int64, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, dbOperationDuration)
+	defer cancel()
+
+	count, err := repository.collection.CountDocuments(ctx, mongoContactFilter(userID, params.Query))
+	if err != nil {
+		return 0, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot count contacts for user [%s] with query [%s]", userID, params.Query))
+	}
+
+	return count, nil
+}
+
+func (repository *mongoContactRepository) FetchByPhoneNumbers(ctx context.Context, userID entities.UserID, phoneNumbers []string) (*[]entities.Contact, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, dbOperationDuration)
+	defer cancel()
+
+	findOptions := options.Find().SetSort(bson.D{
+		{Key: "updated_at", Value: 1},
+		{Key: "_id", Value: 1},
+	})
+	cursor, err := repository.collection.Find(ctx, mongoContactPhoneNumbersFilter(userID, phoneNumbers), findOptions)
+	if err != nil {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot fetch contacts for user [%s] by phone numbers [%v]", userID, phoneNumbers))
+	}
+	defer cursor.Close(ctx)
+
+	contacts := make([]entities.Contact, 0)
+	if err = cursor.All(ctx, &contacts); err != nil {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot decode contacts for user [%s] by phone numbers", userID))
+	}
+
+	return &contacts, nil
+}
+
+func (repository *mongoContactRepository) Delete(ctx context.Context, userID entities.UserID, contactID uuid.UUID) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, dbOperationDuration)
+	defer cancel()
+
+	if _, err := repository.collection.DeleteOne(ctx, mongoContactIDFilter(userID, contactID)); err != nil {
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot delete contact with ID [%s] for user [%s]", contactID, userID))
+	}
+
+	return nil
+}
+
+func (repository *mongoContactRepository) DeleteAllForUser(ctx context.Context, userID entities.UserID) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, dbOperationDuration)
+	defer cancel()
+
+	if _, err := repository.collection.DeleteMany(ctx, bson.D{{Key: "user_id", Value: string(userID)}}); err != nil {
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot delete all contacts for user [%s]", userID))
+	}
+
+	return nil
+}
+
+func mongoContactFilter(userID entities.UserID, query string) bson.D {
+	filter := bson.D{{Key: "user_id", Value: string(userID)}}
+	if query == "" {
+		return filter
+	}
+
+	expression := bson.Regex{Pattern: regexp.QuoteMeta(query), Options: "i"}
+	return append(filter, bson.E{Key: "$or", Value: bson.A{
+		bson.D{{Key: "name", Value: expression}},
+		bson.D{{Key: "emails", Value: expression}},
+		bson.D{{Key: "phone_numbers", Value: expression}},
+	}})
+}
+
+func mongoContactSort(params IndexParams) bson.D {
+	sortBy := "updated_at"
+	if params.SortBy == "name" {
+		sortBy = "name"
+	}
+
+	direction := 1
+	if params.SortBy == "" || params.SortDescending {
+		direction = -1
+	}
+
+	return bson.D{
+		{Key: sortBy, Value: direction},
+		{Key: "_id", Value: direction},
+	}
+}
+
+func mongoContactPhoneNumbersFilter(userID entities.UserID, phoneNumbers []string) bson.D {
+	return bson.D{
+		{Key: "user_id", Value: string(userID)},
+		{Key: "phone_numbers", Value: bson.D{{Key: "$in", Value: phoneNumbers}}},
+	}
+}
+
+func mongoContactIDFilter(userID entities.UserID, contactID uuid.UUID) bson.D {
+	return bson.D{
+		{Key: "user_id", Value: string(userID)},
+		{Key: "_id", Value: contactID.String()},
+	}
+}

--- a/api/pkg/repositories/mongo_contact_repository_test.go
+++ b/api/pkg/repositories/mongo_contact_repository_test.go
@@ -1,0 +1,124 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestMongoContactFilter_ScopesByUserAndSearchesContactFields(t *testing.T) {
+	filter := mongoContactFilter(entities.UserID("user-1"), "Alice")
+
+	assert.Equal(t, bson.D{
+		{Key: "user_id", Value: "user-1"},
+		{Key: "$or", Value: bson.A{
+			bson.D{{Key: "name", Value: bson.Regex{Pattern: "Alice", Options: "i"}}},
+			bson.D{{Key: "emails", Value: bson.Regex{Pattern: "Alice", Options: "i"}}},
+			bson.D{{Key: "phone_numbers", Value: bson.Regex{Pattern: "Alice", Options: "i"}}},
+		}},
+	}, filter)
+}
+
+func TestMongoContactFilter_WithoutSearchOnlyScopesByUser(t *testing.T) {
+	filter := mongoContactFilter(entities.UserID("user-1"), "")
+
+	assert.Equal(t, bson.D{{Key: "user_id", Value: "user-1"}}, filter)
+}
+
+func TestMongoContactFilter_TreatsSearchAsLiteralText(t *testing.T) {
+	filter := mongoContactFilter(entities.UserID("user-1"), "Alice.*")
+
+	expectedExpression := bson.Regex{Pattern: `Alice\.\*`, Options: "i"}
+	assert.Equal(t, bson.D{
+		{Key: "user_id", Value: "user-1"},
+		{Key: "$or", Value: bson.A{
+			bson.D{{Key: "name", Value: expectedExpression}},
+			bson.D{{Key: "emails", Value: expectedExpression}},
+			bson.D{{Key: "phone_numbers", Value: expectedExpression}},
+		}},
+	}, filter)
+}
+
+func TestMongoContactSort_UsesStableRequestedOrdering(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   IndexParams
+		expected bson.D
+	}{
+		{
+			name:     "default",
+			params:   IndexParams{},
+			expected: bson.D{{Key: "updated_at", Value: -1}, {Key: "_id", Value: -1}},
+		},
+		{
+			name:     "name ascending",
+			params:   IndexParams{SortBy: "name"},
+			expected: bson.D{{Key: "name", Value: 1}, {Key: "_id", Value: 1}},
+		},
+		{
+			name:     "name descending",
+			params:   IndexParams{SortBy: "name", SortDescending: true},
+			expected: bson.D{{Key: "name", Value: -1}, {Key: "_id", Value: -1}},
+		},
+		{
+			name:     "updated ascending",
+			params:   IndexParams{SortBy: "updated_at"},
+			expected: bson.D{{Key: "updated_at", Value: 1}, {Key: "_id", Value: 1}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, mongoContactSort(tt.params))
+		})
+	}
+}
+
+func TestMongoContactPhoneNumbersFilter_ScopesByUserAndRequestedNumbers(t *testing.T) {
+	filter := mongoContactPhoneNumbersFilter(
+		entities.UserID("user-1"),
+		[]string{"+18005550199", "+18005550100"},
+	)
+
+	assert.Equal(t, bson.D{
+		{Key: "user_id", Value: "user-1"},
+		{Key: "phone_numbers", Value: bson.D{{Key: "$in", Value: []string{"+18005550199", "+18005550100"}}}},
+	}, filter)
+}
+
+func TestMongoContactIDFilter_ScopesByUserAndContactID(t *testing.T) {
+	contactID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	filter := mongoContactIDFilter(entities.UserID("user-1"), contactID)
+
+	assert.Equal(t, bson.D{
+		{Key: "user_id", Value: "user-1"},
+		{Key: "_id", Value: contactID.String()},
+	}, filter)
+}
+
+func TestContactMongoIndexModels_CoverListingAndPhoneLookup(t *testing.T) {
+	indexes := contactMongoIndexModels()
+
+	require.Len(t, indexes, 3)
+	assert.Equal(t, bson.D{
+		{Key: "user_id", Value: 1},
+		{Key: "updated_at", Value: -1},
+		{Key: "_id", Value: -1},
+	}, indexes[0].Keys)
+	assert.Equal(t, bson.D{
+		{Key: "user_id", Value: 1},
+		{Key: "name", Value: 1},
+		{Key: "_id", Value: 1},
+	}, indexes[1].Keys)
+	assert.Equal(t, bson.D{
+		{Key: "user_id", Value: 1},
+		{Key: "phone_numbers", Value: 1},
+		{Key: "updated_at", Value: 1},
+		{Key: "_id", Value: 1},
+	}, indexes[2].Keys)
+}

--- a/api/pkg/repositories/mongodb.go
+++ b/api/pkg/repositories/mongodb.go
@@ -17,6 +17,7 @@ import (
 const (
 	collectionHeartbeats        = "heartbeats"
 	collectionHeartbeatMonitors = "heartbeat_monitors"
+	collectionContacts          = "contacts"
 )
 
 // uuidEncodeValue encodes uuid.UUID as a BSON string
@@ -122,5 +123,32 @@ func createMongoIndexes(ctx context.Context, db *mongo.Database) error {
 		return stacktrace.Propagatef(err, "cannot create indexes on heartbeat_monitors collection")
 	}
 
+	contactsCol := db.Collection(collectionContacts)
+	_, err = contactsCol.Indexes().CreateMany(ctx, contactMongoIndexModels())
+	if err != nil {
+		return stacktrace.Propagatef(err, "cannot create indexes on contacts collection")
+	}
+
 	return nil
+}
+
+func contactMongoIndexModels() []mongo.IndexModel {
+	return []mongo.IndexModel{
+		{Keys: bson.D{
+			{Key: "user_id", Value: 1},
+			{Key: "updated_at", Value: -1},
+			{Key: "_id", Value: -1},
+		}},
+		{Keys: bson.D{
+			{Key: "user_id", Value: 1},
+			{Key: "name", Value: 1},
+			{Key: "_id", Value: 1},
+		}},
+		{Keys: bson.D{
+			{Key: "user_id", Value: 1},
+			{Key: "phone_numbers", Value: 1},
+			{Key: "updated_at", Value: 1},
+			{Key: "_id", Value: 1},
+		}},
+	}
 }

--- a/api/pkg/requests/contact_index.go
+++ b/api/pkg/requests/contact_index.go
@@ -1,0 +1,39 @@
+package requests
+
+import (
+	"strings"
+
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+)
+
+// ContactIndex lists contacts for a user.
+type ContactIndex struct {
+	request
+	Skip  string `json:"skip" query:"skip"`
+	Query string `json:"query" query:"query"`
+	Limit string `json:"limit" query:"limit"`
+}
+
+// Sanitize sets defaults for the list request.
+func (input *ContactIndex) Sanitize() ContactIndex {
+	input.Query = strings.TrimSpace(input.Query)
+	input.Skip = strings.TrimSpace(input.Skip)
+	input.Limit = strings.TrimSpace(input.Limit)
+
+	if input.Skip == "" {
+		input.Skip = "0"
+	}
+	if input.Limit == "" {
+		input.Limit = "20"
+	}
+	return *input
+}
+
+// ToIndexParams converts the request into repositories.IndexParams.
+func (input *ContactIndex) ToIndexParams() repositories.IndexParams {
+	return repositories.IndexParams{
+		Skip:  input.getInt(input.Skip),
+		Query: input.Query,
+		Limit: input.getInt(input.Limit),
+	}
+}

--- a/api/pkg/requests/contact_index.go
+++ b/api/pkg/requests/contact_index.go
@@ -9,14 +9,17 @@ import (
 // ContactIndex lists contacts for a user.
 type ContactIndex struct {
 	request
-	Skip  string `json:"skip" query:"skip"`
-	Query string `json:"query" query:"query"`
-	Limit string `json:"limit" query:"limit"`
+	Skip           string `json:"skip" query:"skip"`
+	Query          string `json:"query" query:"query"`
+	SortBy         string `json:"sort_by" query:"sort_by"`
+	SortDescending bool   `json:"sort_descending" query:"sort_descending"`
+	Limit          string `json:"limit" query:"limit"`
 }
 
 // Sanitize sets defaults for the list request.
 func (input *ContactIndex) Sanitize() ContactIndex {
 	input.Query = strings.TrimSpace(input.Query)
+	input.SortBy = strings.TrimSpace(input.SortBy)
 	input.Skip = strings.TrimSpace(input.Skip)
 	input.Limit = strings.TrimSpace(input.Limit)
 
@@ -32,8 +35,10 @@ func (input *ContactIndex) Sanitize() ContactIndex {
 // ToIndexParams converts the request into repositories.IndexParams.
 func (input *ContactIndex) ToIndexParams() repositories.IndexParams {
 	return repositories.IndexParams{
-		Skip:  input.getInt(input.Skip),
-		Query: input.Query,
-		Limit: input.getInt(input.Limit),
+		Skip:           input.getInt(input.Skip),
+		Query:          input.Query,
+		SortBy:         input.SortBy,
+		SortDescending: input.SortDescending,
+		Limit:          input.getInt(input.Limit),
 	}
 }

--- a/api/pkg/requests/contact_store.go
+++ b/api/pkg/requests/contact_store.go
@@ -49,7 +49,7 @@ func (input *ContactStoreRequest) UnmarshalJSON(data []byte) error {
 // Sanitize trims and normalizes each contact item.
 func (input ContactStoreRequest) Sanitize() ContactStoreRequest {
 	for index := range input.Contacts {
-		input.Contacts[index] = sanitizeContactItem(input.Contacts[index])
+		input.Contacts[index] = SanitizeContactItem(input.Contacts[index])
 	}
 	return input
 }
@@ -78,7 +78,10 @@ func (input *ContactStoreRequest) ToContacts(userID entities.UserID) []*entities
 	return contacts
 }
 
-func sanitizeContactItem(item ContactItem) ContactItem {
+// SanitizeContactItem trims and normalizes a single contact item so the CSV
+// upload and JSON create paths accept and normalize identical values (e.g. a
+// phone number without a leading "+" or an email with mixed case/whitespace).
+func SanitizeContactItem(item ContactItem) ContactItem {
 	item.Name = strings.TrimSpace(item.Name)
 	item.Emails = sanitizeUniqueStrings(item.Emails, func(value string) string {
 		return strings.ToLower(strings.TrimSpace(value))

--- a/api/pkg/requests/contact_store.go
+++ b/api/pkg/requests/contact_store.go
@@ -92,20 +92,3 @@ func sanitizeContactItem(item ContactItem) ContactItem {
 	}
 	return item
 }
-
-func sanitizeUniqueStrings(values []string, normalize func(string) string) []string {
-	seen := map[string]struct{}{}
-	result := make([]string, 0, len(values))
-	for _, value := range values {
-		value = normalize(value)
-		if value == "" {
-			continue
-		}
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		result = append(result, value)
-	}
-	return result
-}

--- a/api/pkg/requests/contact_store.go
+++ b/api/pkg/requests/contact_store.go
@@ -13,9 +13,9 @@ import (
 // ContactItem is a single contact in a create request.
 type ContactItem struct {
 	Name         string            `json:"name" example:"Alice Smith"`
-	Emails       []string          `json:"emails"`
+	Emails       []string          `json:"emails,omitempty"`
 	PhoneNumbers []string          `json:"phone_numbers"`
-	Properties   map[string]string `json:"properties"`
+	Properties   map[string]string `json:"properties,omitempty"`
 }
 
 // ContactStoreRequest creates one or many contacts.

--- a/api/pkg/requests/contact_store.go
+++ b/api/pkg/requests/contact_store.go
@@ -1,0 +1,111 @@
+package requests
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+)
+
+// ContactItem is a single contact in a create request.
+type ContactItem struct {
+	Name         string            `json:"name" example:"Alice Smith"`
+	Emails       []string          `json:"emails"`
+	PhoneNumbers []string          `json:"phone_numbers"`
+	Properties   map[string]string `json:"properties"`
+}
+
+// ContactStoreRequest creates one or many contacts.
+type ContactStoreRequest struct {
+	request
+	Contacts []ContactItem `json:"contacts"`
+}
+
+// UnmarshalJSON accepts either a JSON array of contacts or {"contacts":[...]}.
+func (input *ContactStoreRequest) UnmarshalJSON(data []byte) error {
+	trimmed := strings.TrimSpace(string(data))
+	if strings.HasPrefix(trimmed, "[") {
+		var items []ContactItem
+		if err := json.Unmarshal(data, &items); err != nil {
+			return err
+		}
+		input.Contacts = items
+		return nil
+	}
+
+	type alias ContactStoreRequest
+	var wrapper alias
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return err
+	}
+
+	input.Contacts = wrapper.Contacts
+	return nil
+}
+
+// Sanitize trims and normalizes each contact item.
+func (input ContactStoreRequest) Sanitize() ContactStoreRequest {
+	for index := range input.Contacts {
+		input.Contacts[index] = sanitizeContactItem(input.Contacts[index])
+	}
+	return input
+}
+
+// ToContacts converts the request into persistable entities.Contact records.
+func (input *ContactStoreRequest) ToContacts(userID entities.UserID) []*entities.Contact {
+	now := time.Now().UTC()
+	contacts := make([]*entities.Contact, 0, len(input.Contacts))
+	for _, item := range input.Contacts {
+		properties := item.Properties
+		if properties == nil {
+			properties = map[string]string{}
+		}
+
+		contacts = append(contacts, &entities.Contact{
+			ID:           uuid.New(),
+			UserID:       userID,
+			Name:         item.Name,
+			Emails:       pq.StringArray(item.Emails),
+			PhoneNumbers: pq.StringArray(item.PhoneNumbers),
+			Properties:   entities.ContactProperties(properties),
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		})
+	}
+	return contacts
+}
+
+func sanitizeContactItem(item ContactItem) ContactItem {
+	item.Name = strings.TrimSpace(item.Name)
+	item.Emails = sanitizeUniqueStrings(item.Emails, func(value string) string {
+		return strings.ToLower(strings.TrimSpace(value))
+	})
+	item.PhoneNumbers = sanitizeUniqueStrings(item.PhoneNumbers, func(value string) string {
+		var base request
+		return base.sanitizeAddress(value)
+	})
+	if item.Properties == nil {
+		item.Properties = map[string]string{}
+	}
+	return item
+}
+
+func sanitizeUniqueStrings(values []string, normalize func(string) string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = normalize(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}

--- a/api/pkg/requests/contact_store_test.go
+++ b/api/pkg/requests/contact_store_test.go
@@ -91,6 +91,19 @@ func TestContactStoreRequest_ToContactsPreservesPropertiesAndOwnership(t *testin
 	assert.True(t, contacts[0].CreatedAt.Equal(contacts[0].UpdatedAt))
 }
 
+func TestContactStoreRequest_ToContactsInitializesNilProperties(t *testing.T) {
+	request := ContactStoreRequest{Contacts: []ContactItem{{
+		Name:         "Alice",
+		PhoneNumbers: []string{"+18005550199"},
+	}}}
+
+	contacts := request.ToContacts(entities.UserID("user-1"))
+
+	require.Len(t, contacts, 1)
+	assert.NotNil(t, contacts[0].Properties)
+	assert.Empty(t, contacts[0].Properties)
+}
+
 func TestContactUpdateRequest_SanitizeAndApplyTo(t *testing.T) {
 	request := ContactUpdateRequest{
 		Name:         "  Alice  ",

--- a/api/pkg/requests/contact_store_test.go
+++ b/api/pkg/requests/contact_store_test.go
@@ -31,6 +31,21 @@ func TestContactStoreRequest_UnmarshalObjectForm(t *testing.T) {
 	assert.Equal(t, []string{"+18005550100"}, request.Contacts[0].PhoneNumbers)
 }
 
+func TestContactStoreRequest_UnmarshalMissingOptionalFields(t *testing.T) {
+	var request ContactStoreRequest
+
+	require.NoError(t, json.Unmarshal([]byte(`[{"name":"Alice","phone_numbers":["+18005550199"]}]`), &request))
+
+	require.Len(t, request.Contacts, 1)
+	assert.Nil(t, request.Contacts[0].Emails)
+	assert.Nil(t, request.Contacts[0].Properties)
+
+	sanitized := request.Sanitize()
+	require.Len(t, sanitized.Contacts, 1)
+	assert.NotNil(t, sanitized.Contacts[0].Properties)
+	assert.Empty(t, sanitized.Contacts[0].Properties)
+}
+
 func TestContactStoreRequest_UnmarshalMalformedJSON(t *testing.T) {
 	var request ContactStoreRequest
 
@@ -138,6 +153,19 @@ func TestContactUpdateRequest_InitializesNilProperties(t *testing.T) {
 
 	assert.NotNil(t, request.Properties)
 	assert.Empty(t, request.Properties)
+}
+
+func TestContactUpdateRequest_UnmarshalMissingOptionalFields(t *testing.T) {
+	var request ContactUpdateRequest
+
+	require.NoError(t, json.Unmarshal([]byte(`{"name":"Alice","phone_numbers":["+18005550199"]}`), &request))
+
+	assert.Nil(t, request.Emails)
+	assert.Nil(t, request.Properties)
+
+	sanitized := request.Sanitize()
+	assert.NotNil(t, sanitized.Properties)
+	assert.Empty(t, sanitized.Properties)
 }
 
 func TestContactIndex_SanitizeUsesDefaultsAndToIndexParams(t *testing.T) {

--- a/api/pkg/requests/contact_store_test.go
+++ b/api/pkg/requests/contact_store_test.go
@@ -1,0 +1,156 @@
+package requests
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContactStoreRequest_UnmarshalArrayForm(t *testing.T) {
+	var request ContactStoreRequest
+
+	require.NoError(t, json.Unmarshal([]byte(`[{"name":"Alice","phone_numbers":["+18005550199"]}]`), &request))
+
+	require.Len(t, request.Contacts, 1)
+	assert.Equal(t, "Alice", request.Contacts[0].Name)
+	assert.Equal(t, []string{"+18005550199"}, request.Contacts[0].PhoneNumbers)
+}
+
+func TestContactStoreRequest_UnmarshalObjectForm(t *testing.T) {
+	var request ContactStoreRequest
+
+	require.NoError(t, json.Unmarshal([]byte(`{"contacts":[{"name":"Bob","phone_numbers":["+18005550100"]}]}`), &request))
+
+	require.Len(t, request.Contacts, 1)
+	assert.Equal(t, "Bob", request.Contacts[0].Name)
+	assert.Equal(t, []string{"+18005550100"}, request.Contacts[0].PhoneNumbers)
+}
+
+func TestContactStoreRequest_UnmarshalMalformedJSON(t *testing.T) {
+	var request ContactStoreRequest
+
+	err := json.Unmarshal([]byte(`{"contacts":[{"name":"Alice"`), &request)
+
+	require.Error(t, err)
+}
+
+func TestContactStoreRequest_SanitizeNormalizesAndDeduplicates(t *testing.T) {
+	request := ContactStoreRequest{Contacts: []ContactItem{{
+		Name:         "  Alice  ",
+		PhoneNumbers: []string{"18005550199", "+18005550199", " ", "+18005550100"},
+		Emails:       []string{" Alice@Example.com ", "", "alice@example.com", "B@example.com", "b@example.com"},
+		Properties:   map[string]string{"company": "Acme", "role": "CTO"},
+	}}}
+
+	request = request.Sanitize()
+
+	require.Len(t, request.Contacts, 1)
+	assert.Equal(t, "Alice", request.Contacts[0].Name)
+	assert.Equal(t, []string{"+18005550199", "+18005550100"}, request.Contacts[0].PhoneNumbers)
+	assert.Equal(t, []string{"alice@example.com", "b@example.com"}, request.Contacts[0].Emails)
+	assert.Equal(t, map[string]string{"company": "Acme", "role": "CTO"}, request.Contacts[0].Properties)
+}
+
+func TestContactStoreRequest_SanitizeInitializesNilProperties(t *testing.T) {
+	request := ContactStoreRequest{Contacts: []ContactItem{{
+		Name:         "Alice",
+		PhoneNumbers: []string{"+18005550199"},
+	}}}
+
+	request = request.Sanitize()
+
+	require.Len(t, request.Contacts, 1)
+	assert.NotNil(t, request.Contacts[0].Properties)
+	assert.Empty(t, request.Contacts[0].Properties)
+}
+
+func TestContactStoreRequest_ToContactsPreservesPropertiesAndOwnership(t *testing.T) {
+	request := ContactStoreRequest{Contacts: []ContactItem{{
+		Name:         "Alice",
+		Emails:       []string{"alice@example.com"},
+		PhoneNumbers: []string{"+18005550199"},
+		Properties:   map[string]string{"company": "Acme"},
+	}}}.Sanitize()
+
+	contacts := request.ToContacts(entities.UserID("user-1"))
+
+	require.Len(t, contacts, 1)
+	assert.NotZero(t, contacts[0].ID)
+	assert.Equal(t, entities.UserID("user-1"), contacts[0].UserID)
+	assert.Equal(t, "Alice", contacts[0].Name)
+	assert.Equal(t, []string{"alice@example.com"}, []string(contacts[0].Emails))
+	assert.Equal(t, []string{"+18005550199"}, []string(contacts[0].PhoneNumbers))
+	assert.Equal(t, entities.ContactProperties{"company": "Acme"}, contacts[0].Properties)
+	assert.False(t, contacts[0].CreatedAt.IsZero())
+	assert.False(t, contacts[0].UpdatedAt.IsZero())
+	assert.True(t, contacts[0].CreatedAt.Equal(contacts[0].UpdatedAt))
+}
+
+func TestContactUpdateRequest_SanitizeAndApplyTo(t *testing.T) {
+	request := ContactUpdateRequest{
+		Name:         "  Alice  ",
+		Emails:       []string{" Alice@Example.com ", "", "alice@example.com"},
+		PhoneNumbers: []string{"18005550199", "+18005550199"},
+		Properties:   map[string]string{"nickname": "Al"},
+	}.Sanitize()
+
+	contact := &entities.Contact{
+		ID:           uuid.MustParse("32343a19-da5e-4b1b-a767-3298a73703cb"),
+		UserID:       entities.UserID("user-1"),
+		Name:         "Before",
+		Emails:       nil,
+		PhoneNumbers: nil,
+		Properties:   entities.ContactProperties{"old": "value"},
+		CreatedAt:    time.Unix(1, 0).UTC(),
+		UpdatedAt:    time.Unix(2, 0).UTC(),
+	}
+
+	request.ApplyTo(contact)
+
+	assert.Equal(t, "Alice", contact.Name)
+	assert.Equal(t, []string{"alice@example.com"}, []string(contact.Emails))
+	assert.Equal(t, []string{"+18005550199"}, []string(contact.PhoneNumbers))
+	assert.Equal(t, entities.ContactProperties{"nickname": "Al"}, contact.Properties)
+	assert.Equal(t, time.Unix(1, 0).UTC(), contact.CreatedAt)
+	assert.True(t, contact.UpdatedAt.After(time.Unix(2, 0).UTC()))
+}
+
+func TestContactUpdateRequest_InitializesNilProperties(t *testing.T) {
+	request := ContactUpdateRequest{Name: "Alice", PhoneNumbers: []string{"+18005550199"}}.Sanitize()
+
+	assert.NotNil(t, request.Properties)
+	assert.Empty(t, request.Properties)
+}
+
+func TestContactIndex_SanitizeUsesDefaultsAndToIndexParams(t *testing.T) {
+	request := ContactIndex{}
+
+	sanitized := request.Sanitize()
+	params := sanitized.ToIndexParams()
+
+	assert.Equal(t, "0", sanitized.Skip)
+	assert.Equal(t, "20", sanitized.Limit)
+	assert.Equal(t, "", sanitized.Query)
+	assert.Equal(t, 0, params.Skip)
+	assert.Equal(t, 20, params.Limit)
+	assert.Equal(t, "", params.Query)
+}
+
+func TestContactIndex_SanitizeTrimsAndConverts(t *testing.T) {
+	request := ContactIndex{Skip: " 15 ", Limit: " 50 ", Query: " alice "}
+
+	sanitized := request.Sanitize()
+	params := sanitized.ToIndexParams()
+
+	assert.Equal(t, "15", sanitized.Skip)
+	assert.Equal(t, "50", sanitized.Limit)
+	assert.Equal(t, "alice", sanitized.Query)
+	assert.Equal(t, 15, params.Skip)
+	assert.Equal(t, 50, params.Limit)
+	assert.Equal(t, "alice", params.Query)
+}

--- a/api/pkg/requests/contact_store_test.go
+++ b/api/pkg/requests/contact_store_test.go
@@ -180,10 +180,18 @@ func TestContactIndex_SanitizeUsesDefaultsAndToIndexParams(t *testing.T) {
 	assert.Equal(t, 0, params.Skip)
 	assert.Equal(t, 20, params.Limit)
 	assert.Equal(t, "", params.Query)
+	assert.Equal(t, "", params.SortBy)
+	assert.False(t, params.SortDescending)
 }
 
 func TestContactIndex_SanitizeTrimsAndConverts(t *testing.T) {
-	request := ContactIndex{Skip: " 15 ", Limit: " 50 ", Query: " alice "}
+	request := ContactIndex{
+		Skip:           " 15 ",
+		Limit:          " 50 ",
+		Query:          " alice ",
+		SortBy:         " name ",
+		SortDescending: true,
+	}
 
 	sanitized := request.Sanitize()
 	params := sanitized.ToIndexParams()
@@ -191,7 +199,10 @@ func TestContactIndex_SanitizeTrimsAndConverts(t *testing.T) {
 	assert.Equal(t, "15", sanitized.Skip)
 	assert.Equal(t, "50", sanitized.Limit)
 	assert.Equal(t, "alice", sanitized.Query)
+	assert.Equal(t, "name", sanitized.SortBy)
 	assert.Equal(t, 15, params.Skip)
 	assert.Equal(t, 50, params.Limit)
 	assert.Equal(t, "alice", params.Query)
+	assert.Equal(t, "name", params.SortBy)
+	assert.True(t, params.SortDescending)
 }

--- a/api/pkg/requests/contact_update.go
+++ b/api/pkg/requests/contact_update.go
@@ -1,0 +1,43 @@
+package requests
+
+import (
+	"strings"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/lib/pq"
+)
+
+// ContactUpdateRequest updates an existing contact.
+type ContactUpdateRequest struct {
+	request
+	Name         string            `json:"name" example:"Alice Smith"`
+	Emails       []string          `json:"emails"`
+	PhoneNumbers []string          `json:"phone_numbers"`
+	Properties   map[string]string `json:"properties"`
+}
+
+// Sanitize trims and normalizes the update request.
+func (input ContactUpdateRequest) Sanitize() ContactUpdateRequest {
+	input.Name = strings.TrimSpace(input.Name)
+	input.Emails = sanitizeUniqueStrings(input.Emails, func(value string) string {
+		return strings.ToLower(strings.TrimSpace(value))
+	})
+	input.PhoneNumbers = sanitizeUniqueStrings(input.PhoneNumbers, func(value string) string {
+		var base request
+		return base.sanitizeAddress(value)
+	})
+	if input.Properties == nil {
+		input.Properties = map[string]string{}
+	}
+	return input
+}
+
+// ApplyTo mutates an existing contact with the update values.
+func (input *ContactUpdateRequest) ApplyTo(contact *entities.Contact) {
+	contact.Name = input.Name
+	contact.Emails = pq.StringArray(input.Emails)
+	contact.PhoneNumbers = pq.StringArray(input.PhoneNumbers)
+	contact.Properties = entities.ContactProperties(input.Properties)
+	contact.UpdatedAt = time.Now().UTC()
+}

--- a/api/pkg/requests/contact_update.go
+++ b/api/pkg/requests/contact_update.go
@@ -12,9 +12,9 @@ import (
 type ContactUpdateRequest struct {
 	request
 	Name         string            `json:"name" example:"Alice Smith"`
-	Emails       []string          `json:"emails"`
+	Emails       []string          `json:"emails,omitempty"`
 	PhoneNumbers []string          `json:"phone_numbers"`
-	Properties   map[string]string `json:"properties"`
+	Properties   map[string]string `json:"properties,omitempty"`
 }
 
 // Sanitize trims and normalizes the update request.

--- a/api/pkg/requests/message_thread_index_request.go
+++ b/api/pkg/requests/message_thread_index_request.go
@@ -18,6 +18,7 @@ type MessageThreadIndex struct {
 	Query      string `json:"query" query:"query"`
 	Limit      string `json:"limit" query:"limit"`
 	Owner      string `json:"owner" query:"owner"`
+	Contacts   string `json:"contacts" query:"contacts" example:"false"`
 }
 
 // Sanitize sets defaults to MessageOutstanding
@@ -30,7 +31,16 @@ func (input *MessageThreadIndex) Sanitize() MessageThreadIndex {
 		input.IsArchived = "false"
 	}
 
+	if strings.TrimSpace(input.Contacts) == "" {
+		input.Contacts = "false"
+	}
+
 	input.IsArchived = input.sanitizeBool(input.IsArchived)
+	input.Contacts = input.sanitizeBool(input.Contacts)
+	if input.Contacts != "true" && input.Contacts != "false" {
+		input.Contacts = "false"
+	}
+
 	input.Query = strings.TrimSpace(input.Query)
 	input.Owner = input.sanitizeAddress(input.Owner)
 
@@ -50,8 +60,9 @@ func (input *MessageThreadIndex) ToGetParams(userID entities.UserID) services.Me
 			Query: input.Query,
 			Limit: input.getInt(input.Limit),
 		},
-		UserID:     userID,
-		IsArchived: input.getBool(input.IsArchived),
-		Owner:      input.Owner,
+		UserID:       userID,
+		IsArchived:   input.getBool(input.IsArchived),
+		WithContacts: input.getBool(input.Contacts),
+		Owner:        input.Owner,
 	}
 }

--- a/api/pkg/requests/message_thread_index_request_test.go
+++ b/api/pkg/requests/message_thread_index_request_test.go
@@ -1,0 +1,40 @@
+package requests
+
+import (
+	"testing"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessageThreadIndex_ToGetParams_WithContactsTrue(t *testing.T) {
+	input := (&MessageThreadIndex{Owner: "+18005550199", Contacts: " true "}).Sanitize()
+	params := input.ToGetParams(entities.UserID("user-id"))
+
+	assert.Equal(t, "true", input.Contacts)
+	assert.True(t, params.WithContacts)
+}
+
+func TestMessageThreadIndex_ToGetParams_WithContactsFalse(t *testing.T) {
+	input := (&MessageThreadIndex{Owner: "+18005550199", Contacts: "0"}).Sanitize()
+	params := input.ToGetParams(entities.UserID("user-id"))
+
+	assert.Equal(t, "false", input.Contacts)
+	assert.False(t, params.WithContacts)
+}
+
+func TestMessageThreadIndex_ToGetParams_WithContactsDefaultsFalse(t *testing.T) {
+	input := (&MessageThreadIndex{Owner: "+18005550199"}).Sanitize()
+	params := input.ToGetParams(entities.UserID("user-id"))
+
+	assert.Equal(t, "false", input.Contacts)
+	assert.False(t, params.WithContacts)
+}
+
+func TestMessageThreadIndex_ToGetParams_WithContactsInvalidNormalizesFalse(t *testing.T) {
+	input := (&MessageThreadIndex{Owner: "+18005550199", Contacts: "definitely"}).Sanitize()
+	params := input.ToGetParams(entities.UserID("user-id"))
+
+	assert.Equal(t, "false", input.Contacts)
+	assert.False(t, params.WithContacts)
+}

--- a/api/pkg/requests/request.go
+++ b/api/pkg/requests/request.go
@@ -120,6 +120,24 @@ func (input *request) removeEmptyStrings(values []string) []string {
 	return result
 }
 
+func sanitizeUniqueStrings(values []string, normalize func(string) string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = normalize(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+
+	return result
+}
+
 func (input *request) sanitizeMessageID(value string) string {
 	id := strings.Builder{}
 	for _, char := range value {

--- a/api/pkg/responses/contact_responses.go
+++ b/api/pkg/responses/contact_responses.go
@@ -12,4 +12,7 @@ type ContactResponse struct {
 type ContactsResponse struct {
 	response
 	Data []entities.Contact `json:"data"`
+	// Total is the number of contacts matching the request filter for the
+	// user, independent of the pagination skip/limit applied to Data.
+	Total int64 `json:"total" example:"57"`
 }

--- a/api/pkg/responses/contact_responses.go
+++ b/api/pkg/responses/contact_responses.go
@@ -1,0 +1,15 @@
+package responses
+
+import "github.com/NdoleStudio/httpsms/pkg/entities"
+
+// ContactResponse is the payload containing entities.Contact.
+type ContactResponse struct {
+	response
+	Data entities.Contact `json:"data"`
+}
+
+// ContactsResponse is the payload containing []entities.Contact.
+type ContactsResponse struct {
+	response
+	Data []entities.Contact `json:"data"`
+}

--- a/api/pkg/responses/contact_responses.go
+++ b/api/pkg/responses/contact_responses.go
@@ -8,6 +8,12 @@ type ContactResponse struct {
 	Data entities.Contact `json:"data"`
 }
 
+// ContactsCreatedResponse is the payload returned after creating contacts.
+type ContactsCreatedResponse struct {
+	response
+	Data []entities.Contact `json:"data"`
+}
+
 // ContactsResponse is the payload containing []entities.Contact.
 type ContactsResponse struct {
 	response

--- a/api/pkg/services/contact_service.go
+++ b/api/pkg/services/contact_service.go
@@ -84,6 +84,20 @@ func (service *ContactService) Index(ctx context.Context, userID entities.UserID
 	return contacts, nil
 }
 
+// Count returns the total number of contacts for a user matching the same
+// search filter as Index, ignoring pagination. It lets callers report an
+// accurate total independent of the current page's skip/limit.
+func (service *ContactService) Count(ctx context.Context, userID entities.UserID, params repositories.IndexParams) (int64, error) {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	total, err := service.repository.Count(ctx, userID, params)
+	if err != nil {
+		return 0, service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot count contacts for user [%s]", userID))
+	}
+	return total, nil
+}
+
 // Update persists changes to a contact and invalidates the cached map.
 func (service *ContactService) Update(ctx context.Context, contact *entities.Contact) error {
 	ctx, span, ctxLogger := service.tracer.StartWithLogger(ctx, service.logger)

--- a/api/pkg/services/contact_service.go
+++ b/api/pkg/services/contact_service.go
@@ -1,0 +1,179 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/cache"
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/google/uuid"
+)
+
+// contactMapCacheTTL bounds staleness of the cached phone-number -> contact map.
+// A 24h ceiling lets self-healing kick in even if an invalidation write is ever lost.
+const contactMapCacheTTL = 24 * time.Hour
+
+// ContactService owns contact CRUD and the cached phone-number-to-contact map
+// used by higher-level services (e.g. GetThreads) to resolve display names.
+type ContactService struct {
+	service
+	logger     telemetry.Logger
+	tracer     telemetry.Tracer
+	repository repositories.ContactRepository
+	cache      cache.Cache
+}
+
+// NewContactService creates a new ContactService.
+func NewContactService(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+	repository repositories.ContactRepository,
+	appCache cache.Cache,
+) (s *ContactService) {
+	return &ContactService{
+		logger:     logger.WithService(fmt.Sprintf("%T", s)),
+		tracer:     tracer,
+		repository: repository,
+		cache:      appCache,
+	}
+}
+
+func (service *ContactService) cacheKey(userID entities.UserID) string {
+	return fmt.Sprintf("contacts.map.%s", userID)
+}
+
+// CreateMany persists one or many contacts in a single batch and invalidates the cached map.
+func (service *ContactService) CreateMany(ctx context.Context, userID entities.UserID, contacts []*entities.Contact) error {
+	ctx, span, ctxLogger := service.tracer.StartWithLogger(ctx, service.logger)
+	defer span.End()
+
+	if err := service.repository.Store(ctx, contacts); err != nil {
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot store [%d] contacts for user [%s]", len(contacts), userID))
+	}
+
+	service.invalidate(ctx, ctxLogger, userID)
+	return nil
+}
+
+// Get returns a single contact scoped to the user.
+func (service *ContactService) Get(ctx context.Context, userID entities.UserID, contactID uuid.UUID) (*entities.Contact, error) {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	contact, err := service.repository.Load(ctx, userID, contactID)
+	if err != nil {
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCodef(err, stacktrace.GetCode(err), "cannot load contact [%s] for user [%s]", contactID, userID))
+	}
+	return contact, nil
+}
+
+// Index lists contacts for a user with the provided search/pagination params.
+func (service *ContactService) Index(ctx context.Context, userID entities.UserID, params repositories.IndexParams) (*[]entities.Contact, error) {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	contacts, err := service.repository.Index(ctx, userID, params)
+	if err != nil {
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot index contacts for user [%s]", userID))
+	}
+	return contacts, nil
+}
+
+// Update persists changes to a contact and invalidates the cached map.
+func (service *ContactService) Update(ctx context.Context, contact *entities.Contact) error {
+	ctx, span, ctxLogger := service.tracer.StartWithLogger(ctx, service.logger)
+	defer span.End()
+
+	if err := service.repository.Update(ctx, contact); err != nil {
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot update contact [%s] for user [%s]", contact.ID, contact.UserID))
+	}
+
+	service.invalidate(ctx, ctxLogger, contact.UserID)
+	return nil
+}
+
+// Delete removes a contact scoped to the user and invalidates the cached map.
+func (service *ContactService) Delete(ctx context.Context, userID entities.UserID, contactID uuid.UUID) error {
+	ctx, span, ctxLogger := service.tracer.StartWithLogger(ctx, service.logger)
+	defer span.End()
+
+	if err := service.repository.Delete(ctx, userID, contactID); err != nil {
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot delete contact [%s] for user [%s]", contactID, userID))
+	}
+
+	service.invalidate(ctx, ctxLogger, userID)
+	return nil
+}
+
+// GetContactMap returns a phone_number -> *Contact map for the given user, backed by a per-user cache.
+// FetchAll orders by updated_at ASC, so map construction naturally lets the most-recently-updated
+// contact win when two contacts share a phone number.
+func (service *ContactService) GetContactMap(ctx context.Context, userID entities.UserID) (map[string]*entities.Contact, error) {
+	ctx, span, ctxLogger := service.tracer.StartWithLogger(ctx, service.logger)
+	defer span.End()
+
+	key := service.cacheKey(userID)
+
+	raw, cacheErr := service.cache.Get(ctx, key)
+	switch {
+	case cacheErr != nil:
+		// The Cache interface has no typed miss signal, so a Get error is
+		// treated as "no cached value, rebuild from source". This is expected
+		// on cold starts, so log at Debug — a real fault surfaces via the
+		// subsequent repository/set calls or via cache-level metrics.
+		ctxLogger.Debug(fmt.Sprintf("contact map cache miss for user [%s]: %s", userID, cacheErr.Error()))
+	case raw == "":
+		// Empty string is the invalidation marker written by mutations.
+		ctxLogger.Debug(fmt.Sprintf("contact map cache invalidated for user [%s], rebuilding", userID))
+	default:
+		result := map[string]*entities.Contact{}
+		if err := json.Unmarshal([]byte(raw), &result); err != nil {
+			ctxLogger.Error(stacktrace.Propagatef(err, "cannot unmarshal contact map cache for user [%s], rebuilding", userID))
+		} else {
+			return result, nil
+		}
+	}
+
+	contacts, err := service.repository.FetchAll(ctx, userID)
+	if err != nil {
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot fetch contacts to build map for user [%s]", userID))
+	}
+
+	result := make(map[string]*entities.Contact, len(*contacts))
+	for index := range *contacts {
+		// Take a fresh copy of the slice element so the map holds a stable pointer
+		// that does not alias the underlying slice storage.
+		contact := (*contacts)[index]
+		for _, number := range contact.PhoneNumbers {
+			result[number] = &contact
+		}
+	}
+
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot marshal contact map cache payload for user [%s]", userID))
+		return result, nil
+	}
+	if err := service.cache.Set(ctx, key, string(encoded), contactMapCacheTTL); err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot populate contact map cache for user [%s]", userID))
+	}
+
+	return result, nil
+}
+
+// invalidate writes an empty marker under the user's cache key. The Cache
+// interface has no Delete; the marker is treated as a rebuild trigger by
+// GetContactMap. Failures are logged at Error but do not fail the calling
+// mutation: the DB write already succeeded, and the 24h TTL bounds staleness.
+// See docs in contact_service_test.go / task-6-report.md for the rationale.
+func (service *ContactService) invalidate(ctx context.Context, ctxLogger telemetry.Logger, userID entities.UserID) {
+	key := service.cacheKey(userID)
+	if err := service.cache.Set(ctx, key, "", contactMapCacheTTL); err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot invalidate contact map cache for user [%s] with key [%s]", userID, key))
+	}
+}

--- a/api/pkg/services/contact_service.go
+++ b/api/pkg/services/contact_service.go
@@ -124,6 +124,19 @@ func (service *ContactService) Delete(ctx context.Context, userID entities.UserI
 	return nil
 }
 
+// DeleteAllForUser removes every contact owned by a user and invalidates the cached map.
+func (service *ContactService) DeleteAllForUser(ctx context.Context, userID entities.UserID) error {
+	ctx, span, ctxLogger := service.tracer.StartWithLogger(ctx, service.logger)
+	defer span.End()
+
+	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot delete all contacts for user [%s]", userID))
+	}
+
+	service.invalidate(ctx, ctxLogger, userID)
+	return nil
+}
+
 // GetContactMap returns a phone_number -> *Contact map for the given user, backed by a per-user cache.
 // FetchAll orders by updated_at ASC, so map construction naturally lets the most-recently-updated
 // contact win when two contacts share a phone number.

--- a/api/pkg/services/contact_service.go
+++ b/api/pkg/services/contact_service.go
@@ -14,9 +14,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// contactCacheTTL bounds staleness if an invalidation is ever missed.
+// contactMapCacheTTL bounds cross-instance staleness because invalidation is process-local.
 const (
-	contactMapCacheTTL               = 24 * time.Hour
+	contactMapCacheTTL               = 5 * time.Minute
 	contactGenerationCleanupInterval = time.Hour
 )
 

--- a/api/pkg/services/contact_service.go
+++ b/api/pkg/services/contact_service.go
@@ -2,30 +2,46 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
-	"github.com/NdoleStudio/httpsms/pkg/cache"
 	"github.com/NdoleStudio/httpsms/pkg/entities"
 	"github.com/NdoleStudio/httpsms/pkg/repositories"
 	"github.com/NdoleStudio/httpsms/pkg/telemetry"
 	"github.com/NdoleStudio/stacktrace"
+	"github.com/dgraph-io/ristretto/v2"
 	"github.com/google/uuid"
 )
 
-// contactMapCacheTTL bounds staleness of the cached phone-number -> contact map.
-// A 24h ceiling lets self-healing kick in even if an invalidation write is ever lost.
-const contactMapCacheTTL = 24 * time.Hour
+// contactCacheTTL bounds staleness if an invalidation is ever missed.
+const (
+	contactMapCacheTTL               = 24 * time.Hour
+	contactGenerationCleanupInterval = time.Hour
+)
 
-// ContactService owns contact CRUD and the cached phone-number-to-contact map
-// used by higher-level services (e.g. GetThreads) to resolve display names.
+// ContactCacheEntry stores a contact together with its user's cache generation.
+type ContactCacheEntry struct {
+	contact    *entities.Contact
+	generation uint64
+}
+
+type contactGeneration struct {
+	value      uint64
+	lastAccess time.Time
+}
+
+// ContactService owns contact CRUD and phone-number contact lookups.
 type ContactService struct {
 	service
-	logger     telemetry.Logger
-	tracer     telemetry.Tracer
-	repository repositories.ContactRepository
-	cache      cache.Cache
+	logger                telemetry.Logger
+	tracer                telemetry.Tracer
+	repository            repositories.ContactRepository
+	cache                 *ristretto.Cache[string, ContactCacheEntry]
+	generationMu          sync.Mutex
+	generations           map[entities.UserID]contactGeneration
+	nextGeneration        uint64
+	lastGenerationCleanup time.Time
 }
 
 // NewContactService creates a new ContactService.
@@ -33,30 +49,87 @@ func NewContactService(
 	logger telemetry.Logger,
 	tracer telemetry.Tracer,
 	repository repositories.ContactRepository,
-	appCache cache.Cache,
+	contactCache *ristretto.Cache[string, ContactCacheEntry],
 ) (s *ContactService) {
 	return &ContactService{
-		logger:     logger.WithService(fmt.Sprintf("%T", s)),
-		tracer:     tracer,
-		repository: repository,
-		cache:      appCache,
+		logger:      logger.WithService(fmt.Sprintf("%T", s)),
+		tracer:      tracer,
+		repository:  repository,
+		cache:       contactCache,
+		generations: make(map[entities.UserID]contactGeneration),
 	}
 }
 
-func (service *ContactService) cacheKey(userID entities.UserID) string {
-	return fmt.Sprintf("contacts.map.%s", userID)
+func (service *ContactService) cacheKey(userID entities.UserID, phoneNumber string) string {
+	return fmt.Sprintf("%s|%s", userID, phoneNumber)
 }
 
-// CreateMany persists one or many contacts in a single batch and invalidates the cached map.
+func (service *ContactService) generation(userID entities.UserID) uint64 {
+	now := time.Now()
+	service.generationMu.Lock()
+	defer service.generationMu.Unlock()
+
+	service.expireGenerationsLocked(now)
+	if generation, ok := service.generations[userID]; ok {
+		generation.lastAccess = now
+		service.generations[userID] = generation
+		return generation.value
+	}
+
+	service.nextGeneration++
+	service.generations[userID] = contactGeneration{
+		value:      service.nextGeneration,
+		lastAccess: now,
+	}
+	return service.nextGeneration
+}
+
+func (service *ContactService) advanceGeneration(userID entities.UserID) {
+	now := time.Now()
+	service.generationMu.Lock()
+	defer service.generationMu.Unlock()
+
+	service.expireGenerationsLocked(now)
+	service.nextGeneration++
+	service.generations[userID] = contactGeneration{
+		value:      service.nextGeneration,
+		lastAccess: now,
+	}
+}
+
+func (service *ContactService) expireGenerations(now time.Time) {
+	service.generationMu.Lock()
+	defer service.generationMu.Unlock()
+	service.expireGenerationsLocked(now)
+}
+
+func (service *ContactService) expireGenerationsLocked(now time.Time) {
+	if !service.lastGenerationCleanup.IsZero() &&
+		now.Sub(service.lastGenerationCleanup) < contactGenerationCleanupInterval {
+		return
+	}
+	for userID, generation := range service.generations {
+		if now.Sub(generation.lastAccess) >= contactMapCacheTTL {
+			delete(service.generations, userID)
+		}
+	}
+	service.lastGenerationCleanup = now
+}
+
+// CreateMany persists one or many contacts in a single batch.
 func (service *ContactService) CreateMany(ctx context.Context, userID entities.UserID, contacts []*entities.Contact) error {
-	ctx, span, ctxLogger := service.tracer.StartWithLogger(ctx, service.logger)
+	ctx, span := service.tracer.Start(ctx)
 	defer span.End()
 
 	if err := service.repository.Store(ctx, contacts); err != nil {
 		return service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot store [%d] contacts for user [%s]", len(contacts), userID))
 	}
 
-	service.invalidate(ctx, ctxLogger, userID)
+	phoneNumbers := make([]string, 0)
+	for _, contact := range contacts {
+		phoneNumbers = append(phoneNumbers, contact.PhoneNumbers...)
+	}
+	service.invalidate(userID, phoneNumbers)
 	return nil
 }
 
@@ -98,109 +171,118 @@ func (service *ContactService) Count(ctx context.Context, userID entities.UserID
 	return total, nil
 }
 
-// Update persists changes to a contact and invalidates the cached map.
-func (service *ContactService) Update(ctx context.Context, contact *entities.Contact) error {
-	ctx, span, ctxLogger := service.tracer.StartWithLogger(ctx, service.logger)
+// Update persists changes to a contact and invalidates its old and new numbers.
+func (service *ContactService) Update(ctx context.Context, contact *entities.Contact, previousPhoneNumbers []string) error {
+	ctx, span := service.tracer.Start(ctx)
 	defer span.End()
 
 	if err := service.repository.Update(ctx, contact); err != nil {
 		return service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot update contact [%s] for user [%s]", contact.ID, contact.UserID))
 	}
 
-	service.invalidate(ctx, ctxLogger, contact.UserID)
+	phoneNumbers := make([]string, 0, len(previousPhoneNumbers)+len(contact.PhoneNumbers))
+	phoneNumbers = append(phoneNumbers, previousPhoneNumbers...)
+	phoneNumbers = append(phoneNumbers, contact.PhoneNumbers...)
+	service.invalidate(contact.UserID, phoneNumbers)
 	return nil
 }
 
-// Delete removes a contact scoped to the user and invalidates the cached map.
+// Delete removes a contact scoped to the user and invalidates its phone numbers.
 func (service *ContactService) Delete(ctx context.Context, userID entities.UserID, contactID uuid.UUID) error {
-	ctx, span, ctxLogger := service.tracer.StartWithLogger(ctx, service.logger)
+	ctx, span := service.tracer.Start(ctx)
 	defer span.End()
+
+	contact, err := service.repository.Load(ctx, userID, contactID)
+	if err != nil {
+		return service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCodef(err, stacktrace.GetCode(err), "cannot load contact [%s] for user [%s] before delete", contactID, userID))
+	}
 
 	if err := service.repository.Delete(ctx, userID, contactID); err != nil {
 		return service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot delete contact [%s] for user [%s]", contactID, userID))
 	}
 
-	service.invalidate(ctx, ctxLogger, userID)
+	service.invalidate(userID, contact.PhoneNumbers)
 	return nil
 }
 
-// DeleteAllForUser removes every contact owned by a user and invalidates the cached map.
+// DeleteAllForUser removes every contact owned by a user and clears cached contacts.
 func (service *ContactService) DeleteAllForUser(ctx context.Context, userID entities.UserID) error {
-	ctx, span, ctxLogger := service.tracer.StartWithLogger(ctx, service.logger)
+	ctx, span := service.tracer.Start(ctx)
 	defer span.End()
 
 	if err := service.repository.DeleteAllForUser(ctx, userID); err != nil {
 		return service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot delete all contacts for user [%s]", userID))
 	}
 
-	service.invalidate(ctx, ctxLogger, userID)
+	service.invalidate(userID, nil)
 	return nil
 }
 
-// GetContactMap returns a phone_number -> *Contact map for the given user, backed by a per-user cache.
-// FetchAll orders by updated_at ASC, so map construction naturally lets the most-recently-updated
-// contact win when two contacts share a phone number.
-func (service *ContactService) GetContactMap(ctx context.Context, userID entities.UserID) (map[string]*entities.Contact, error) {
+// GetContactMap resolves only the requested phone numbers. Each contact is
+// cached independently by user and phone number.
+func (service *ContactService) GetContactMap(ctx context.Context, userID entities.UserID, phoneNumbers []string) (map[string]*entities.Contact, error) {
 	ctx, span, ctxLogger := service.tracer.StartWithLogger(ctx, service.logger)
 	defer span.End()
 
-	key := service.cacheKey(userID)
-
-	raw, cacheErr := service.cache.Get(ctx, key)
-	switch {
-	case cacheErr != nil:
-		// The Cache interface has no typed miss signal, so a Get error is
-		// treated as "no cached value, rebuild from source". This is expected
-		// on cold starts, so log at Debug — a real fault surfaces via the
-		// subsequent repository/set calls or via cache-level metrics.
-		ctxLogger.Debug(fmt.Sprintf("contact map cache miss for user [%s]: %s", userID, cacheErr.Error()))
-	case raw == "":
-		// Empty string is the invalidation marker written by mutations.
-		ctxLogger.Debug(fmt.Sprintf("contact map cache invalidated for user [%s], rebuilding", userID))
-	default:
-		result := map[string]*entities.Contact{}
-		if err := json.Unmarshal([]byte(raw), &result); err != nil {
-			ctxLogger.Error(stacktrace.Propagatef(err, "cannot unmarshal contact map cache for user [%s], rebuilding", userID))
-		} else {
-			return result, nil
+	generation := service.generation(userID)
+	result := make(map[string]*entities.Contact, len(phoneNumbers))
+	missing := make([]string, 0, len(phoneNumbers))
+	missingSet := make(map[string]struct{}, len(phoneNumbers))
+	requested := make(map[string]struct{}, len(phoneNumbers))
+	for _, phoneNumber := range phoneNumbers {
+		if _, seen := requested[phoneNumber]; seen {
+			continue
 		}
-	}
-
-	contacts, err := service.repository.FetchAll(ctx, userID)
-	if err != nil {
-		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot fetch contacts to build map for user [%s]", userID))
-	}
-
-	result := make(map[string]*entities.Contact, len(*contacts))
-	for index := range *contacts {
-		// Take a fresh copy of the slice element so the map holds a stable pointer
-		// that does not alias the underlying slice storage.
-		contact := (*contacts)[index]
-		for _, number := range contact.PhoneNumbers {
-			result[number] = &contact
+		requested[phoneNumber] = struct{}{}
+		key := service.cacheKey(userID, phoneNumber)
+		if entry, found := service.cache.Get(key); found {
+			if entry.generation == generation {
+				if entry.contact != nil {
+					result[phoneNumber] = entry.contact
+				}
+				continue
+			}
+			service.cache.Del(key)
 		}
+		missing = append(missing, phoneNumber)
+		missingSet[phoneNumber] = struct{}{}
 	}
 
-	encoded, err := json.Marshal(result)
-	if err != nil {
-		ctxLogger.Error(stacktrace.Propagatef(err, "cannot marshal contact map cache payload for user [%s]", userID))
+	if len(missing) == 0 {
 		return result, nil
 	}
-	if err := service.cache.Set(ctx, key, string(encoded), contactMapCacheTTL); err != nil {
-		ctxLogger.Error(stacktrace.Propagatef(err, "cannot populate contact map cache for user [%s]", userID))
+
+	contacts, err := service.repository.FetchByPhoneNumbers(ctx, userID, missing)
+	if err != nil {
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot fetch contacts by phone numbers for user [%s]", userID))
+	}
+
+	for index := range *contacts {
+		contact := (*contacts)[index]
+		for _, phoneNumber := range contact.PhoneNumbers {
+			if _, requested := missingSet[phoneNumber]; requested {
+				result[phoneNumber] = &contact
+			}
+		}
+	}
+
+	if service.generation(userID) == generation {
+		for _, phoneNumber := range missing {
+			contact := result[phoneNumber]
+			entry := ContactCacheEntry{contact: contact, generation: generation}
+			if accepted := service.cache.SetWithTTL(service.cacheKey(userID, phoneNumber), entry, 1, contactMapCacheTTL); !accepted {
+				ctxLogger.Error(stacktrace.NewErrorf("cannot cache contact lookup for user [%s] and phone number [%s]", userID, phoneNumber))
+			}
+		}
 	}
 
 	return result, nil
 }
 
-// invalidate writes an empty marker under the user's cache key. The Cache
-// interface has no Delete; the marker is treated as a rebuild trigger by
-// GetContactMap. Failures are logged at Error but do not fail the calling
-// mutation: the DB write already succeeded, and the 24h TTL bounds staleness.
-// See docs in contact_service_test.go / task-6-report.md for the rationale.
-func (service *ContactService) invalidate(ctx context.Context, ctxLogger telemetry.Logger, userID entities.UserID) {
-	key := service.cacheKey(userID)
-	if err := service.cache.Set(ctx, key, "", contactMapCacheTTL); err != nil {
-		ctxLogger.Error(stacktrace.Propagatef(err, "cannot invalidate contact map cache for user [%s] with key [%s]", userID, key))
+func (service *ContactService) invalidate(userID entities.UserID, phoneNumbers []string) {
+	service.advanceGeneration(userID)
+	service.cache.Wait()
+	for _, phoneNumber := range phoneNumbers {
+		service.cache.Del(service.cacheKey(userID, phoneNumber))
 	}
 }

--- a/api/pkg/services/contact_service_test.go
+++ b/api/pkg/services/contact_service_test.go
@@ -90,6 +90,7 @@ type fakeContactRepo struct {
 	updateCalls []*entities.Contact
 	loadCalls   []loadCall
 	indexCalls  []indexCall
+	countCalls  []indexCall
 	deleteCalls []deleteCall
 	fetchAll    int
 
@@ -97,10 +98,12 @@ type fakeContactRepo struct {
 	updateErr error
 	loadErr   error
 	indexErr  error
+	countErr  error
 	deleteErr error
 	fetchErr  error
 
 	indexResult []entities.Contact
+	countResult int64
 }
 
 type loadCall struct {
@@ -167,6 +170,17 @@ func (r *fakeContactRepo) Index(_ context.Context, userID entities.UserID, param
 	}
 	out := append([]entities.Contact{}, r.indexResult...)
 	return &out, nil
+}
+
+func (r *fakeContactRepo) Count(_ context.Context, userID entities.UserID, params repositories.IndexParams) (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.countCalls = append(r.countCalls, indexCall{userID: userID, params: params})
+	if r.countErr != nil {
+		return 0, r.countErr
+	}
+	return r.countResult, nil
 }
 
 func (r *fakeContactRepo) FetchAll(_ context.Context, _ entities.UserID) (*[]entities.Contact, error) {
@@ -581,6 +595,29 @@ func TestContactService_Index_RepositoryErrorIsWrapped(t *testing.T) {
 	_, err := service.Index(context.Background(), entities.UserID("u1"), repositories.IndexParams{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "index boom")
+}
+
+func TestContactService_Count_DelegatesParamsAndReturnsTotal(t *testing.T) {
+	repo := &fakeContactRepo{countResult: 57}
+	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+
+	params := repositories.IndexParams{Skip: 5, Limit: 10, Query: "Ali"}
+	total, err := service.Count(context.Background(), entities.UserID("u1"), params)
+	require.NoError(t, err)
+	assert.Equal(t, int64(57), total)
+
+	require.Len(t, repo.countCalls, 1)
+	assert.Equal(t, entities.UserID("u1"), repo.countCalls[0].userID)
+	assert.Equal(t, params, repo.countCalls[0].params)
+}
+
+func TestContactService_Count_RepositoryErrorIsWrapped(t *testing.T) {
+	repo := &fakeContactRepo{countErr: errors.New("count boom")}
+	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+
+	_, err := service.Count(context.Background(), entities.UserID("u1"), repositories.IndexParams{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "count boom")
 }
 
 func TestContactService_Update_RepositoryErrorIsWrappedAndSkipsInvalidation(t *testing.T) {

--- a/api/pkg/services/contact_service_test.go
+++ b/api/pkg/services/contact_service_test.go
@@ -1,0 +1,616 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// --- fake cache -------------------------------------------------------------
+
+type fakeCache struct {
+	mu     sync.Mutex
+	store  map[string]string
+	getErr error
+	setErr error
+	sets   []cacheSetCall
+	gets   int
+}
+
+type cacheSetCall struct {
+	key   string
+	value string
+	ttl   time.Duration
+}
+
+func newFakeCache() *fakeCache { return &fakeCache{store: map[string]string{}} }
+
+func (c *fakeCache) Get(_ context.Context, key string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.gets++
+	if c.getErr != nil {
+		return "", c.getErr
+	}
+	value, ok := c.store[key]
+	if !ok {
+		return "", stacktrace.NewErrorf("no item found in cache with key [%s]", key)
+	}
+	return value, nil
+}
+
+func (c *fakeCache) Set(_ context.Context, key, value string, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.sets = append(c.sets, cacheSetCall{key: key, value: value, ttl: ttl})
+	if c.setErr != nil {
+		return c.setErr
+	}
+	c.store[key] = value
+	return nil
+}
+
+// setsFor returns the recorded Set calls for a given key.
+func (c *fakeCache) setsFor(key string) []cacheSetCall {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var out []cacheSetCall
+	for _, s := range c.sets {
+		if s.key == key {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// --- fake repository --------------------------------------------------------
+
+type fakeContactRepo struct {
+	mu sync.Mutex
+
+	contacts []*entities.Contact
+
+	storeCalls  [][]*entities.Contact
+	updateCalls []*entities.Contact
+	loadCalls   []loadCall
+	indexCalls  []indexCall
+	deleteCalls []deleteCall
+	fetchAll    int
+
+	storeErr  error
+	updateErr error
+	loadErr   error
+	indexErr  error
+	deleteErr error
+	fetchErr  error
+
+	indexResult []entities.Contact
+}
+
+type loadCall struct {
+	userID entities.UserID
+	id     uuid.UUID
+}
+
+type indexCall struct {
+	userID entities.UserID
+	params repositories.IndexParams
+}
+
+type deleteCall struct {
+	userID entities.UserID
+	id     uuid.UUID
+}
+
+func (r *fakeContactRepo) Store(_ context.Context, contacts []*entities.Contact) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.storeCalls = append(r.storeCalls, contacts)
+	if r.storeErr != nil {
+		return r.storeErr
+	}
+	r.contacts = append(r.contacts, contacts...)
+	return nil
+}
+
+func (r *fakeContactRepo) Update(_ context.Context, contact *entities.Contact) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.updateCalls = append(r.updateCalls, contact)
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	return nil
+}
+
+func (r *fakeContactRepo) Load(_ context.Context, userID entities.UserID, id uuid.UUID) (*entities.Contact, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.loadCalls = append(r.loadCalls, loadCall{userID: userID, id: id})
+	if r.loadErr != nil {
+		return nil, r.loadErr
+	}
+	for _, c := range r.contacts {
+		if c.ID == id && c.UserID == userID {
+			return c, nil
+		}
+	}
+	return nil, stacktrace.NewErrorWithCodef(repositories.ErrCodeNotFound, "contact [%s] not found", id)
+}
+
+func (r *fakeContactRepo) Index(_ context.Context, userID entities.UserID, params repositories.IndexParams) (*[]entities.Contact, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.indexCalls = append(r.indexCalls, indexCall{userID: userID, params: params})
+	if r.indexErr != nil {
+		return nil, r.indexErr
+	}
+	out := append([]entities.Contact{}, r.indexResult...)
+	return &out, nil
+}
+
+func (r *fakeContactRepo) FetchAll(_ context.Context, _ entities.UserID) (*[]entities.Contact, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.fetchAll++
+	if r.fetchErr != nil {
+		return nil, r.fetchErr
+	}
+	out := make([]entities.Contact, 0, len(r.contacts))
+	for _, c := range r.contacts {
+		out = append(out, *c)
+	}
+	return &out, nil
+}
+
+func (r *fakeContactRepo) Delete(_ context.Context, userID entities.UserID, id uuid.UUID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.deleteCalls = append(r.deleteCalls, deleteCall{userID: userID, id: id})
+	return r.deleteErr
+}
+
+func (r *fakeContactRepo) DeleteAllForUser(_ context.Context, _ entities.UserID) error { return nil }
+
+// --- recording logger -------------------------------------------------------
+
+type recordingLogger struct {
+	*noopLogger
+	mu     sync.Mutex
+	errors []error
+	warns  []error
+	infos  []string
+	debugs []string
+}
+
+func newRecordingLogger() *recordingLogger {
+	return &recordingLogger{noopLogger: &noopLogger{}}
+}
+
+func (l *recordingLogger) Error(err error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.errors = append(l.errors, err)
+}
+
+func (l *recordingLogger) Warn(err error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, err)
+}
+
+func (l *recordingLogger) Info(v string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.infos = append(l.infos, v)
+}
+
+func (l *recordingLogger) Debug(v string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.debugs = append(l.debugs, v)
+}
+
+func (l *recordingLogger) WithService(_ string) telemetry.Logger   { return l }
+func (l *recordingLogger) WithString(_, _ string) telemetry.Logger { return l }
+func (l *recordingLogger) WithSpan(_ trace.SpanContext) telemetry.Logger {
+	return l
+}
+
+func (l *recordingLogger) errorCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.errors)
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func newContactServiceForTest(t *testing.T, repo repositories.ContactRepository, appCache *fakeCache, logger telemetry.Logger) *ContactService {
+	t.Helper()
+	if logger == nil {
+		logger = &noopLogger{}
+	}
+	tracer := telemetry.NewOtelLogger("test", logger)
+	return NewContactService(logger, tracer, repo, appCache)
+}
+
+// --- tests -----------------------------------------------------------------
+
+func TestContactService_GetContactMap_TieBreakMostRecentlyUpdatedWins(t *testing.T) {
+	older := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "Old", PhoneNumbers: pq.StringArray{"+18005550199"}, UpdatedAt: time.Now().Add(-time.Hour)}
+	newer := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "New", PhoneNumbers: pq.StringArray{"+18005550199"}, UpdatedAt: time.Now()}
+	repo := &fakeContactRepo{contacts: []*entities.Contact{older, newer}}
+	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+
+	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+
+	require.NotNil(t, result["+18005550199"])
+	assert.Equal(t, "New", result["+18005550199"].Name)
+	assert.Equal(t, newer.ID, result["+18005550199"].ID)
+}
+
+func TestContactService_GetContactMap_AllPhoneNumbersMapToOneContact(t *testing.T) {
+	contact := &entities.Contact{
+		ID:           uuid.New(),
+		UserID:       "u1",
+		Name:         "Alice",
+		PhoneNumbers: pq.StringArray{"+18005550199", "+18005550100", "+18005550111"},
+	}
+	repo := &fakeContactRepo{contacts: []*entities.Contact{contact}}
+	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+
+	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+
+	for _, num := range contact.PhoneNumbers {
+		got, ok := result[num]
+		require.True(t, ok, "missing entry for %s", num)
+		assert.Equal(t, contact.ID, got.ID)
+		assert.Equal(t, "Alice", got.Name)
+	}
+}
+
+func TestContactService_GetContactMap_NoCollisionDistinctPointersPerContact(t *testing.T) {
+	a := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}, UpdatedAt: time.Now().Add(-2 * time.Hour)}
+	b := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "Bob", PhoneNumbers: pq.StringArray{"+18005550100"}, UpdatedAt: time.Now().Add(-time.Hour)}
+	c := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "Carol", PhoneNumbers: pq.StringArray{"+18005550111"}, UpdatedAt: time.Now()}
+	repo := &fakeContactRepo{contacts: []*entities.Contact{a, b, c}}
+	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+
+	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+
+	require.Len(t, result, 3)
+	assert.Equal(t, "Alice", result["+18005550199"].Name)
+	assert.Equal(t, "Bob", result["+18005550100"].Name)
+	assert.Equal(t, "Carol", result["+18005550111"].Name)
+
+	// Each entry must point to a stable, independent value.
+	assert.NotSame(t, result["+18005550199"], result["+18005550100"])
+	assert.NotSame(t, result["+18005550100"], result["+18005550111"])
+
+	// Mutating the returned pointer must not corrupt other entries.
+	result["+18005550199"].Name = "Mutated"
+	assert.Equal(t, "Bob", result["+18005550100"].Name)
+	assert.Equal(t, "Carol", result["+18005550111"].Name)
+}
+
+func TestContactService_GetContactMap_CacheHitAvoidsFetchAll(t *testing.T) {
+	repo := &fakeContactRepo{contacts: []*entities.Contact{{
+		ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"},
+	}}}
+	appCache := newFakeCache()
+	service := newContactServiceForTest(t, repo, appCache, nil)
+
+	_, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+	_, err = service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, repo.fetchAll, "second call must hit cache")
+}
+
+func TestContactService_GetContactMap_EmptyMarkerTriggersRebuild(t *testing.T) {
+	repo := &fakeContactRepo{contacts: []*entities.Contact{{
+		ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"},
+	}}}
+	appCache := newFakeCache()
+	// Pre-seed the invalidation marker.
+	require.NoError(t, appCache.Set(context.Background(), "contacts.map.u1", "", time.Hour))
+	logger := newRecordingLogger()
+	service := newContactServiceForTest(t, repo, appCache, logger)
+
+	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, repo.fetchAll, "empty marker must force rebuild")
+	assert.Equal(t, "Alice", result["+18005550199"].Name)
+	assert.Equal(t, 0, logger.errorCount(), "empty marker rebuild must not log an error")
+}
+
+func TestContactService_GetContactMap_CorruptCacheRebuildsAndLogs(t *testing.T) {
+	repo := &fakeContactRepo{contacts: []*entities.Contact{{
+		ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"},
+	}}}
+	appCache := newFakeCache()
+	require.NoError(t, appCache.Set(context.Background(), "contacts.map.u1", "not-json{", time.Hour))
+	logger := newRecordingLogger()
+	service := newContactServiceForTest(t, repo, appCache, logger)
+
+	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, repo.fetchAll, "corrupt cache must force rebuild")
+	assert.Equal(t, "Alice", result["+18005550199"].Name)
+	assert.GreaterOrEqual(t, logger.errorCount(), 1, "corrupt cache must log an error")
+}
+
+func TestContactService_GetContactMap_CachePopulationErrorReturnsMapAndLogs(t *testing.T) {
+	repo := &fakeContactRepo{contacts: []*entities.Contact{{
+		ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"},
+	}}}
+	appCache := newFakeCache()
+	appCache.setErr = errors.New("boom")
+	logger := newRecordingLogger()
+	service := newContactServiceForTest(t, repo, appCache, logger)
+
+	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err, "population failure must not fail the caller")
+	require.NotNil(t, result["+18005550199"])
+	assert.Equal(t, "Alice", result["+18005550199"].Name)
+	assert.GreaterOrEqual(t, logger.errorCount(), 1, "population failure must be logged")
+}
+
+func TestContactService_GetContactMap_CachedRoundTripPreservesData(t *testing.T) {
+	// After the first call populates the cache, verify the cached payload is well-formed JSON
+	// mapping phone numbers to contact objects and that a second call returns equivalent data.
+	repo := &fakeContactRepo{contacts: []*entities.Contact{{
+		ID:           uuid.New(),
+		UserID:       "u1",
+		Name:         "Alice",
+		PhoneNumbers: pq.StringArray{"+18005550199", "+18005550100"},
+	}}}
+	appCache := newFakeCache()
+	service := newContactServiceForTest(t, repo, appCache, nil)
+
+	first, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+
+	raw, err := appCache.Get(context.Background(), "contacts.map.u1")
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	decoded := map[string]*entities.Contact{}
+	require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
+	assert.Equal(t, first["+18005550199"].ID, decoded["+18005550199"].ID)
+
+	second, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+	assert.Equal(t, first["+18005550199"].ID, second["+18005550199"].ID)
+	assert.Equal(t, first["+18005550100"].ID, second["+18005550100"].ID)
+}
+
+// --- mutation invalidation tests ------------------------------------------
+
+func TestContactService_CreateMany_InvalidatesCacheExactlyOnce(t *testing.T) {
+	repo := &fakeContactRepo{contacts: []*entities.Contact{{
+		ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"},
+	}}}
+	appCache := newFakeCache()
+	service := newContactServiceForTest(t, repo, appCache, nil)
+
+	// Warm the cache.
+	_, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+	require.Equal(t, 1, repo.fetchAll)
+
+	setsBefore := len(appCache.setsFor("contacts.map.u1"))
+
+	added := []*entities.Contact{
+		{ID: uuid.New(), UserID: "u1", Name: "Bob", PhoneNumbers: pq.StringArray{"+18005550100"}},
+		{ID: uuid.New(), UserID: "u1", Name: "Carol", PhoneNumbers: pq.StringArray{"+18005550111"}},
+	}
+	require.NoError(t, service.CreateMany(context.Background(), entities.UserID("u1"), added))
+
+	assert.Len(t, repo.storeCalls, 1, "batch must be persisted in a single Store call")
+	assert.Equal(t, added, repo.storeCalls[0])
+
+	afterInvalidation := appCache.setsFor("contacts.map.u1")
+	require.Len(t, afterInvalidation, setsBefore+1, "CreateMany must invalidate the cache exactly once")
+	assert.Equal(t, "", afterInvalidation[len(afterInvalidation)-1].value, "invalidation marker must be empty")
+
+	// Next GetContactMap rebuilds.
+	_, err = service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+	assert.Equal(t, 2, repo.fetchAll)
+}
+
+func TestContactService_Update_InvalidatesCacheExactlyOnce(t *testing.T) {
+	c := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}}
+	repo := &fakeContactRepo{contacts: []*entities.Contact{c}}
+	appCache := newFakeCache()
+	service := newContactServiceForTest(t, repo, appCache, nil)
+
+	_, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+	setsBefore := len(appCache.setsFor("contacts.map.u1"))
+
+	updated := *c
+	updated.Name = "Alicia"
+	require.NoError(t, service.Update(context.Background(), &updated))
+
+	require.Len(t, repo.updateCalls, 1)
+	assert.Equal(t, "Alicia", repo.updateCalls[0].Name)
+	assert.Equal(t, entities.UserID("u1"), repo.updateCalls[0].UserID)
+
+	afterInvalidation := appCache.setsFor("contacts.map.u1")
+	require.Len(t, afterInvalidation, setsBefore+1)
+	assert.Equal(t, "", afterInvalidation[len(afterInvalidation)-1].value)
+}
+
+func TestContactService_Delete_InvalidatesCacheExactlyOnce(t *testing.T) {
+	id := uuid.New()
+	repo := &fakeContactRepo{contacts: []*entities.Contact{{ID: id, UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}}}}
+	appCache := newFakeCache()
+	service := newContactServiceForTest(t, repo, appCache, nil)
+
+	_, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+	setsBefore := len(appCache.setsFor("contacts.map.u1"))
+
+	require.NoError(t, service.Delete(context.Background(), entities.UserID("u1"), id))
+
+	require.Len(t, repo.deleteCalls, 1)
+	assert.Equal(t, deleteCall{userID: "u1", id: id}, repo.deleteCalls[0])
+
+	afterInvalidation := appCache.setsFor("contacts.map.u1")
+	require.Len(t, afterInvalidation, setsBefore+1)
+	assert.Equal(t, "", afterInvalidation[len(afterInvalidation)-1].value)
+}
+
+func TestContactService_InvalidationFailure_LogsErrorButReturnsNil(t *testing.T) {
+	// Persistence succeeded but cache invalidation failed. The mutation itself
+	// must not return an error (see report: chosen contract), but MUST log the
+	// invalidation failure explicitly at Error level so operators are alerted.
+	repo := &fakeContactRepo{}
+	appCache := newFakeCache()
+	appCache.setErr = errors.New("cache down")
+	logger := newRecordingLogger()
+	service := newContactServiceForTest(t, repo, appCache, logger)
+
+	err := service.CreateMany(context.Background(), entities.UserID("u1"), []*entities.Contact{{
+		ID: uuid.New(), UserID: "u1", Name: "Bob", PhoneNumbers: pq.StringArray{"+18005550100"},
+	}})
+	require.NoError(t, err, "mutation must not surface invalidation failure to caller")
+
+	// Repository actually got the write.
+	require.Len(t, repo.storeCalls, 1)
+	// The invalidation attempt was logged as an error.
+	assert.GreaterOrEqual(t, logger.errorCount(), 1, "invalidation failure must be logged as error")
+}
+
+// --- CRUD delegation and user scope tests ---------------------------------
+
+func TestContactService_CreateMany_PersistsBatchInSingleCall(t *testing.T) {
+	repo := &fakeContactRepo{}
+	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+
+	batch := []*entities.Contact{
+		{ID: uuid.New(), UserID: "u1", Name: "A", PhoneNumbers: pq.StringArray{"+18005550100"}},
+		{ID: uuid.New(), UserID: "u1", Name: "B", PhoneNumbers: pq.StringArray{"+18005550111"}},
+	}
+	require.NoError(t, service.CreateMany(context.Background(), entities.UserID("u1"), batch))
+
+	require.Len(t, repo.storeCalls, 1)
+	assert.Equal(t, batch, repo.storeCalls[0])
+}
+
+func TestContactService_CreateMany_RepositoryErrorIsWrapped(t *testing.T) {
+	repo := &fakeContactRepo{storeErr: errors.New("db down")}
+	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+
+	err := service.CreateMany(context.Background(), entities.UserID("u1"), []*entities.Contact{{
+		ID: uuid.New(), UserID: "u1", Name: "A", PhoneNumbers: pq.StringArray{"+18005550100"},
+	}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db down")
+}
+
+func TestContactService_Get_DelegatesWithUserScope(t *testing.T) {
+	id := uuid.New()
+	other := uuid.New()
+	repo := &fakeContactRepo{contacts: []*entities.Contact{
+		{ID: id, UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}},
+		{ID: other, UserID: "u2", Name: "Bob", PhoneNumbers: pq.StringArray{"+18005550100"}},
+	}}
+	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+
+	got, err := service.Get(context.Background(), entities.UserID("u1"), id)
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", got.Name)
+
+	// Wrong user scope must not resolve the contact.
+	_, err = service.Get(context.Background(), entities.UserID("u1"), other)
+	require.Error(t, err)
+	assert.Equal(t, repositories.ErrCodeNotFound, stacktrace.GetCode(err))
+}
+
+func TestContactService_Index_DelegatesParams(t *testing.T) {
+	want := []entities.Contact{{ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}}}
+	repo := &fakeContactRepo{indexResult: want}
+	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+
+	params := repositories.IndexParams{Skip: 5, Limit: 10, SortBy: "name", Query: "Ali"}
+	got, err := service.Index(context.Background(), entities.UserID("u1"), params)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, want, *got)
+
+	require.Len(t, repo.indexCalls, 1)
+	assert.Equal(t, entities.UserID("u1"), repo.indexCalls[0].userID)
+	assert.Equal(t, params, repo.indexCalls[0].params)
+}
+
+func TestContactService_Index_RepositoryErrorIsWrapped(t *testing.T) {
+	repo := &fakeContactRepo{indexErr: errors.New("index boom")}
+	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+
+	_, err := service.Index(context.Background(), entities.UserID("u1"), repositories.IndexParams{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "index boom")
+}
+
+func TestContactService_Update_RepositoryErrorIsWrappedAndSkipsInvalidation(t *testing.T) {
+	repo := &fakeContactRepo{updateErr: errors.New("update boom")}
+	appCache := newFakeCache()
+	service := newContactServiceForTest(t, repo, appCache, nil)
+
+	err := service.Update(context.Background(), &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "A", PhoneNumbers: pq.StringArray{"+18005550100"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "update boom")
+	assert.Len(t, appCache.setsFor("contacts.map.u1"), 0, "invalidation must not run when the write fails")
+}
+
+func TestContactService_Delete_RepositoryErrorIsWrappedAndSkipsInvalidation(t *testing.T) {
+	repo := &fakeContactRepo{deleteErr: errors.New("delete boom")}
+	appCache := newFakeCache()
+	service := newContactServiceForTest(t, repo, appCache, nil)
+
+	err := service.Delete(context.Background(), entities.UserID("u1"), uuid.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete boom")
+	assert.Len(t, appCache.setsFor("contacts.map.u1"), 0)
+}
+
+func TestContactService_GetContactMap_FetchAllErrorIsWrapped(t *testing.T) {
+	repo := &fakeContactRepo{fetchErr: errors.New("fetch boom")}
+	appCache := newFakeCache()
+	service := newContactServiceForTest(t, repo, appCache, nil)
+
+	_, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch boom")
+}

--- a/api/pkg/services/contact_service_test.go
+++ b/api/pkg/services/contact_service_test.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"sync"
 	"testing"
@@ -12,72 +11,13 @@ import (
 	"github.com/NdoleStudio/httpsms/pkg/repositories"
 	"github.com/NdoleStudio/httpsms/pkg/telemetry"
 	"github.com/NdoleStudio/stacktrace"
+	"github.com/dgraph-io/ristretto/v2"
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 )
-
-// --- fake cache -------------------------------------------------------------
-
-type fakeCache struct {
-	mu     sync.Mutex
-	store  map[string]string
-	getErr error
-	setErr error
-	sets   []cacheSetCall
-	gets   int
-}
-
-type cacheSetCall struct {
-	key   string
-	value string
-	ttl   time.Duration
-}
-
-func newFakeCache() *fakeCache { return &fakeCache{store: map[string]string{}} }
-
-func (c *fakeCache) Get(_ context.Context, key string) (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.gets++
-	if c.getErr != nil {
-		return "", c.getErr
-	}
-	value, ok := c.store[key]
-	if !ok {
-		return "", stacktrace.NewErrorf("no item found in cache with key [%s]", key)
-	}
-	return value, nil
-}
-
-func (c *fakeCache) Set(_ context.Context, key, value string, ttl time.Duration) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.sets = append(c.sets, cacheSetCall{key: key, value: value, ttl: ttl})
-	if c.setErr != nil {
-		return c.setErr
-	}
-	c.store[key] = value
-	return nil
-}
-
-// setsFor returns the recorded Set calls for a given key.
-func (c *fakeCache) setsFor(key string) []cacheSetCall {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	var out []cacheSetCall
-	for _, s := range c.sets {
-		if s.key == key {
-			out = append(out, s)
-		}
-	}
-	return out
-}
 
 // --- fake repository --------------------------------------------------------
 
@@ -93,7 +33,7 @@ type fakeContactRepo struct {
 	countCalls     []indexCall
 	deleteCalls    []deleteCall
 	deleteAllCalls []entities.UserID
-	fetchAll       int
+	fetchCalls     []fetchCall
 
 	storeErr     error
 	updateErr    error
@@ -123,6 +63,33 @@ type deleteCall struct {
 	id     uuid.UUID
 }
 
+type fetchCall struct {
+	userID       entities.UserID
+	phoneNumbers []string
+}
+
+type blockingContactRepo struct {
+	*fakeContactRepo
+	fetchStarted chan struct{}
+	releaseFetch chan struct{}
+	fetchOnce    sync.Once
+}
+
+func (r *blockingContactRepo) FetchByPhoneNumbers(ctx context.Context, userID entities.UserID, phoneNumbers []string) (*[]entities.Contact, error) {
+	var captured []entities.Contact
+	r.fetchOnce.Do(func() {
+		r.fakeContactRepo.mu.Lock()
+		captured = append(captured, *r.fakeContactRepo.contacts[0])
+		r.fakeContactRepo.mu.Unlock()
+		close(r.fetchStarted)
+		<-r.releaseFetch
+	})
+	if captured != nil {
+		return &captured, nil
+	}
+	return r.fakeContactRepo.FetchByPhoneNumbers(ctx, userID, phoneNumbers)
+}
+
 func (r *fakeContactRepo) Store(_ context.Context, contacts []*entities.Contact) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -142,6 +109,13 @@ func (r *fakeContactRepo) Update(_ context.Context, contact *entities.Contact) e
 	r.updateCalls = append(r.updateCalls, contact)
 	if r.updateErr != nil {
 		return r.updateErr
+	}
+	for index := range r.contacts {
+		if r.contacts[index].ID == contact.ID && r.contacts[index].UserID == contact.UserID {
+			clone := *contact
+			r.contacts[index] = &clone
+			break
+		}
 	}
 	return nil
 }
@@ -185,17 +159,33 @@ func (r *fakeContactRepo) Count(_ context.Context, userID entities.UserID, param
 	return r.countResult, nil
 }
 
-func (r *fakeContactRepo) FetchAll(_ context.Context, _ entities.UserID) (*[]entities.Contact, error) {
+func (r *fakeContactRepo) FetchByPhoneNumbers(_ context.Context, userID entities.UserID, phoneNumbers []string) (*[]entities.Contact, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.fetchAll++
+	r.fetchCalls = append(r.fetchCalls, fetchCall{
+		userID:       userID,
+		phoneNumbers: append([]string{}, phoneNumbers...),
+	})
 	if r.fetchErr != nil {
 		return nil, r.fetchErr
 	}
-	out := make([]entities.Contact, 0, len(r.contacts))
+	requested := make(map[string]struct{}, len(phoneNumbers))
+	for _, phoneNumber := range phoneNumbers {
+		requested[phoneNumber] = struct{}{}
+	}
+
+	out := make([]entities.Contact, 0)
 	for _, c := range r.contacts {
-		out = append(out, *c)
+		if c.UserID != userID {
+			continue
+		}
+		for _, phoneNumber := range c.PhoneNumbers {
+			if _, ok := requested[phoneNumber]; ok {
+				out = append(out, *c)
+				break
+			}
+		}
 	}
 	return &out, nil
 }
@@ -213,10 +203,18 @@ func (r *fakeContactRepo) DeleteAllForUser(_ context.Context, userID entities.Us
 	defer r.mu.Unlock()
 
 	r.deleteAllCalls = append(r.deleteAllCalls, userID)
-	return r.deleteAllErr
+	if r.deleteAllErr != nil {
+		return r.deleteAllErr
+	}
+	remaining := r.contacts[:0]
+	for _, contact := range r.contacts {
+		if contact.UserID != userID {
+			remaining = append(remaining, contact)
+		}
+	}
+	r.contacts = remaining
+	return nil
 }
-
-// --- recording logger -------------------------------------------------------
 
 type recordingLogger struct {
 	*noopLogger
@@ -261,309 +259,204 @@ func (l *recordingLogger) WithSpan(_ trace.SpanContext) telemetry.Logger {
 	return l
 }
 
-func (l *recordingLogger) errorCount() int {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	return len(l.errors)
-}
-
 // --- helpers ---------------------------------------------------------------
 
-func newContactServiceForTest(t *testing.T, repo repositories.ContactRepository, appCache *fakeCache, logger telemetry.Logger) *ContactService {
+func newContactCache(t *testing.T) *ristretto.Cache[string, ContactCacheEntry] {
+	t.Helper()
+
+	contactCache, err := ristretto.NewCache[string, ContactCacheEntry](&ristretto.Config[string, ContactCacheEntry]{
+		MaxCost:     100,
+		NumCounters: 1_000,
+		BufferItems: 64,
+	})
+	require.NoError(t, err)
+	t.Cleanup(contactCache.Close)
+	return contactCache
+}
+
+func newContactServiceForTest(t *testing.T, repo repositories.ContactRepository, logger telemetry.Logger) *ContactService {
 	t.Helper()
 	if logger == nil {
 		logger = &noopLogger{}
 	}
 	tracer := telemetry.NewOtelLogger("test", logger)
-	return NewContactService(logger, tracer, repo, appCache)
+	return NewContactService(logger, tracer, repo, newContactCache(t))
 }
 
 // --- tests -----------------------------------------------------------------
 
-func TestContactService_GetContactMap_TieBreakMostRecentlyUpdatedWins(t *testing.T) {
-	older := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "Old", PhoneNumbers: pq.StringArray{"+18005550199"}, UpdatedAt: time.Now().Add(-time.Hour)}
-	newer := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "New", PhoneNumbers: pq.StringArray{"+18005550199"}, UpdatedAt: time.Now()}
-	repo := &fakeContactRepo{contacts: []*entities.Contact{older, newer}}
-	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
-
-	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
-	require.NoError(t, err)
-
-	require.NotNil(t, result["+18005550199"])
-	assert.Equal(t, "New", result["+18005550199"].Name)
-	assert.Equal(t, newer.ID, result["+18005550199"].ID)
-}
-
-func TestContactService_GetContactMap_AllPhoneNumbersMapToOneContact(t *testing.T) {
-	contact := &entities.Contact{
-		ID:           uuid.New(),
-		UserID:       "u1",
-		Name:         "Alice",
-		PhoneNumbers: pq.StringArray{"+18005550199", "+18005550100", "+18005550111"},
-	}
-	repo := &fakeContactRepo{contacts: []*entities.Contact{contact}}
-	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
-
-	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
-	require.NoError(t, err)
-
-	for _, num := range contact.PhoneNumbers {
-		got, ok := result[num]
-		require.True(t, ok, "missing entry for %s", num)
-		assert.Equal(t, contact.ID, got.ID)
-		assert.Equal(t, "Alice", got.Name)
-	}
-}
-
-func TestContactService_GetContactMap_NoCollisionDistinctPointersPerContact(t *testing.T) {
-	a := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}, UpdatedAt: time.Now().Add(-2 * time.Hour)}
-	b := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "Bob", PhoneNumbers: pq.StringArray{"+18005550100"}, UpdatedAt: time.Now().Add(-time.Hour)}
-	c := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "Carol", PhoneNumbers: pq.StringArray{"+18005550111"}, UpdatedAt: time.Now()}
-	repo := &fakeContactRepo{contacts: []*entities.Contact{a, b, c}}
-	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
-
-	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
-	require.NoError(t, err)
-
-	require.Len(t, result, 3)
-	assert.Equal(t, "Alice", result["+18005550199"].Name)
-	assert.Equal(t, "Bob", result["+18005550100"].Name)
-	assert.Equal(t, "Carol", result["+18005550111"].Name)
-
-	// Each entry must point to a stable, independent value.
-	assert.NotSame(t, result["+18005550199"], result["+18005550100"])
-	assert.NotSame(t, result["+18005550100"], result["+18005550111"])
-
-	// Mutating the returned pointer must not corrupt other entries.
-	result["+18005550199"].Name = "Mutated"
-	assert.Equal(t, "Bob", result["+18005550100"].Name)
-	assert.Equal(t, "Carol", result["+18005550111"].Name)
-}
-
-func TestContactService_GetContactMap_CacheHitAvoidsFetchAll(t *testing.T) {
-	repo := &fakeContactRepo{contacts: []*entities.Contact{{
-		ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"},
-	}}}
-	appCache := newFakeCache()
-	service := newContactServiceForTest(t, repo, appCache, nil)
-
-	_, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
-	require.NoError(t, err)
-	_, err = service.GetContactMap(context.Background(), entities.UserID("u1"))
-	require.NoError(t, err)
-
-	assert.Equal(t, 1, repo.fetchAll, "second call must hit cache")
-}
-
-func TestContactService_GetContactMap_EmptyMarkerTriggersRebuild(t *testing.T) {
-	repo := &fakeContactRepo{contacts: []*entities.Contact{{
-		ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"},
-	}}}
-	appCache := newFakeCache()
-	// Pre-seed the invalidation marker.
-	require.NoError(t, appCache.Set(context.Background(), "contacts.map.u1", "", time.Hour))
-	logger := newRecordingLogger()
-	service := newContactServiceForTest(t, repo, appCache, logger)
-
-	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
-	require.NoError(t, err)
-
-	assert.Equal(t, 1, repo.fetchAll, "empty marker must force rebuild")
-	assert.Equal(t, "Alice", result["+18005550199"].Name)
-	assert.Equal(t, 0, logger.errorCount(), "empty marker rebuild must not log an error")
-}
-
-func TestContactService_GetContactMap_CorruptCacheRebuildsAndLogs(t *testing.T) {
-	repo := &fakeContactRepo{contacts: []*entities.Contact{{
-		ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"},
-	}}}
-	appCache := newFakeCache()
-	require.NoError(t, appCache.Set(context.Background(), "contacts.map.u1", "not-json{", time.Hour))
-	logger := newRecordingLogger()
-	service := newContactServiceForTest(t, repo, appCache, logger)
-
-	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
-	require.NoError(t, err)
-
-	assert.Equal(t, 1, repo.fetchAll, "corrupt cache must force rebuild")
-	assert.Equal(t, "Alice", result["+18005550199"].Name)
-	assert.GreaterOrEqual(t, logger.errorCount(), 1, "corrupt cache must log an error")
-}
-
-func TestContactService_GetContactMap_CachePopulationErrorReturnsMapAndLogs(t *testing.T) {
-	repo := &fakeContactRepo{contacts: []*entities.Contact{{
-		ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"},
-	}}}
-	appCache := newFakeCache()
-	appCache.setErr = errors.New("boom")
-	logger := newRecordingLogger()
-	service := newContactServiceForTest(t, repo, appCache, logger)
-
-	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
-	require.NoError(t, err, "population failure must not fail the caller")
-	require.NotNil(t, result["+18005550199"])
-	assert.Equal(t, "Alice", result["+18005550199"].Name)
-	assert.GreaterOrEqual(t, logger.errorCount(), 1, "population failure must be logged")
-}
-
-func TestContactService_GetContactMap_CachedRoundTripPreservesData(t *testing.T) {
-	// After the first call populates the cache, verify the cached payload is well-formed JSON
-	// mapping phone numbers to contact objects and that a second call returns equivalent data.
-	repo := &fakeContactRepo{contacts: []*entities.Contact{{
-		ID:           uuid.New(),
-		UserID:       "u1",
-		Name:         "Alice",
-		PhoneNumbers: pq.StringArray{"+18005550199", "+18005550100"},
-	}}}
-	appCache := newFakeCache()
-	service := newContactServiceForTest(t, repo, appCache, nil)
-
-	first, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
-	require.NoError(t, err)
-
-	raw, err := appCache.Get(context.Background(), "contacts.map.u1")
-	require.NoError(t, err)
-	require.NotEmpty(t, raw)
-
-	decoded := map[string]*entities.Contact{}
-	require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
-	assert.Equal(t, first["+18005550199"].ID, decoded["+18005550199"].ID)
-
-	second, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
-	require.NoError(t, err)
-	assert.Equal(t, first["+18005550199"].ID, second["+18005550199"].ID)
-	assert.Equal(t, first["+18005550100"].ID, second["+18005550100"].ID)
-}
-
-// --- mutation invalidation tests ------------------------------------------
-
-func TestContactService_CreateMany_InvalidatesCacheExactlyOnce(t *testing.T) {
-	repo := &fakeContactRepo{contacts: []*entities.Contact{{
-		ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"},
-	}}}
-	appCache := newFakeCache()
-	service := newContactServiceForTest(t, repo, appCache, nil)
-
-	// Warm the cache.
-	_, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
-	require.NoError(t, err)
-	require.Equal(t, 1, repo.fetchAll)
-
-	setsBefore := len(appCache.setsFor("contacts.map.u1"))
-
-	added := []*entities.Contact{
+func TestContactService_GetContactMap_FetchesOnlyUncachedPhoneNumbers(t *testing.T) {
+	repo := &fakeContactRepo{contacts: []*entities.Contact{
+		{ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}},
 		{ID: uuid.New(), UserID: "u1", Name: "Bob", PhoneNumbers: pq.StringArray{"+18005550100"}},
 		{ID: uuid.New(), UserID: "u1", Name: "Carol", PhoneNumbers: pq.StringArray{"+18005550111"}},
-	}
-	require.NoError(t, service.CreateMany(context.Background(), entities.UserID("u1"), added))
+	}}
+	service := newContactServiceForTest(t, repo, nil)
 
-	assert.Len(t, repo.storeCalls, 1, "batch must be persisted in a single Store call")
-	assert.Equal(t, added, repo.storeCalls[0])
-
-	afterInvalidation := appCache.setsFor("contacts.map.u1")
-	require.Len(t, afterInvalidation, setsBefore+1, "CreateMany must invalidate the cache exactly once")
-	assert.Equal(t, "", afterInvalidation[len(afterInvalidation)-1].value, "invalidation marker must be empty")
-
-	// Next GetContactMap rebuilds.
-	_, err = service.GetContactMap(context.Background(), entities.UserID("u1"))
+	first, err := service.GetContactMap(context.Background(), entities.UserID("u1"), []string{"+18005550199"})
 	require.NoError(t, err)
-	assert.Equal(t, 2, repo.fetchAll)
+	service.cache.Wait()
+	require.Len(t, first, 1)
+
+	second, err := service.GetContactMap(context.Background(), entities.UserID("u1"), []string{"+18005550199", "+18005550111"})
+	require.NoError(t, err)
+
+	require.Len(t, repo.fetchCalls, 2)
+	assert.Equal(t, []string{"+18005550199"}, repo.fetchCalls[0].phoneNumbers)
+	assert.Equal(t, []string{"+18005550111"}, repo.fetchCalls[1].phoneNumbers)
+	assert.Equal(t, "Carol", second["+18005550111"].Name)
 }
 
-func TestContactService_Update_InvalidatesCacheExactlyOnce(t *testing.T) {
-	c := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}}
-	repo := &fakeContactRepo{contacts: []*entities.Contact{c}}
-	appCache := newFakeCache()
-	service := newContactServiceForTest(t, repo, appCache, nil)
+func TestContactService_GetContactMap_CacheKeyIncludesUserAndPhoneNumber(t *testing.T) {
+	number := "+18005550199"
+	repo := &fakeContactRepo{contacts: []*entities.Contact{
+		{ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{number}},
+		{ID: uuid.New(), UserID: "u2", Name: "Bob", PhoneNumbers: pq.StringArray{number}},
+	}}
+	service := newContactServiceForTest(t, repo, nil)
 
-	_, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	first, err := service.GetContactMap(context.Background(), entities.UserID("u1"), []string{number})
 	require.NoError(t, err)
-	setsBefore := len(appCache.setsFor("contacts.map.u1"))
+	service.cache.Wait()
+	second, err := service.GetContactMap(context.Background(), entities.UserID("u2"), []string{number})
+	require.NoError(t, err)
 
-	updated := *c
-	updated.Name = "Alicia"
-	require.NoError(t, service.Update(context.Background(), &updated))
-
-	require.Len(t, repo.updateCalls, 1)
-	assert.Equal(t, "Alicia", repo.updateCalls[0].Name)
-	assert.Equal(t, entities.UserID("u1"), repo.updateCalls[0].UserID)
-
-	afterInvalidation := appCache.setsFor("contacts.map.u1")
-	require.Len(t, afterInvalidation, setsBefore+1)
-	assert.Equal(t, "", afterInvalidation[len(afterInvalidation)-1].value)
+	assert.Equal(t, "Alice", first[number].Name)
+	assert.Equal(t, "Bob", second[number].Name)
+	require.Len(t, repo.fetchCalls, 2)
 }
 
-func TestContactService_Delete_InvalidatesCacheExactlyOnce(t *testing.T) {
-	id := uuid.New()
-	repo := &fakeContactRepo{contacts: []*entities.Contact{{ID: id, UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}}}}
-	appCache := newFakeCache()
-	service := newContactServiceForTest(t, repo, appCache, nil)
-
-	_, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
-	require.NoError(t, err)
-	setsBefore := len(appCache.setsFor("contacts.map.u1"))
-
-	require.NoError(t, service.Delete(context.Background(), entities.UserID("u1"), id))
-
-	require.Len(t, repo.deleteCalls, 1)
-	assert.Equal(t, deleteCall{userID: "u1", id: id}, repo.deleteCalls[0])
-
-	afterInvalidation := appCache.setsFor("contacts.map.u1")
-	require.Len(t, afterInvalidation, setsBefore+1)
-	assert.Equal(t, "", afterInvalidation[len(afterInvalidation)-1].value)
-}
-
-func TestContactService_DeleteAllForUser_InvalidatesCache(t *testing.T) {
+func TestContactService_GetContactMap_CachesMissingPhoneNumbers(t *testing.T) {
 	repo := &fakeContactRepo{}
-	appCache := newFakeCache()
-	service := newContactServiceForTest(t, repo, appCache, nil)
+	service := newContactServiceForTest(t, repo, nil)
+	number := "+18005550199"
+
+	first, err := service.GetContactMap(context.Background(), entities.UserID("u1"), []string{number})
+	require.NoError(t, err)
+	service.cache.Wait()
+	second, err := service.GetContactMap(context.Background(), entities.UserID("u1"), []string{number})
+	require.NoError(t, err)
+
+	assert.Empty(t, first)
+	assert.Empty(t, second)
+	require.Len(t, repo.fetchCalls, 1)
+}
+
+func TestContactService_ExpiresInactiveGenerationStateWithoutReusingEpoch(t *testing.T) {
+	service := newContactServiceForTest(t, &fakeContactRepo{}, nil)
+
+	first := service.generation(entities.UserID("u1"))
+	service.expireGenerations(time.Now().Add(contactMapCacheTTL + time.Hour))
+	second := service.generation(entities.UserID("u1"))
+
+	assert.NotEqual(t, first, second)
+}
+
+func TestContactService_GetContactMap_TieBreakMostRecentlyUpdatedWins(t *testing.T) {
+	number := "+18005550199"
+	older := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "Old", PhoneNumbers: pq.StringArray{number}, UpdatedAt: time.Now().Add(-time.Hour)}
+	newer := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "New", PhoneNumbers: pq.StringArray{number}, UpdatedAt: time.Now()}
+	repo := &fakeContactRepo{contacts: []*entities.Contact{older, newer}}
+	service := newContactServiceForTest(t, repo, nil)
+
+	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"), []string{number})
+	require.NoError(t, err)
+
+	require.NotNil(t, result[number])
+	assert.Equal(t, newer.ID, result[number].ID)
+}
+
+func TestContactService_Update_InvalidatesOldAndNewPhoneNumbers(t *testing.T) {
+	oldNumber := "+18005550199"
+	newNumber := "+18005550100"
+	id := uuid.New()
+	repo := &fakeContactRepo{contacts: []*entities.Contact{{
+		ID: id, UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{oldNumber},
+	}}}
+	contactCache := newContactCache(t)
+	stale := &entities.Contact{ID: id, UserID: "u1", Name: "Stale"}
+	require.True(t, contactCache.Set("u1|"+oldNumber, ContactCacheEntry{contact: stale}, 1))
+	require.True(t, contactCache.Set("u1|"+newNumber, ContactCacheEntry{contact: stale}, 1))
+	contactCache.Wait()
+	logger := &noopLogger{}
+	service := NewContactService(logger, telemetry.NewOtelLogger("test", logger), repo, contactCache)
+
+	err := service.Update(context.Background(), &entities.Contact{
+		ID: id, UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{newNumber},
+	}, []string{oldNumber})
+	require.NoError(t, err)
+	contactCache.Wait()
+
+	_, oldFound := contactCache.Get("u1|" + oldNumber)
+	_, newFound := contactCache.Get("u1|" + newNumber)
+	assert.False(t, oldFound)
+	assert.False(t, newFound)
+}
+
+func TestContactService_GetContactMap_DoesNotReuseResultFetchedDuringUpdate(t *testing.T) {
+	number := "+18005550199"
+	id := uuid.New()
+	repo := &blockingContactRepo{
+		fakeContactRepo: &fakeContactRepo{contacts: []*entities.Contact{{
+			ID: id, UserID: "u1", Name: "Old", PhoneNumbers: pq.StringArray{number},
+		}}},
+		fetchStarted: make(chan struct{}),
+		releaseFetch: make(chan struct{}),
+	}
+	service := newContactServiceForTest(t, repo, nil)
+
+	firstResult := make(chan map[string]*entities.Contact, 1)
+	go func() {
+		result, _ := service.GetContactMap(context.Background(), entities.UserID("u1"), []string{number})
+		firstResult <- result
+	}()
+	<-repo.fetchStarted
+
+	require.NoError(t, service.Update(context.Background(), &entities.Contact{
+		ID: id, UserID: "u1", Name: "New", PhoneNumbers: pq.StringArray{number},
+	}, []string{number}))
+	close(repo.releaseFetch)
+	assert.Equal(t, "Old", (<-firstResult)[number].Name)
+	service.cache.Wait()
+
+	second, err := service.GetContactMap(context.Background(), entities.UserID("u1"), []string{number})
+	require.NoError(t, err)
+	assert.Equal(t, "New", second[number].Name)
+}
+
+func TestContactService_DeleteAllForUser_DoesNotEvictOtherUsers(t *testing.T) {
+	repo := &fakeContactRepo{contacts: []*entities.Contact{
+		{UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}},
+		{UserID: "u2", Name: "Bob", PhoneNumbers: pq.StringArray{"+18005550100"}},
+	}}
+	contactCache := newContactCache(t)
+	logger := &noopLogger{}
+	service := NewContactService(logger, telemetry.NewOtelLogger("test", logger), repo, contactCache)
+	require.True(t, contactCache.Set("u1|+18005550199", ContactCacheEntry{
+		contact: repo.contacts[0], generation: service.generation("u1"),
+	}, 1))
+	require.True(t, contactCache.Set("u2|+18005550100", ContactCacheEntry{
+		contact: repo.contacts[1], generation: service.generation("u2"),
+	}, 1))
+	contactCache.Wait()
 
 	require.NoError(t, service.DeleteAllForUser(context.Background(), entities.UserID("u1")))
 
-	assert.Equal(t, []entities.UserID{"u1"}, repo.deleteAllCalls)
-	sets := appCache.setsFor("contacts.map.u1")
-	require.Len(t, sets, 1)
-	assert.Equal(t, "", sets[0].value)
-}
-
-func TestContactService_DeleteAllForUser_RepositoryErrorSkipsInvalidation(t *testing.T) {
-	repo := &fakeContactRepo{deleteAllErr: errors.New("delete all boom")}
-	appCache := newFakeCache()
-	service := newContactServiceForTest(t, repo, appCache, nil)
-
-	err := service.DeleteAllForUser(context.Background(), entities.UserID("u1"))
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "delete all boom")
-	assert.Empty(t, appCache.setsFor("contacts.map.u1"))
-}
-
-func TestContactService_InvalidationFailure_LogsErrorButReturnsNil(t *testing.T) {
-	// Persistence succeeded but cache invalidation failed. The mutation itself
-	// must not return an error (see report: chosen contract), but MUST log the
-	// invalidation failure explicitly at Error level so operators are alerted.
-	repo := &fakeContactRepo{}
-	appCache := newFakeCache()
-	appCache.setErr = errors.New("cache down")
-	logger := newRecordingLogger()
-	service := newContactServiceForTest(t, repo, appCache, logger)
-
-	err := service.CreateMany(context.Background(), entities.UserID("u1"), []*entities.Contact{{
-		ID: uuid.New(), UserID: "u1", Name: "Bob", PhoneNumbers: pq.StringArray{"+18005550100"},
-	}})
-	require.NoError(t, err, "mutation must not surface invalidation failure to caller")
-
-	// Repository actually got the write.
-	require.Len(t, repo.storeCalls, 1)
-	// The invalidation attempt was logged as an error.
-	assert.GreaterOrEqual(t, logger.errorCount(), 1, "invalidation failure must be logged as error")
+	first, err := service.GetContactMap(context.Background(), entities.UserID("u1"), []string{"+18005550199"})
+	require.NoError(t, err)
+	second, err := service.GetContactMap(context.Background(), entities.UserID("u2"), []string{"+18005550100"})
+	require.NoError(t, err)
+	assert.Empty(t, first)
+	assert.Equal(t, "Bob", second["+18005550100"].Name)
+	require.Len(t, repo.fetchCalls, 1)
+	assert.Equal(t, entities.UserID("u1"), repo.fetchCalls[0].userID)
 }
 
 // --- CRUD delegation and user scope tests ---------------------------------
 
 func TestContactService_CreateMany_PersistsBatchInSingleCall(t *testing.T) {
 	repo := &fakeContactRepo{}
-	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+	service := newContactServiceForTest(t, repo, nil)
 
 	batch := []*entities.Contact{
 		{ID: uuid.New(), UserID: "u1", Name: "A", PhoneNumbers: pq.StringArray{"+18005550100"}},
@@ -577,7 +470,7 @@ func TestContactService_CreateMany_PersistsBatchInSingleCall(t *testing.T) {
 
 func TestContactService_CreateMany_RepositoryErrorIsWrapped(t *testing.T) {
 	repo := &fakeContactRepo{storeErr: errors.New("db down")}
-	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+	service := newContactServiceForTest(t, repo, nil)
 
 	err := service.CreateMany(context.Background(), entities.UserID("u1"), []*entities.Contact{{
 		ID: uuid.New(), UserID: "u1", Name: "A", PhoneNumbers: pq.StringArray{"+18005550100"},
@@ -593,7 +486,7 @@ func TestContactService_Get_DelegatesWithUserScope(t *testing.T) {
 		{ID: id, UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}},
 		{ID: other, UserID: "u2", Name: "Bob", PhoneNumbers: pq.StringArray{"+18005550100"}},
 	}}
-	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+	service := newContactServiceForTest(t, repo, nil)
 
 	got, err := service.Get(context.Background(), entities.UserID("u1"), id)
 	require.NoError(t, err)
@@ -608,7 +501,7 @@ func TestContactService_Get_DelegatesWithUserScope(t *testing.T) {
 func TestContactService_Index_DelegatesParams(t *testing.T) {
 	want := []entities.Contact{{ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}}}
 	repo := &fakeContactRepo{indexResult: want}
-	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+	service := newContactServiceForTest(t, repo, nil)
 
 	params := repositories.IndexParams{Skip: 5, Limit: 10, SortBy: "name", Query: "Ali"}
 	got, err := service.Index(context.Background(), entities.UserID("u1"), params)
@@ -623,7 +516,7 @@ func TestContactService_Index_DelegatesParams(t *testing.T) {
 
 func TestContactService_Index_RepositoryErrorIsWrapped(t *testing.T) {
 	repo := &fakeContactRepo{indexErr: errors.New("index boom")}
-	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+	service := newContactServiceForTest(t, repo, nil)
 
 	_, err := service.Index(context.Background(), entities.UserID("u1"), repositories.IndexParams{})
 	require.Error(t, err)
@@ -632,7 +525,7 @@ func TestContactService_Index_RepositoryErrorIsWrapped(t *testing.T) {
 
 func TestContactService_Count_DelegatesParamsAndReturnsTotal(t *testing.T) {
 	repo := &fakeContactRepo{countResult: 57}
-	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+	service := newContactServiceForTest(t, repo, nil)
 
 	params := repositories.IndexParams{Skip: 5, Limit: 10, Query: "Ali"}
 	total, err := service.Count(context.Background(), entities.UserID("u1"), params)
@@ -646,7 +539,7 @@ func TestContactService_Count_DelegatesParamsAndReturnsTotal(t *testing.T) {
 
 func TestContactService_Count_RepositoryErrorIsWrapped(t *testing.T) {
 	repo := &fakeContactRepo{countErr: errors.New("count boom")}
-	service := newContactServiceForTest(t, repo, newFakeCache(), nil)
+	service := newContactServiceForTest(t, repo, nil)
 
 	_, err := service.Count(context.Background(), entities.UserID("u1"), repositories.IndexParams{})
 	require.Error(t, err)
@@ -654,33 +547,52 @@ func TestContactService_Count_RepositoryErrorIsWrapped(t *testing.T) {
 }
 
 func TestContactService_Update_RepositoryErrorIsWrappedAndSkipsInvalidation(t *testing.T) {
-	repo := &fakeContactRepo{updateErr: errors.New("update boom")}
-	appCache := newFakeCache()
-	service := newContactServiceForTest(t, repo, appCache, nil)
+	id := uuid.New()
+	repo := &fakeContactRepo{
+		contacts:  []*entities.Contact{{ID: id, UserID: "u1", PhoneNumbers: pq.StringArray{"+18005550100"}}},
+		updateErr: errors.New("update boom"),
+	}
+	contactCache := newContactCache(t)
+	require.True(t, contactCache.Set("u1|+18005550100", ContactCacheEntry{contact: &entities.Contact{Name: "Cached"}}, 1))
+	contactCache.Wait()
+	logger := &noopLogger{}
+	service := NewContactService(logger, telemetry.NewOtelLogger("test", logger), repo, contactCache)
 
-	err := service.Update(context.Background(), &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "A", PhoneNumbers: pq.StringArray{"+18005550100"}})
+	err := service.Update(
+		context.Background(),
+		&entities.Contact{ID: id, UserID: "u1", Name: "A", PhoneNumbers: pq.StringArray{"+18005550100"}},
+		[]string{"+18005550100"},
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "update boom")
-	assert.Len(t, appCache.setsFor("contacts.map.u1"), 0, "invalidation must not run when the write fails")
+	_, found := contactCache.Get("u1|+18005550100")
+	assert.True(t, found, "invalidation must not run when the write fails")
 }
 
 func TestContactService_Delete_RepositoryErrorIsWrappedAndSkipsInvalidation(t *testing.T) {
-	repo := &fakeContactRepo{deleteErr: errors.New("delete boom")}
-	appCache := newFakeCache()
-	service := newContactServiceForTest(t, repo, appCache, nil)
+	id := uuid.New()
+	repo := &fakeContactRepo{
+		contacts:  []*entities.Contact{{ID: id, UserID: "u1", PhoneNumbers: pq.StringArray{"+18005550100"}}},
+		deleteErr: errors.New("delete boom"),
+	}
+	contactCache := newContactCache(t)
+	require.True(t, contactCache.Set("u1|+18005550100", ContactCacheEntry{contact: &entities.Contact{Name: "Cached"}}, 1))
+	contactCache.Wait()
+	logger := &noopLogger{}
+	service := NewContactService(logger, telemetry.NewOtelLogger("test", logger), repo, contactCache)
 
-	err := service.Delete(context.Background(), entities.UserID("u1"), uuid.New())
+	err := service.Delete(context.Background(), entities.UserID("u1"), id)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "delete boom")
-	assert.Len(t, appCache.setsFor("contacts.map.u1"), 0)
+	_, found := contactCache.Get("u1|+18005550100")
+	assert.True(t, found, "invalidation must not run when the write fails")
 }
 
-func TestContactService_GetContactMap_FetchAllErrorIsWrapped(t *testing.T) {
+func TestContactService_GetContactMap_FetchErrorIsWrapped(t *testing.T) {
 	repo := &fakeContactRepo{fetchErr: errors.New("fetch boom")}
-	appCache := newFakeCache()
-	service := newContactServiceForTest(t, repo, appCache, nil)
+	service := newContactServiceForTest(t, repo, nil)
 
-	_, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	_, err := service.GetContactMap(context.Background(), entities.UserID("u1"), []string{"+18005550100"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "fetch boom")
 }

--- a/api/pkg/services/contact_service_test.go
+++ b/api/pkg/services/contact_service_test.go
@@ -86,21 +86,23 @@ type fakeContactRepo struct {
 
 	contacts []*entities.Contact
 
-	storeCalls  [][]*entities.Contact
-	updateCalls []*entities.Contact
-	loadCalls   []loadCall
-	indexCalls  []indexCall
-	countCalls  []indexCall
-	deleteCalls []deleteCall
-	fetchAll    int
+	storeCalls     [][]*entities.Contact
+	updateCalls    []*entities.Contact
+	loadCalls      []loadCall
+	indexCalls     []indexCall
+	countCalls     []indexCall
+	deleteCalls    []deleteCall
+	deleteAllCalls []entities.UserID
+	fetchAll       int
 
-	storeErr  error
-	updateErr error
-	loadErr   error
-	indexErr  error
-	countErr  error
-	deleteErr error
-	fetchErr  error
+	storeErr     error
+	updateErr    error
+	loadErr      error
+	indexErr     error
+	countErr     error
+	deleteErr    error
+	deleteAllErr error
+	fetchErr     error
 
 	indexResult []entities.Contact
 	countResult int64
@@ -206,7 +208,13 @@ func (r *fakeContactRepo) Delete(_ context.Context, userID entities.UserID, id u
 	return r.deleteErr
 }
 
-func (r *fakeContactRepo) DeleteAllForUser(_ context.Context, _ entities.UserID) error { return nil }
+func (r *fakeContactRepo) DeleteAllForUser(_ context.Context, userID entities.UserID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.deleteAllCalls = append(r.deleteAllCalls, userID)
+	return r.deleteAllErr
+}
 
 // --- recording logger -------------------------------------------------------
 
@@ -503,6 +511,31 @@ func TestContactService_Delete_InvalidatesCacheExactlyOnce(t *testing.T) {
 	afterInvalidation := appCache.setsFor("contacts.map.u1")
 	require.Len(t, afterInvalidation, setsBefore+1)
 	assert.Equal(t, "", afterInvalidation[len(afterInvalidation)-1].value)
+}
+
+func TestContactService_DeleteAllForUser_InvalidatesCache(t *testing.T) {
+	repo := &fakeContactRepo{}
+	appCache := newFakeCache()
+	service := newContactServiceForTest(t, repo, appCache, nil)
+
+	require.NoError(t, service.DeleteAllForUser(context.Background(), entities.UserID("u1")))
+
+	assert.Equal(t, []entities.UserID{"u1"}, repo.deleteAllCalls)
+	sets := appCache.setsFor("contacts.map.u1")
+	require.Len(t, sets, 1)
+	assert.Equal(t, "", sets[0].value)
+}
+
+func TestContactService_DeleteAllForUser_RepositoryErrorSkipsInvalidation(t *testing.T) {
+	repo := &fakeContactRepo{deleteAllErr: errors.New("delete all boom")}
+	appCache := newFakeCache()
+	service := newContactServiceForTest(t, repo, appCache, nil)
+
+	err := service.DeleteAllForUser(context.Background(), entities.UserID("u1"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete all boom")
+	assert.Empty(t, appCache.setsFor("contacts.map.u1"))
 }
 
 func TestContactService_InvalidationFailure_LogsErrorButReturnsNil(t *testing.T) {

--- a/api/pkg/services/entitlement_service.go
+++ b/api/pkg/services/entitlement_service.go
@@ -63,6 +63,18 @@ func (service *EntitlementService) Check(
 	entityName string,
 	countFunc func() (int, error),
 ) (*EntitlementCheckResult, error) {
+	return service.CheckAdditional(ctx, userID, entityName, 1, countFunc)
+}
+
+// CheckAdditional verifies if the user can create additionalCount instances of
+// the given entity without exceeding their subscription plan limit.
+func (service *EntitlementService) CheckAdditional(
+	ctx context.Context,
+	userID entities.UserID,
+	entityName string,
+	additionalCount int,
+	countFunc func() (int, error),
+) (*EntitlementCheckResult, error) {
 	ctx, span := service.tracer.Start(ctx)
 	defer span.End()
 
@@ -70,8 +82,8 @@ func (service *EntitlementService) Check(
 		return &EntitlementCheckResult{Allowed: true}, nil
 	}
 
-	limits, exists := entityLimits[entityName]
-	if !exists {
+	limits, hasConfiguredLimits := entityLimits[entityName]
+	if !hasConfiguredLimits && entityName != entities.EntityNameContact {
 		return &EntitlementCheckResult{Allowed: true}, nil
 	}
 
@@ -83,9 +95,13 @@ func (service *EntitlementService) Check(
 		)
 	}
 
-	limit, hasLimit := limits[user.SubscriptionName]
-	if !hasLimit || limit == 0 {
-		return &EntitlementCheckResult{Allowed: true}, nil
+	limit := int(user.SubscriptionName.Limit())
+	if entityName != entities.EntityNameContact {
+		var hasLimit bool
+		limit, hasLimit = limits[user.SubscriptionName]
+		if !hasLimit || limit == 0 {
+			return &EntitlementCheckResult{Allowed: true}, nil
+		}
 	}
 
 	currentCount, err := countFunc()
@@ -96,11 +112,11 @@ func (service *EntitlementService) Check(
 		)
 	}
 
-	if currentCount >= limit {
+	if currentCount+additionalCount > limit {
 		return &EntitlementCheckResult{
 			Allowed: false,
 			Message: fmt.Sprintf(
-				"Upgrade to a paid plan to create more than [%d] %s. Visit https://httpsms.com/pricing for details.",
+				"Upgrade your plan to create more than [%d] %s. Visit https://httpsms.com/pricing for details.",
 				limit,
 				formatEntityName(entityName, true),
 			),

--- a/api/pkg/services/entitlement_service_test.go
+++ b/api/pkg/services/entitlement_service_test.go
@@ -1,0 +1,104 @@
+package services
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type entitlementUserRepository struct {
+	repositories.UserRepository
+	user      *entities.User
+	loadCalls int
+}
+
+func (repository *entitlementUserRepository) Load(_ context.Context, _ entities.UserID) (*entities.User, error) {
+	repository.loadCalls++
+	return repository.user, nil
+}
+
+func newEntitlementServiceForTest(enabled bool, repository repositories.UserRepository) *EntitlementService {
+	logger := newRecordingLogger()
+	return NewEntitlementService(logger, telemetry.NewOtelLogger("test", logger), enabled, repository)
+}
+
+func TestEntitlementService_CheckAdditional_DisabledAllowsWithoutLoadingUserOrCount(t *testing.T) {
+	repository := &entitlementUserRepository{}
+	service := newEntitlementServiceForTest(false, repository)
+	countCalls := 0
+
+	result, err := service.CheckAdditional(context.Background(), "user-id", "Contact", 1000, func() (int, error) {
+		countCalls++
+		return 200, nil
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.Allowed)
+	assert.Zero(t, repository.loadCalls)
+	assert.Zero(t, countCalls)
+}
+
+func TestEntitlementService_CheckAdditional_UsesSubscriptionLimitForContactBatch(t *testing.T) {
+	tests := []struct {
+		name             string
+		subscriptionName entities.SubscriptionName
+		currentCount     int
+		additionalCount  int
+		allowed          bool
+	}{
+		{
+			name:             "free user can reach 200 contacts",
+			subscriptionName: entities.SubscriptionNameFree,
+			currentCount:     199,
+			additionalCount:  1,
+			allowed:          true,
+		},
+		{
+			name:             "free user cannot exceed 200 contacts",
+			subscriptionName: entities.SubscriptionNameFree,
+			currentCount:     199,
+			additionalCount:  2,
+			allowed:          false,
+		},
+		{
+			name:             "pro user can reach 5000 contacts",
+			subscriptionName: entities.SubscriptionNameProMonthly,
+			currentCount:     4999,
+			additionalCount:  1,
+			allowed:          true,
+		},
+		{
+			name:             "pro user cannot exceed 5000 contacts",
+			subscriptionName: entities.SubscriptionNameProMonthly,
+			currentCount:     4999,
+			additionalCount:  2,
+			allowed:          false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repository := &entitlementUserRepository{
+				user: &entities.User{SubscriptionName: test.subscriptionName},
+			}
+			service := newEntitlementServiceForTest(true, repository)
+
+			result, err := service.CheckAdditional(context.Background(), "user-id", "Contact", test.additionalCount, func() (int, error) {
+				return test.currentCount, nil
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, test.allowed, result.Allowed)
+			if !test.allowed {
+				assert.Contains(t, result.Message, "more than ["+strconv.FormatUint(uint64(test.subscriptionName.Limit()), 10)+"]")
+				assert.Contains(t, result.Message, "Upgrade your plan")
+			}
+		})
+	}
+}

--- a/api/pkg/services/message_thread_service.go
+++ b/api/pkg/services/message_thread_service.go
@@ -15,6 +15,10 @@ import (
 	"github.com/google/uuid"
 )
 
+type contactMapProvider interface {
+	GetContactMap(ctx context.Context, userID entities.UserID) (map[string]*entities.Contact, error)
+}
+
 // MessageThreadService is handles message requests
 type MessageThreadService struct {
 	service
@@ -23,6 +27,7 @@ type MessageThreadService struct {
 	repository      repositories.MessageThreadRepository
 	phoneRepository repositories.PhoneRepository
 	eventDispatcher *EventDispatcher
+	contactService  contactMapProvider
 }
 
 // NewMessageThreadService creates a new MessageThreadService
@@ -32,6 +37,7 @@ func NewMessageThreadService(
 	repository repositories.MessageThreadRepository,
 	phoneRepository repositories.PhoneRepository,
 	eventDispatcher *EventDispatcher,
+	contactService contactMapProvider,
 ) (s *MessageThreadService) {
 	return &MessageThreadService{
 		logger:          logger.WithService(fmt.Sprintf("%T", s)),
@@ -39,6 +45,7 @@ func NewMessageThreadService(
 		eventDispatcher: eventDispatcher,
 		repository:      repository,
 		phoneRepository: phoneRepository,
+		contactService:  contactService,
 	}
 }
 
@@ -265,9 +272,10 @@ func (service *MessageThreadService) getColor() string {
 // MessageThreadGetParams parameters fetching threads
 type MessageThreadGetParams struct {
 	repositories.IndexParams
-	IsArchived bool
-	UserID     entities.UserID
-	Owner      string
+	IsArchived   bool
+	WithContacts bool
+	UserID       entities.UserID
+	Owner        string
 }
 
 // GetThreads fetches threads for an owner
@@ -280,6 +288,19 @@ func (service *MessageThreadService) GetThreads(ctx context.Context, params Mess
 	threads, err := service.repository.Index(ctx, params.UserID, params.Owner, params.IsArchived, params.IndexParams)
 	if err != nil {
 		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "could not fetch messages threads for params [%+#v]", params))
+	}
+
+	if params.WithContacts && service.contactService != nil && len(*threads) > 0 {
+		contactMap, mapErr := service.contactService.GetContactMap(ctx, params.UserID)
+		if mapErr != nil {
+			ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(mapErr, "cannot build contact map for user [%s]", params.UserID)))
+		} else {
+			for index := range *threads {
+				if contact, ok := contactMap[(*threads)[index].Contact]; ok {
+					(*threads)[index].ContactDetails = contact
+				}
+			}
+		}
 	}
 
 	ctxLogger.Info(fmt.Sprintf("fetched [%d] threads with params [%+#v]", len(*threads), params))

--- a/api/pkg/services/message_thread_service.go
+++ b/api/pkg/services/message_thread_service.go
@@ -280,17 +280,15 @@ type MessageThreadGetParams struct {
 
 // GetThreads fetches threads for an owner
 func (service *MessageThreadService) GetThreads(ctx context.Context, params MessageThreadGetParams) (*[]entities.MessageThread, error) {
-	ctx, span := service.tracer.Start(ctx)
+	ctx, span, ctxLogger := service.tracer.StartWithLogger(ctx, service.logger)
 	defer span.End()
-
-	ctxLogger := service.tracer.CtxLogger(service.logger, span)
 
 	threads, err := service.repository.Index(ctx, params.UserID, params.Owner, params.IsArchived, params.IndexParams)
 	if err != nil {
 		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "could not fetch messages threads for params [%+#v]", params))
 	}
 
-	if params.WithContacts && service.contactService != nil && len(*threads) > 0 {
+	if params.WithContacts && len(*threads) > 0 {
 		contactMap, mapErr := service.contactService.GetContactMap(ctx, params.UserID)
 		if mapErr != nil {
 			ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(mapErr, "cannot build contact map for user [%s]", params.UserID)))

--- a/api/pkg/services/message_thread_service.go
+++ b/api/pkg/services/message_thread_service.go
@@ -16,7 +16,7 @@ import (
 )
 
 type contactMapProvider interface {
-	GetContactMap(ctx context.Context, userID entities.UserID) (map[string]*entities.Contact, error)
+	GetContactMap(ctx context.Context, userID entities.UserID, phoneNumbers []string) (map[string]*entities.Contact, error)
 }
 
 // MessageThreadService is handles message requests
@@ -289,7 +289,12 @@ func (service *MessageThreadService) GetThreads(ctx context.Context, params Mess
 	}
 
 	if params.WithContacts && len(*threads) > 0 {
-		contactMap, mapErr := service.contactService.GetContactMap(ctx, params.UserID)
+		phoneNumbers := make([]string, 0, len(*threads))
+		for index := range *threads {
+			phoneNumbers = append(phoneNumbers, (*threads)[index].Contact)
+		}
+
+		contactMap, mapErr := service.contactService.GetContactMap(ctx, params.UserID, phoneNumbers)
 		if mapErr != nil {
 			ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(mapErr, "cannot build contact map for user [%s]", params.UserID)))
 		} else {

--- a/api/pkg/services/message_thread_service_contacts_test.go
+++ b/api/pkg/services/message_thread_service_contacts_test.go
@@ -1,0 +1,154 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type messageThreadContactRepositoryStub struct {
+	repositories.MessageThreadRepository
+	threads []entities.MessageThread
+	err     error
+	calls   int
+}
+
+func (stub *messageThreadContactRepositoryStub) Index(_ context.Context, _ entities.UserID, _ string, _ bool, _ repositories.IndexParams) (*[]entities.MessageThread, error) {
+	stub.calls++
+	if stub.err != nil {
+		return nil, stub.err
+	}
+	threads := make([]entities.MessageThread, len(stub.threads))
+	copy(threads, stub.threads)
+	return &threads, nil
+}
+
+type messageThreadContactProviderStub struct {
+	contacts map[string]*entities.Contact
+	err      error
+	calls    int
+	userID   entities.UserID
+}
+
+func (stub *messageThreadContactProviderStub) GetContactMap(_ context.Context, userID entities.UserID) (map[string]*entities.Contact, error) {
+	stub.calls++
+	stub.userID = userID
+	return stub.contacts, stub.err
+}
+
+type messageThreadContactLogger struct {
+	errors []error
+}
+
+var _ telemetry.Logger = (*messageThreadContactLogger)(nil)
+
+func (logger *messageThreadContactLogger) Error(err error) {
+	logger.errors = append(logger.errors, err)
+}
+func (logger *messageThreadContactLogger) WithService(string) telemetry.Logger { return logger }
+func (logger *messageThreadContactLogger) WithString(string, string) telemetry.Logger { return logger }
+
+func (logger *messageThreadContactLogger) WithSpan(trace.SpanContext) telemetry.Logger { return logger }
+func (logger *messageThreadContactLogger) Trace(string)                                {}
+func (logger *messageThreadContactLogger) Info(string)                                 {}
+func (logger *messageThreadContactLogger) Warn(error)                                  {}
+func (logger *messageThreadContactLogger) Debug(string)                                {}
+func (logger *messageThreadContactLogger) Fatal(error)                                 {}
+func (logger *messageThreadContactLogger) Printf(string, ...interface{})               {}
+
+func newMessageThreadContactServiceForTest(repository repositories.MessageThreadRepository, provider contactMapProvider, logger telemetry.Logger) *MessageThreadService {
+	if logger == nil {
+		logger = &noopLogger{}
+	}
+	tracer := telemetry.NewOtelLogger("test", logger)
+	return NewMessageThreadService(logger, tracer, repository, nil, nil, provider)
+}
+
+func TestGetThreads_SkipsContactLookupWhenFlagOff(t *testing.T) {
+	repository := &messageThreadContactRepositoryStub{threads: []entities.MessageThread{{Contact: "+18005550199"}}}
+	provider := &messageThreadContactProviderStub{contacts: map[string]*entities.Contact{
+		"+18005550199": {Name: "Alice"},
+	}}
+	service := newMessageThreadContactServiceForTest(repository, provider, nil)
+
+	threads, err := service.GetThreads(context.Background(), MessageThreadGetParams{UserID: entities.UserID("user-id"), WithContacts: false})
+
+	require.NoError(t, err)
+	require.Len(t, *threads, 1)
+	assert.Nil(t, (*threads)[0].ContactDetails)
+	assert.Equal(t, 0, provider.calls)
+}
+
+func TestGetThreads_AttachesContactDetailsWhenFlagOn(t *testing.T) {
+	alice := &entities.Contact{ID: uuid.New(), Name: "Alice", PhoneNumbers: []string{"+18005550199"}}
+	repository := &messageThreadContactRepositoryStub{threads: []entities.MessageThread{
+		{Contact: "+18005550199"},
+		{Contact: "+18005550100"},
+	}}
+	provider := &messageThreadContactProviderStub{contacts: map[string]*entities.Contact{
+		"+18005550199": alice,
+	}}
+	service := newMessageThreadContactServiceForTest(repository, provider, nil)
+
+	threads, err := service.GetThreads(context.Background(), MessageThreadGetParams{UserID: entities.UserID("user-id"), WithContacts: true})
+
+	require.NoError(t, err)
+	require.Len(t, *threads, 2)
+	assert.Equal(t, 1, provider.calls)
+	assert.Equal(t, entities.UserID("user-id"), provider.userID)
+	require.NotNil(t, (*threads)[0].ContactDetails)
+	assert.Same(t, alice, (*threads)[0].ContactDetails)
+	assert.Equal(t, "Alice", (*threads)[0].ContactDetails.Name)
+	assert.Nil(t, (*threads)[1].ContactDetails)
+}
+
+func TestGetThreads_SkipsContactLookupWhenNoThreads(t *testing.T) {
+	repository := &messageThreadContactRepositoryStub{threads: []entities.MessageThread{}}
+	provider := &messageThreadContactProviderStub{contacts: map[string]*entities.Contact{}}
+	service := newMessageThreadContactServiceForTest(repository, provider, nil)
+
+	threads, err := service.GetThreads(context.Background(), MessageThreadGetParams{UserID: entities.UserID("user-id"), WithContacts: true})
+
+	require.NoError(t, err)
+	require.Empty(t, *threads)
+	assert.Equal(t, 0, provider.calls)
+}
+
+func TestGetThreads_LogsContactMapErrorAndReturnsThreads(t *testing.T) {
+	repository := &messageThreadContactRepositoryStub{threads: []entities.MessageThread{{Contact: "+18005550199"}}}
+	provider := &messageThreadContactProviderStub{err: errors.New("contacts unavailable")}
+	logger := &messageThreadContactLogger{}
+	service := newMessageThreadContactServiceForTest(repository, provider, logger)
+
+	threads, err := service.GetThreads(context.Background(), MessageThreadGetParams{UserID: entities.UserID("user-id"), WithContacts: true})
+
+	require.NoError(t, err)
+	require.Len(t, *threads, 1)
+	assert.Nil(t, (*threads)[0].ContactDetails)
+	assert.Equal(t, 1, provider.calls)
+	require.Len(t, logger.errors, 1)
+	assert.ErrorContains(t, logger.errors[0], "cannot build contact map")
+}
+
+func TestGetThreads_DoesNotLookupContactsWhenRepositoryFails(t *testing.T) {
+	repository := &messageThreadContactRepositoryStub{err: stacktrace.NewError("repository failed")}
+	provider := &messageThreadContactProviderStub{contacts: map[string]*entities.Contact{
+		"+18005550199": {Name: "Alice"},
+	}}
+	service := newMessageThreadContactServiceForTest(repository, provider, nil)
+
+	threads, err := service.GetThreads(context.Background(), MessageThreadGetParams{UserID: entities.UserID("user-id"), WithContacts: true})
+
+	require.Error(t, err)
+	assert.Nil(t, threads)
+	assert.Equal(t, 0, provider.calls)
+}

--- a/api/pkg/services/message_thread_service_contacts_test.go
+++ b/api/pkg/services/message_thread_service_contacts_test.go
@@ -37,11 +37,13 @@ type messageThreadContactProviderStub struct {
 	err      error
 	calls    int
 	userID   entities.UserID
+	numbers  []string
 }
 
-func (stub *messageThreadContactProviderStub) GetContactMap(_ context.Context, userID entities.UserID) (map[string]*entities.Contact, error) {
+func (stub *messageThreadContactProviderStub) GetContactMap(_ context.Context, userID entities.UserID, phoneNumbers []string) (map[string]*entities.Contact, error) {
 	stub.calls++
 	stub.userID = userID
+	stub.numbers = append([]string{}, phoneNumbers...)
 	return stub.contacts, stub.err
 }
 
@@ -54,7 +56,9 @@ var _ telemetry.Logger = (*messageThreadContactLogger)(nil)
 func (logger *messageThreadContactLogger) Error(err error) {
 	logger.errors = append(logger.errors, err)
 }
+
 func (logger *messageThreadContactLogger) WithService(string) telemetry.Logger { return logger }
+
 func (logger *messageThreadContactLogger) WithString(string, string) telemetry.Logger { return logger }
 
 func (logger *messageThreadContactLogger) WithSpan(trace.SpanContext) telemetry.Logger { return logger }
@@ -105,6 +109,7 @@ func TestGetThreads_AttachesContactDetailsWhenFlagOn(t *testing.T) {
 	require.Len(t, *threads, 2)
 	assert.Equal(t, 1, provider.calls)
 	assert.Equal(t, entities.UserID("user-id"), provider.userID)
+	assert.Equal(t, []string{"+18005550199", "+18005550100"}, provider.numbers)
 	require.NotNil(t, (*threads)[0].ContactDetails)
 	assert.Same(t, alice, (*threads)[0].ContactDetails)
 	assert.Equal(t, "Alice", (*threads)[0].ContactDetails.Name)

--- a/api/pkg/services/message_thread_service_test.go
+++ b/api/pkg/services/message_thread_service_test.go
@@ -72,7 +72,7 @@ func (stub *messageThreadRepositoryStub) DeleteAllForUser(context.Context, entit
 func newMessageThreadServiceForTest(repository repositories.MessageThreadRepository) *MessageThreadService {
 	logger := &noopLogger{}
 	tracer := telemetry.NewOtelLogger("test", logger)
-	return NewMessageThreadService(logger, tracer, repository, nil, nil)
+	return NewMessageThreadService(logger, tracer, repository, nil, nil, nil)
 }
 
 func TestUpdateThreadPassesUnreadWatermarkForInboundActivity(t *testing.T) {

--- a/api/pkg/validators/bulk_message_handler_validator.go
+++ b/api/pkg/validators/bulk_message_handler_validator.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/xuri/excelize/v2"
 
-	"github.com/NdoleStudio/httpsms/pkg/cache"
 	"github.com/NdoleStudio/httpsms/pkg/entities"
 	"github.com/NdoleStudio/httpsms/pkg/repositories"
 	"github.com/NdoleStudio/httpsms/pkg/requests"
@@ -31,7 +30,6 @@ type BulkMessageHandlerValidator struct {
 	userService  *services.UserService
 	logger       telemetry.Logger
 	tracer       telemetry.Tracer
-	cache        cache.Cache
 }
 
 // NewBulkMessageHandlerValidator creates a new handlers.BulkMessageHandlerValidator validator
@@ -40,14 +38,12 @@ func NewBulkMessageHandlerValidator(
 	tracer telemetry.Tracer,
 	phoneService *services.PhoneService,
 	userService *services.UserService,
-	appCache cache.Cache,
 ) (v *BulkMessageHandlerValidator) {
 	return &BulkMessageHandlerValidator{
 		logger:       logger.WithService(fmt.Sprintf("%T", v)),
 		tracer:       tracer,
 		userService:  userService,
 		phoneService: phoneService,
-		cache:        appCache,
 	}
 }
 

--- a/api/pkg/validators/contact_handler_validator.go
+++ b/api/pkg/validators/contact_handler_validator.go
@@ -31,6 +31,8 @@ const (
 	contactCSVColumnPhones   = "PhoneNumbers"
 	contactCSVContentType    = "text/csv"
 	contactCSVContentTypeAlt = "application/csv"
+	contactCSVContentTypeBin = "application/octet-stream"
+	contactCSVContentTypeXls = "application/vnd.ms-excel"
 )
 
 // ContactHandlerValidator validates models used in handlers.ContactHandler
@@ -317,8 +319,11 @@ func isContactCSVFile(header *multipart.FileHeader) bool {
 		contentType = strings.TrimSpace(contentType[:index])
 	}
 
-	return contentType == contactCSVContentType ||
-		contentType == contactCSVContentTypeAlt
+	return contentType == "" ||
+		contentType == contactCSVContentType ||
+		contentType == contactCSVContentTypeAlt ||
+		contentType == contactCSVContentTypeBin ||
+		contentType == contactCSVContentTypeXls
 }
 
 func splitContactMultiValue(value string) []string {

--- a/api/pkg/validators/contact_handler_validator.go
+++ b/api/pkg/validators/contact_handler_validator.go
@@ -146,11 +146,15 @@ func (validator *ContactHandlerValidator) ValidateUpload(ctx context.Context, us
 
 	items := make([]requests.ContactItem, 0, len(rows))
 	for _, row := range rows {
-		item := requests.ContactItem{
-			Name:         strings.TrimSpace(row.values[contactCSVColumnName]),
+		// Sanitize each row exactly like the JSON create path (SanitizeContactItem)
+		// before validating it, so both entry points accept and normalize the same
+		// phone/email formats. Row-indexed error messages are preserved because the
+		// row number is still passed to validateItem.
+		item := requests.SanitizeContactItem(requests.ContactItem{
+			Name:         row.values[contactCSVColumnName],
 			Emails:       splitContactMultiValue(row.values[contactCSVColumnEmails]),
 			PhoneNumbers: splitContactMultiValue(row.values[contactCSVColumnPhones]),
-		}
+		})
 		items = append(items, item)
 		validator.validateItem(result, contactUploadDocumentKey, "Row", row.number, item)
 	}

--- a/api/pkg/validators/contact_handler_validator.go
+++ b/api/pkg/validators/contact_handler_validator.go
@@ -1,0 +1,349 @@
+package validators
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/mail"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/requests"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/nyaruka/phonenumbers"
+	"github.com/thedevsaddam/govalidator"
+)
+
+const (
+	maxContactBatch          = 1000
+	maxContactUploadBytes    = 500 * 1024
+	contactUploadDocumentKey = "document"
+	contactUploadContactsKey = "contacts"
+	contactCSVColumnName     = "Name"
+	contactCSVColumnEmails   = "Emails"
+	contactCSVColumnPhones   = "PhoneNumbers"
+	contactCSVContentType    = "text/csv"
+	contactCSVContentTypeAlt = "application/csv"
+)
+
+// ContactHandlerValidator validates models used in handlers.ContactHandler
+type ContactHandlerValidator struct {
+	validator
+	logger telemetry.Logger
+	tracer telemetry.Tracer
+}
+
+// NewContactHandlerValidator creates a new handlers.ContactHandler validator
+func NewContactHandlerValidator(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+) (v *ContactHandlerValidator) {
+	return &ContactHandlerValidator{
+		logger: logger.WithService(fmt.Sprintf("%T", v)),
+		tracer: tracer,
+	}
+}
+
+// ValidateStore validates a contact create request.
+func (validator *ContactHandlerValidator) ValidateStore(_ context.Context, request requests.ContactStoreRequest) url.Values {
+	result := url.Values{}
+
+	if len(request.Contacts) == 0 {
+		result.Add(contactUploadContactsKey, "You must provide at least one contact.")
+		return result
+	}
+
+	if len(request.Contacts) > maxContactBatch {
+		result.Add(contactUploadContactsKey, fmt.Sprintf("You cannot create more than %d contacts in one request.", maxContactBatch))
+		return result
+	}
+
+	for index, item := range request.Contacts {
+		validator.validateItem(result, contactUploadContactsKey, "Contact", index+1, item)
+	}
+
+	return result
+}
+
+// ValidateUpdate validates a contact update request.
+func (validator *ContactHandlerValidator) ValidateUpdate(_ context.Context, request requests.ContactUpdateRequest) url.Values {
+	result := url.Values{}
+	validator.validateItem(result, contactUploadContactsKey, "Contact", 1, requests.ContactItem{
+		Name:         request.Name,
+		Emails:       request.Emails,
+		PhoneNumbers: request.PhoneNumbers,
+		Properties:   request.Properties,
+	})
+	return result
+}
+
+// ValidateIndex validates a contact index request.
+func (validator *ContactHandlerValidator) ValidateIndex(_ context.Context, request requests.ContactIndex) url.Values {
+	result := govalidator.New(govalidator.Options{
+		Data: &request,
+		Rules: govalidator.MapData{
+			"limit": []string{"required", "numeric"},
+			"skip":  []string{"required", "numeric"},
+			"query": []string{"max:100"},
+		},
+	}).ValidateStruct()
+
+	if limit, err := strconv.Atoi(request.Limit); request.Limit != "" && err == nil {
+		if limit < 1 || limit > 100 {
+			result.Add("limit", "The limit must be between 1 and 100.")
+		}
+	}
+
+	if skip, err := strconv.Atoi(request.Skip); request.Skip != "" && err == nil {
+		if skip < 0 {
+			result.Add("skip", "The skip must be greater than or equal to 0.")
+		}
+	}
+
+	return result
+}
+
+// ValidateUpload parses and validates a CSV contacts upload.
+func (validator *ContactHandlerValidator) ValidateUpload(ctx context.Context, userID entities.UserID, header *multipart.FileHeader) ([]requests.ContactItem, url.Values) {
+	_, span, ctxLogger := validator.tracer.StartWithLogger(ctx, validator.logger)
+	defer span.End()
+
+	result := url.Values{}
+	if header == nil {
+		result.Add(contactUploadDocumentKey, "The CSV file is required.")
+		return nil, result
+	}
+
+	if !isContactCSVFile(header) {
+		ctxLogger.Error(stacktrace.NewErrorf("cannot parse file [%s] for user [%s] with content type [%s]", header.Filename, userID, header.Header.Get("Content-Type")))
+		result.Add(contactUploadDocumentKey, fmt.Sprintf("The file [%s] is not a valid CSV file. Only CSV files are supported.", header.Filename))
+		return nil, result
+	}
+
+	content, errors := validator.parseContactUploadBytes(ctxLogger, userID, header)
+	if len(errors) != 0 {
+		return nil, errors
+	}
+
+	rows, errors := validator.parseContactCSV(ctxLogger, userID, header.Filename, content)
+	if len(errors) != 0 {
+		return nil, errors
+	}
+
+	if len(rows) > maxContactBatch {
+		result.Add(contactUploadDocumentKey, fmt.Sprintf("The uploaded file must contain no more than %d records.", maxContactBatch))
+		return nil, result
+	}
+
+	items := make([]requests.ContactItem, 0, len(rows))
+	for _, row := range rows {
+		item := requests.ContactItem{
+			Name:         strings.TrimSpace(row.values[contactCSVColumnName]),
+			Emails:       splitContactMultiValue(row.values[contactCSVColumnEmails]),
+			PhoneNumbers: splitContactMultiValue(row.values[contactCSVColumnPhones]),
+		}
+		items = append(items, item)
+		validator.validateItem(result, contactUploadDocumentKey, "Row", row.number, item)
+	}
+
+	if len(items) == 0 {
+		result.Add(contactUploadDocumentKey, "The uploaded file must contain at least one contact.")
+	}
+
+	return items, result
+}
+
+func (validator *ContactHandlerValidator) validateItem(result url.Values, key string, label string, index int, item requests.ContactItem) {
+	prefix := fmt.Sprintf("%s [%d]", label, index)
+
+	if strings.TrimSpace(item.Name) == "" {
+		result.Add(key, fmt.Sprintf("%s: The name is required.", prefix))
+	}
+
+	if !hasNonEmptyValue(item.PhoneNumbers) {
+		result.Add(key, fmt.Sprintf("%s: At least one phone number is required.", prefix))
+	}
+
+	for _, number := range item.PhoneNumbers {
+		cleanNumber := strings.TrimSpace(number)
+		if cleanNumber == "" {
+			result.Add(key, fmt.Sprintf("%s: The phone number is required.", prefix))
+			continue
+		}
+
+		parsed, err := phonenumbers.Parse(cleanNumber, phonenumbers.UNKNOWN_REGION)
+		if err != nil || !phonenumbers.IsValidNumber(parsed) {
+			result.Add(key, fmt.Sprintf("%s: The phone number [%s] is not a valid E.164 phone number.", prefix, cleanNumber))
+		}
+	}
+
+	for _, email := range item.Emails {
+		cleanEmail := strings.TrimSpace(email)
+		if cleanEmail == "" {
+			result.Add(key, fmt.Sprintf("%s: The email is not a valid email address.", prefix))
+			continue
+		}
+
+		address, err := mail.ParseAddress(cleanEmail)
+		if err != nil || address.Address != cleanEmail {
+			result.Add(key, fmt.Sprintf("%s: The email [%s] is not a valid email address.", prefix, cleanEmail))
+		}
+	}
+}
+
+func (validator *ContactHandlerValidator) parseContactUploadBytes(ctxLogger telemetry.Logger, userID entities.UserID, header *multipart.FileHeader) ([]byte, url.Values) {
+	result := url.Values{}
+
+	if header.Size > maxContactUploadBytes {
+		result.Add(contactUploadDocumentKey, "The CSV file must be less than or equal to 500 KB.")
+		return nil, result
+	}
+
+	file, err := header.Open()
+	if err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot open file [%s] for reading for user [%s]", header.Filename, userID))
+		result.Add(contactUploadDocumentKey, fmt.Sprintf("Cannot open the uploaded file [%s].", header.Filename))
+		return nil, result
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			ctxLogger.Error(stacktrace.Propagatef(closeErr, "cannot close file [%s] for user [%s]", header.Filename, userID))
+		}
+	}()
+
+	content, err := io.ReadAll(io.LimitReader(file, maxContactUploadBytes+1))
+	if err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot read file [%s] for user [%s]", header.Filename, userID))
+		result.Add(contactUploadDocumentKey, fmt.Sprintf("Cannot read the uploaded file [%s].", header.Filename))
+		return nil, result
+	}
+
+	if len(content) > maxContactUploadBytes {
+		result.Add(contactUploadDocumentKey, "The CSV file must be less than or equal to 500 KB.")
+		return nil, result
+	}
+
+	return content, result
+}
+
+type contactCSVRow struct {
+	number int
+	values map[string]string
+}
+
+func (validator *ContactHandlerValidator) parseContactCSV(ctxLogger telemetry.Logger, userID entities.UserID, filename string, content []byte) ([]contactCSVRow, url.Values) {
+	result := url.Values{}
+	reader := csv.NewReader(bytes.NewReader(content))
+	reader.TrimLeadingSpace = true
+
+	headers, err := reader.Read()
+	if err == io.EOF {
+		result.Add(contactUploadDocumentKey, fmt.Sprintf("Cannot parse the uploaded CSV file [%s]. The file is empty.", filename))
+		return nil, result
+	}
+	if err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot read CSV header from file [%s] for user [%s]", filename, userID))
+		result.Add(contactUploadDocumentKey, fmt.Sprintf("Cannot parse the uploaded CSV file [%s]. Use the official httpSMS contacts template.", filename))
+		return nil, result
+	}
+
+	columnIndexes, ok := contactCSVColumnIndexes(headers)
+	if !ok {
+		result.Add(contactUploadDocumentKey, "The uploaded CSV file must contain the columns [Name, Emails, PhoneNumbers].")
+		return nil, result
+	}
+
+	reader.FieldsPerRecord = len(headers)
+
+	var rows []contactCSVRow
+	for rowNumber := 2; ; rowNumber++ {
+		record, readErr := reader.Read()
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			ctxLogger.Error(stacktrace.Propagatef(readErr, "cannot read CSV row [%d] from file [%s] for user [%s]", rowNumber, filename, userID))
+			result.Add(contactUploadDocumentKey, fmt.Sprintf("Cannot parse the uploaded CSV file [%s]. Use the official httpSMS contacts template.", filename))
+			return nil, result
+		}
+
+		row := contactCSVRow{
+			number: rowNumber,
+			values: map[string]string{
+				contactCSVColumnName:   record[columnIndexes[contactCSVColumnName]],
+				contactCSVColumnEmails: record[columnIndexes[contactCSVColumnEmails]],
+				contactCSVColumnPhones: record[columnIndexes[contactCSVColumnPhones]],
+			},
+		}
+		rows = append(rows, row)
+		if len(rows) > maxContactBatch {
+			return rows, result
+		}
+	}
+
+	return rows, result
+}
+
+func contactCSVColumnIndexes(headers []string) (map[string]int, bool) {
+	required := []string{contactCSVColumnName, contactCSVColumnEmails, contactCSVColumnPhones}
+	indexes := map[string]int{}
+	for index, header := range headers {
+		indexes[strings.TrimSpace(header)] = index
+	}
+
+	for _, column := range required {
+		if _, ok := indexes[column]; !ok {
+			return nil, false
+		}
+	}
+
+	return indexes, true
+}
+
+func isContactCSVFile(header *multipart.FileHeader) bool {
+	if strings.ToLower(filepath.Ext(header.Filename)) != ".csv" {
+		return false
+	}
+
+	contentType := strings.ToLower(strings.TrimSpace(header.Header.Get("Content-Type")))
+	if index := strings.Index(contentType, ";"); index >= 0 {
+		contentType = strings.TrimSpace(contentType[:index])
+	}
+
+	return contentType == contactCSVContentType ||
+		contentType == contactCSVContentTypeAlt
+}
+
+func splitContactMultiValue(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+
+	var result []string
+	for _, item := range strings.FieldsFunc(value, func(r rune) bool {
+		return r == ',' || r == ';'
+	}) {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			result = append(result, item)
+		}
+	}
+
+	return result
+}
+
+func hasNonEmptyValue(values []string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/api/pkg/validators/contact_handler_validator.go
+++ b/api/pkg/validators/contact_handler_validator.go
@@ -91,9 +91,10 @@ func (validator *ContactHandlerValidator) ValidateIndex(_ context.Context, reque
 	result := govalidator.New(govalidator.Options{
 		Data: &request,
 		Rules: govalidator.MapData{
-			"limit": []string{"required", "numeric"},
-			"skip":  []string{"required", "numeric"},
-			"query": []string{"max:100"},
+			"limit":   []string{"required", "numeric"},
+			"skip":    []string{"required", "numeric"},
+			"query":   []string{"max:100"},
+			"sort_by": []string{"in:name,updated_at"},
 		},
 	}).ValidateStruct()
 

--- a/api/pkg/validators/contact_handler_validator_test.go
+++ b/api/pkg/validators/contact_handler_validator_test.go
@@ -1,0 +1,355 @@
+package validators
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"strings"
+	"testing"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/requests"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func newContactValidator() *ContactHandlerValidator {
+	return &ContactHandlerValidator{}
+}
+
+func newContactUploadValidator() *ContactHandlerValidator {
+	logger := &contactValidatorNoopLogger{}
+	return NewContactHandlerValidator(logger, telemetry.NewOtelLogger("test", logger))
+}
+
+func TestContactValidator_ValidateStore_ValidOneAndMany(t *testing.T) {
+	validator := newContactValidator()
+
+	tests := []struct {
+		name    string
+		request requests.ContactStoreRequest
+	}{
+		{
+			name: "one contact",
+			request: requests.ContactStoreRequest{Contacts: []requests.ContactItem{{
+				Name:         "Alice",
+				PhoneNumbers: []string{"+18005550199"},
+				Emails:       []string{"alice@example.com"},
+			}}},
+		},
+		{
+			name: "many contacts",
+			request: requests.ContactStoreRequest{Contacts: []requests.ContactItem{
+				{
+					Name:         "Alice",
+					PhoneNumbers: []string{"+18005550199", "+18005550100"},
+					Emails:       []string{"alice@example.com", "alice.work@example.com"},
+				},
+				{
+					Name:         "Bob",
+					PhoneNumbers: []string{"+14155552671"},
+				},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validator.ValidateStore(context.Background(), tt.request)
+
+			assert.Empty(t, errs)
+		})
+	}
+}
+
+func TestContactValidator_ValidateStore_MissingName(t *testing.T) {
+	validator := newContactValidator()
+
+	errs := validator.ValidateStore(context.Background(), requests.ContactStoreRequest{Contacts: []requests.ContactItem{{
+		PhoneNumbers: []string{"+18005550199"},
+	}}})
+
+	require.NotEmpty(t, errs.Get("contacts"))
+	assert.Contains(t, errs["contacts"][0], "Contact [1]")
+	assert.Contains(t, errs["contacts"][0], "name")
+}
+
+func TestContactValidator_ValidateStore_NoPhoneNumber(t *testing.T) {
+	validator := newContactValidator()
+
+	errs := validator.ValidateStore(context.Background(), requests.ContactStoreRequest{Contacts: []requests.ContactItem{{
+		Name: "Alice",
+	}}})
+
+	require.NotEmpty(t, errs.Get("contacts"))
+	assert.Contains(t, errs["contacts"][0], "Contact [1]")
+	assert.Contains(t, errs["contacts"][0], "phone number")
+}
+
+func TestContactValidator_ValidateStore_EmptyBatch(t *testing.T) {
+	validator := newContactValidator()
+
+	errs := validator.ValidateStore(context.Background(), requests.ContactStoreRequest{})
+
+	require.NotEmpty(t, errs.Get("contacts"))
+	assert.Contains(t, errs["contacts"][0], "at least one contact")
+}
+
+func TestContactValidator_ValidateStore_InvalidPhoneNumber(t *testing.T) {
+	validator := newContactValidator()
+
+	errs := validator.ValidateStore(context.Background(), requests.ContactStoreRequest{Contacts: []requests.ContactItem{{
+		Name:         "Alice",
+		PhoneNumbers: []string{"not-a-number"},
+	}}})
+
+	require.NotEmpty(t, errs.Get("contacts"))
+	assert.Contains(t, errs["contacts"][0], "Contact [1]")
+	assert.Contains(t, errs["contacts"][0], "not-a-number")
+}
+
+func TestContactValidator_ValidateStore_InvalidEmail(t *testing.T) {
+	validator := newContactValidator()
+
+	errs := validator.ValidateStore(context.Background(), requests.ContactStoreRequest{Contacts: []requests.ContactItem{{
+		Name:         "Alice",
+		PhoneNumbers: []string{"+18005550199"},
+		Emails:       []string{"not-an-email"},
+	}}})
+
+	require.NotEmpty(t, errs.Get("contacts"))
+	assert.Contains(t, errs["contacts"][0], "Contact [1]")
+	assert.Contains(t, errs["contacts"][0], "not-an-email")
+}
+
+func TestContactValidator_ValidateStore_RejectsEmptyPhoneAndEmailElements(t *testing.T) {
+	validator := newContactValidator()
+
+	errs := validator.ValidateStore(context.Background(), requests.ContactStoreRequest{Contacts: []requests.ContactItem{{
+		Name:         "Alice",
+		PhoneNumbers: []string{"+18005550199", " "},
+		Emails:       []string{" "},
+	}}})
+
+	contactsErrors := strings.Join(errs["contacts"], "\n")
+	assert.Contains(t, contactsErrors, "phone number")
+	assert.Contains(t, contactsErrors, "email")
+}
+
+func TestContactValidator_ValidateStore_RejectsMoreThan1000Contacts(t *testing.T) {
+	validator := newContactValidator()
+	contacts := make([]requests.ContactItem, 1001)
+	for index := range contacts {
+		contacts[index] = requests.ContactItem{Name: "Alice", PhoneNumbers: []string{"+18005550199"}}
+	}
+
+	errs := validator.ValidateStore(context.Background(), requests.ContactStoreRequest{Contacts: contacts})
+
+	require.NotEmpty(t, errs.Get("contacts"))
+	assert.Contains(t, errs["contacts"][0], "1000")
+}
+
+func TestContactValidator_ValidateUpdate_ValidAndInvalid(t *testing.T) {
+	validator := newContactValidator()
+
+	validErrs := validator.ValidateUpdate(context.Background(), requests.ContactUpdateRequest{
+		Name:         "Alice",
+		PhoneNumbers: []string{"+18005550199"},
+		Emails:       []string{"alice@example.com"},
+	})
+	assert.Empty(t, validErrs)
+
+	invalidErrs := validator.ValidateUpdate(context.Background(), requests.ContactUpdateRequest{
+		Name:         "",
+		PhoneNumbers: []string{"not-a-number"},
+		Emails:       []string{"not-an-email"},
+	})
+	assert.NotEmpty(t, invalidErrs.Get("contacts"))
+}
+
+func TestContactValidator_ValidateIndex_Bounds(t *testing.T) {
+	validator := newContactValidator()
+
+	validErrs := validator.ValidateIndex(context.Background(), requests.ContactIndex{Skip: "0", Limit: "100", Query: strings.Repeat("a", 100)})
+	assert.Empty(t, validErrs)
+
+	tests := []struct {
+		name    string
+		request requests.ContactIndex
+		key     string
+	}{
+		{name: "limit too low", request: requests.ContactIndex{Skip: "0", Limit: "0"}, key: "limit"},
+		{name: "limit too high", request: requests.ContactIndex{Skip: "0", Limit: "101"}, key: "limit"},
+		{name: "skip negative", request: requests.ContactIndex{Skip: "-1", Limit: "20"}, key: "skip"},
+		{name: "query too long", request: requests.ContactIndex{Skip: "0", Limit: "20", Query: strings.Repeat("a", 101)}, key: "query"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validator.ValidateIndex(context.Background(), tt.request)
+
+			assert.NotEmpty(t, errs.Get(tt.key))
+		})
+	}
+}
+
+func TestContactValidator_ValidateUpload_ParsesValidCSVWithQuotedMultiValueCells(t *testing.T) {
+	validator := newContactUploadValidator()
+	header := multipartFileHeader(t, "contacts.csv", "text/csv", strings.Join([]string{
+		"Name,Emails,PhoneNumbers",
+		`Alice,"alice@example.com,alice.work@example.com","+18005550199,+18005550100"`,
+		`Bob,bob@example.com;bob.work@example.com,+14155552671;+14155552672`,
+	}, "\n"))
+
+	items, errs := validator.ValidateUpload(context.Background(), entities.UserID("user-1"), header)
+
+	require.Empty(t, errs)
+	require.Len(t, items, 2)
+	assert.Equal(t, "Alice", items[0].Name)
+	assert.Equal(t, []string{"alice@example.com", "alice.work@example.com"}, items[0].Emails)
+	assert.Equal(t, []string{"+18005550199", "+18005550100"}, items[0].PhoneNumbers)
+	assert.Equal(t, "Bob", items[1].Name)
+	assert.Equal(t, []string{"bob@example.com", "bob.work@example.com"}, items[1].Emails)
+	assert.Equal(t, []string{"+14155552671", "+14155552672"}, items[1].PhoneNumbers)
+}
+
+func TestContactValidator_ValidateUpload_RejectsNonCSVExtensionAndMIME(t *testing.T) {
+	validator := newContactUploadValidator()
+
+	tests := []struct {
+		name        string
+		filename    string
+		contentType string
+	}{
+		{name: "xlsx extension", filename: "contacts.xlsx", contentType: "text/csv"},
+		{name: "xlsx mime", filename: "contacts.csv", contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := multipartFileHeader(t, tt.filename, tt.contentType, "Name,Emails,PhoneNumbers\nAlice,alice@example.com,+18005550199")
+
+			items, errs := validator.ValidateUpload(context.Background(), entities.UserID("user-1"), header)
+
+			assert.Nil(t, items)
+			assert.NotEmpty(t, errs.Get("document"))
+		})
+	}
+}
+
+func TestContactValidator_ValidateUpload_RejectsOversizedFile(t *testing.T) {
+	validator := newContactUploadValidator()
+	header := multipartFileHeader(t, "contacts.csv", "text/csv", strings.Repeat("a", 500*1024+1))
+
+	items, errs := validator.ValidateUpload(context.Background(), entities.UserID("user-1"), header)
+
+	assert.Nil(t, items)
+	require.NotEmpty(t, errs.Get("document"))
+	assert.Contains(t, errs["document"][0], "500 KB")
+}
+
+func TestContactValidator_ValidateUpload_RejectsMalformedCSV(t *testing.T) {
+	validator := newContactUploadValidator()
+	header := multipartFileHeader(t, "contacts.csv", "text/csv", "Name,Emails,PhoneNumbers\nAlice,\"alice@example.com,+18005550199")
+
+	items, errs := validator.ValidateUpload(context.Background(), entities.UserID("user-1"), header)
+
+	assert.Nil(t, items)
+	require.NotEmpty(t, errs.Get("document"))
+	assert.Contains(t, errs["document"][0], "Cannot parse")
+}
+
+func TestContactValidator_ValidateUpload_RejectsMissingRequiredColumns(t *testing.T) {
+	validator := newContactUploadValidator()
+	header := multipartFileHeader(t, "contacts.csv", "text/csv", "Name,Emails\nAlice,alice@example.com")
+
+	items, errs := validator.ValidateUpload(context.Background(), entities.UserID("user-1"), header)
+
+	assert.Nil(t, items)
+	require.NotEmpty(t, errs.Get("document"))
+	assert.Contains(t, errs["document"][0], "Name, Emails, PhoneNumbers")
+}
+
+func TestContactValidator_ValidateUpload_RejectsMoreThan1000Rows(t *testing.T) {
+	validator := newContactUploadValidator()
+	rows := []string{"Name,Emails,PhoneNumbers"}
+	for range 1001 {
+		rows = append(rows, "Alice,alice@example.com,+18005550199")
+	}
+	header := multipartFileHeader(t, "contacts.csv", "text/csv", strings.Join(rows, "\n"))
+
+	items, errs := validator.ValidateUpload(context.Background(), entities.UserID("user-1"), header)
+
+	assert.Nil(t, items)
+	require.NotEmpty(t, errs.Get("document"))
+	assert.Contains(t, errs["document"][0], "1000")
+}
+
+func TestContactValidator_ValidateUpload_ReturnsRowIndexedValidationErrors(t *testing.T) {
+	validator := newContactUploadValidator()
+	header := multipartFileHeader(t, "contacts.csv", "text/csv", strings.Join([]string{
+		"Name,Emails,PhoneNumbers",
+		",alice@example.com,+18005550199",
+		"Alice,,",
+		"Bob,not-an-email,not-a-number",
+	}, "\n"))
+
+	items, errs := validator.ValidateUpload(context.Background(), entities.UserID("user-1"), header)
+
+	require.Len(t, items, 3)
+	documentErrors := strings.Join(errs["document"], "\n")
+	assert.Contains(t, documentErrors, "Row [2]")
+	assert.Contains(t, documentErrors, "Row [3]")
+	assert.Contains(t, documentErrors, "Row [4]")
+	assert.Contains(t, documentErrors, "not-an-email")
+	assert.Contains(t, documentErrors, "not-a-number")
+}
+
+func multipartFileHeader(t *testing.T, filename string, contentType string, content string) *multipart.FileHeader {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	header := textproto.MIMEHeader{}
+	header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="document"; filename="%s"`, filename))
+	header.Set("Content-Type", contentType)
+
+	part, err := writer.CreatePart(header)
+	require.NoError(t, err)
+	_, err = part.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	request := httptest.NewRequest(http.MethodPost, "/", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	require.NoError(t, request.ParseMultipartForm(int64(body.Len()+1024)))
+	files := request.MultipartForm.File["document"]
+	require.Len(t, files, 1)
+
+	return files[0]
+}
+
+type contactValidatorNoopLogger struct{}
+
+var _ telemetry.Logger = (*contactValidatorNoopLogger)(nil)
+
+func (logger *contactValidatorNoopLogger) Error(_ error)                         {}
+func (logger *contactValidatorNoopLogger) WithService(_ string) telemetry.Logger { return logger }
+
+func (logger *contactValidatorNoopLogger) WithString(_, _ string) telemetry.Logger { return logger }
+
+func (logger *contactValidatorNoopLogger) WithSpan(_ trace.SpanContext) telemetry.Logger {
+	return logger
+}
+func (logger *contactValidatorNoopLogger) Trace(_ string)                    {}
+func (logger *contactValidatorNoopLogger) Info(_ string)                     {}
+func (logger *contactValidatorNoopLogger) Warn(_ error)                      {}
+func (logger *contactValidatorNoopLogger) Debug(_ string)                    {}
+func (logger *contactValidatorNoopLogger) Fatal(_ error)                     {}
+func (logger *contactValidatorNoopLogger) Printf(_ string, _ ...interface{}) {}

--- a/api/pkg/validators/contact_handler_validator_test.go
+++ b/api/pkg/validators/contact_handler_validator_test.go
@@ -366,6 +366,25 @@ func TestContactValidator_ValidateUpload_ReturnsRowIndexedValidationErrors(t *te
 	assert.Contains(t, documentErrors, "not-a-number")
 }
 
+func TestContactValidator_ValidateUpload_SanitizesItemsLikeJSONBeforeValidation(t *testing.T) {
+	validator := newContactUploadValidator()
+	// The phone number lacks a leading "+" and the email has mixed case and
+	// surrounding whitespace. The JSON create path sanitizes these before
+	// validation, so the CSV path must accept and normalize them identically.
+	header := multipartFileHeader(t, "contacts.csv", "text/csv", strings.Join([]string{
+		"Name,Emails,PhoneNumbers",
+		"Alice, Alice@Example.com ,18005550199",
+	}, "\n"))
+
+	items, errs := validator.ValidateUpload(context.Background(), entities.UserID("user-1"), header)
+
+	require.Empty(t, errs, "sanitized CSV rows must pass validation like the JSON path")
+	require.Len(t, items, 1)
+	assert.Equal(t, "Alice", items[0].Name)
+	assert.Equal(t, []string{"+18005550199"}, items[0].PhoneNumbers)
+	assert.Equal(t, []string{"alice@example.com"}, items[0].Emails)
+}
+
 func multipartFileHeader(t *testing.T, filename string, contentType string, content string) *multipart.FileHeader {
 	t.Helper()
 

--- a/api/pkg/validators/contact_handler_validator_test.go
+++ b/api/pkg/validators/contact_handler_validator_test.go
@@ -243,6 +243,61 @@ func TestContactValidator_ValidateUpload_RejectsNonCSVExtensionAndMIME(t *testin
 	}
 }
 
+func TestContactValidator_ValidateUpload_AcceptsCSVWithOctetStreamMIME(t *testing.T) {
+	validator := newContactUploadValidator()
+	header := multipartFileHeader(t, "contacts.csv", "application/octet-stream", "Name,Emails,PhoneNumbers\nAlice,alice@example.com,+18005550199")
+
+	items, errs := validator.ValidateUpload(context.Background(), entities.UserID("user-1"), header)
+
+	require.Empty(t, errs)
+	require.Len(t, items, 1)
+	assert.Equal(t, "Alice", items[0].Name)
+}
+
+func TestContactValidator_ValidateUpload_AcceptsCSVWithVndMsExcelMIME(t *testing.T) {
+	validator := newContactUploadValidator()
+	header := multipartFileHeader(t, "contacts.csv", "application/vnd.ms-excel", "Name,Emails,PhoneNumbers\nAlice,alice@example.com,+18005550199")
+
+	items, errs := validator.ValidateUpload(context.Background(), entities.UserID("user-1"), header)
+
+	require.Empty(t, errs)
+	require.Len(t, items, 1)
+	assert.Equal(t, "Alice", items[0].Name)
+}
+
+func TestContactValidator_ValidateUpload_AcceptsCSVWithEmptyMIME(t *testing.T) {
+	validator := newContactUploadValidator()
+	header := multipartFileHeader(t, "contacts.csv", "", "Name,Emails,PhoneNumbers\nAlice,alice@example.com,+18005550199")
+
+	items, errs := validator.ValidateUpload(context.Background(), entities.UserID("user-1"), header)
+
+	require.Empty(t, errs)
+	require.Len(t, items, 1)
+	assert.Equal(t, "Alice", items[0].Name)
+}
+
+func TestContactValidator_ValidateUpload_RejectsXlsxDespiteSpreadsheetMIME(t *testing.T) {
+	validator := newContactUploadValidator()
+	header := multipartFileHeader(t, "contacts.xlsx", "application/vnd.ms-excel", "Name,Emails,PhoneNumbers\nAlice,alice@example.com,+18005550199")
+
+	items, errs := validator.ValidateUpload(context.Background(), entities.UserID("user-1"), header)
+
+	assert.Nil(t, items)
+	require.NotEmpty(t, errs.Get("document"))
+	assert.Contains(t, errs["document"][0], "not a valid CSV file")
+}
+
+func TestContactValidator_ValidateUpload_RejectsCSVWithUnrelatedMIME(t *testing.T) {
+	validator := newContactUploadValidator()
+	header := multipartFileHeader(t, "contacts.csv", "image/png", "Name,Emails,PhoneNumbers\nAlice,alice@example.com,+18005550199")
+
+	items, errs := validator.ValidateUpload(context.Background(), entities.UserID("user-1"), header)
+
+	assert.Nil(t, items)
+	require.NotEmpty(t, errs.Get("document"))
+	assert.Contains(t, errs["document"][0], "not a valid CSV file")
+}
+
 func TestContactValidator_ValidateUpload_RejectsOversizedFile(t *testing.T) {
 	validator := newContactUploadValidator()
 	header := multipartFileHeader(t, "contacts.csv", "text/csv", strings.Repeat("a", 500*1024+1))

--- a/api/pkg/validators/contact_handler_validator_test.go
+++ b/api/pkg/validators/contact_handler_validator_test.go
@@ -173,10 +173,15 @@ func TestContactValidator_ValidateUpdate_ValidAndInvalid(t *testing.T) {
 	assert.NotEmpty(t, invalidErrs.Get("contacts"))
 }
 
-func TestContactValidator_ValidateIndex_Bounds(t *testing.T) {
+func TestContactValidator_ValidateIndex(t *testing.T) {
 	validator := newContactValidator()
 
-	validErrs := validator.ValidateIndex(context.Background(), requests.ContactIndex{Skip: "0", Limit: "100", Query: strings.Repeat("a", 100)})
+	validErrs := validator.ValidateIndex(context.Background(), requests.ContactIndex{
+		Skip:   "0",
+		Limit:  "100",
+		Query:  strings.Repeat("a", 100),
+		SortBy: "updated_at",
+	})
 	assert.Empty(t, validErrs)
 
 	tests := []struct {
@@ -188,6 +193,7 @@ func TestContactValidator_ValidateIndex_Bounds(t *testing.T) {
 		{name: "limit too high", request: requests.ContactIndex{Skip: "0", Limit: "101"}, key: "limit"},
 		{name: "skip negative", request: requests.ContactIndex{Skip: "-1", Limit: "20"}, key: "skip"},
 		{name: "query too long", request: requests.ContactIndex{Skip: "0", Limit: "20", Query: strings.Repeat("a", 101)}, key: "query"},
+		{name: "unsupported sort field", request: requests.ContactIndex{Skip: "0", Limit: "20", SortBy: "created_at"}, key: "sort_by"},
 	}
 
 	for _, tt := range tests {

--- a/api/pkg/validators/message_handler_validator.go
+++ b/api/pkg/validators/message_handler_validator.go
@@ -36,14 +36,12 @@ func NewMessageHandlerValidator(
 	tracer telemetry.Tracer,
 	phoneService *services.PhoneService,
 	tokenValidator *TurnstileTokenValidator,
-	appCache cache.Cache,
 ) (v *MessageHandlerValidator) {
 	return &MessageHandlerValidator{
 		logger:         logger.WithService(fmt.Sprintf("%T", v)),
 		tracer:         tracer,
 		phoneService:   phoneService,
 		tokenValidator: tokenValidator,
-		cache:          appCache,
 	}
 }
 

--- a/docs/superpowers/plans/2026-07-19-contacts-feature.md
+++ b/docs/superpowers/plans/2026-07-19-contacts-feature.md
@@ -1,0 +1,3025 @@
+# Contacts Feature Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Contacts feature (name, emails, phone numbers, free-form properties) with full CRUD + CSV import, and display the resolved contact name instead of the raw phone number on the threads page, using as few DB queries as possible.
+
+**Architecture:** New `Contact` entity + layered backend (handler → service → repository → validator → requests/responses) mirroring existing patterns. Thread-name resolution is opt-in per request and served from a per-user `phone_number → *Contact` map cached in `cache.Cache`, so the common path adds zero DB queries and a name change is a single-row `UPDATE` + cache invalidation. Frontend adds a Pinia store and a Plunk-style Contacts page (Nuxt 4 SPA).
+
+**Tech Stack:** Go (Fiber v3, GORM v1.31.2, lib/pq, nyaruka/phonenumbers, jszwec/csvutil), Nuxt 4 + Pinia + Vuetify 4, Swagger (`swag`), swagger-typescript-api.
+
+## Global Constraints
+
+- Source of truth: `docs/superpowers/specs/2026-07-19-contacts-feature-design.md`. Follow it exactly.
+- Run Go tests with `go test -vet=off ./...` from `api/` (Go 1.26 vet rejects the repo's `stacktrace.Propagate(err, fmt.Sprintf(...))` pattern).
+- Wrap all Go errors with `github.com/NdoleStudio/stacktrace` (`Propagatef` / `PropagateWithCodef`) — never return bare errors.
+- All GORM queries use `repository.db.WithContext(ctx)`. No raw SQL.
+- Register Fiber routes via the `h.register(router, fiber.MethodX, path, middlewares, route)` helper (Fiber v3), not `Get`/`Post` directly.
+- Contacts are global to the user account. **No** uniqueness constraint on phone numbers; **no** `contact_phone_numbers` lookup table.
+- On phone-number collision across contacts, the **most recently updated** contact wins for display.
+- Thread-name resolution is **opt-in** via `?contacts=true` (default off).
+- Create endpoint accepts one or many; batch capped at **≤ 1000** contacts; cache invalidated **once** after the batch commits.
+- CSV import is **CSV only** — Excel/XLSX is not supported for contacts. Max 500 KB, ≤ 1000 rows.
+- `pq.StringArray` with `gorm:"type:text[]" swaggertype:"array,string"` for array fields (convention from `phone_api_key.go`/`webhook.go`).
+- Web conventions: every `VDialog` has `opacity="0.9"` and a Close button with `color="warning"`; hyperlinks get `text-decoration-none hover:text-decoration-underline`; destructure filters from `useFilters()` in `<script setup>` and use directly in the template; no glowing gradient text off the homepage; Vuetify 4 typography classes (`text-headline-large`, `text-title-large`, `text-display-large`, etc.); in `useApi` `onRequest`, `options.headers` is a `Headers` instance — use `.set()`.
+- Regenerate Swagger after API annotation changes: `cd api && swag init --requiredByDefault --parseDependency --parseInternal`.
+- Regenerate web API models after Swagger changes: `cd web && pnpm api:models`.
+
+---
+
+## File Structure
+
+Backend (`api/`):
+- `pkg/entities/contact.go` — `Contact` entity + `ContactProperties` custom jsonb type (Valuer/Scanner).
+- `pkg/entities/contact_test.go` — round-trip tests for `ContactProperties`.
+- `pkg/entities/message_thread.go` — add non-persisted `ContactDetails *Contact` field.
+- `pkg/repositories/contact_repository.go` — `ContactRepository` interface + param structs.
+- `pkg/repositories/gorm_contact_repository.go` — GORM implementation.
+- `pkg/repositories/gorm_contact_repository_test.go` — repository tests.
+- `pkg/requests/contact_store.go` — create-many request + per-item `ContactItem`.
+- `pkg/requests/contact_update.go` — update request.
+- `pkg/requests/contact_index.go` — list/search request.
+- `pkg/responses/*` — reuse existing generic OK/Created responses (no new file needed).
+- `pkg/validators/contact_handler_validator.go` — validates store/update/index + CSV parse.
+- `pkg/services/contact_service.go` — CRUD + contact-map build + cache invalidation.
+- `pkg/services/contact_service_test.go` — service tests.
+- `pkg/handlers/contact_handler.go` — HTTP handlers + `RegisterRoutes`.
+- `pkg/services/message_thread_service.go` — extend `GetThreads` to attach `ContactDetails`.
+- `pkg/requests/message_thread_index_request.go` — add `Contacts` query param.
+- `pkg/di/container.go` — wire repo/service/validator/handler, AutoMigrate, register routes.
+
+Frontend (`web/`):
+- `app/stores/contacts.ts` — Pinia store.
+- `app/pages/contacts/index.vue` — Plunk-style Contacts page + dialogs.
+- `app/stores/threads.ts` — pass `contacts: true`.
+- `app/components/MessageThread.vue`, `app/components/MessageThreadHeader.vue` — render resolved name.
+- default layout — add Contacts nav link.
+- `shared/types/api` — regenerated from Swagger.
+- `public/templates/httpsms-contacts.csv` — CSV template.
+
+---
+
+### Task 1: Contact entity + ContactProperties custom type
+
+**Files:**
+- Create: `api/pkg/entities/contact.go`
+- Create: `api/pkg/entities/contact_test.go`
+
+**Interfaces:**
+- Produces: `entities.Contact` struct; `entities.ContactProperties` (`map[string]string`) implementing `driver.Valuer` and `sql.Scanner`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `api/pkg/entities/contact_test.go`:
+
+```go
+package entities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContactProperties_ValueScanRoundTrip(t *testing.T) {
+	cases := []ContactProperties{
+		nil,
+		{},
+		{"company": "Acme", "role": "CTO"},
+	}
+
+	for _, original := range cases {
+		value, err := original.Value()
+		assert.Nil(t, err)
+
+		var scanned ContactProperties
+		assert.Nil(t, scanned.Scan(value))
+
+		if len(original) == 0 {
+			assert.Equal(t, 0, len(scanned))
+			continue
+		}
+		assert.Equal(t, original, scanned)
+	}
+}
+
+func TestContactProperties_ScanFromString(t *testing.T) {
+	var scanned ContactProperties
+	assert.Nil(t, scanned.Scan(`{"k":"v"}`))
+	assert.Equal(t, ContactProperties{"k": "v"}, scanned)
+}
+
+func TestContactProperties_ScanNil(t *testing.T) {
+	var scanned ContactProperties
+	assert.Nil(t, scanned.Scan(nil))
+	assert.Equal(t, 0, len(scanned))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd api && go test -vet=off ./pkg/entities/ -run TestContactProperties`
+Expected: FAIL / build error — `Contact`/`ContactProperties` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `api/pkg/entities/contact.go`:
+
+```go
+package entities
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+)
+
+// ContactProperties is a free-form key/value map persisted as a jsonb column.
+type ContactProperties map[string]string
+
+// Value implements driver.Valuer, serializing the map to JSON bytes.
+func (p ContactProperties) Value() (driver.Value, error) {
+	if p == nil {
+		return []byte("{}"), nil
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// Scan implements sql.Scanner, deserializing jsonb bytes/string into the map.
+func (p *ContactProperties) Scan(src any) error {
+	if src == nil {
+		*p = ContactProperties{}
+		return nil
+	}
+
+	var data []byte
+	switch value := src.(type) {
+	case []byte:
+		data = value
+	case string:
+		data = []byte(value)
+	default:
+		return fmt.Errorf("unsupported type [%T] for ContactProperties", src)
+	}
+
+	if len(data) == 0 {
+		*p = ContactProperties{}
+		return nil
+	}
+
+	result := ContactProperties{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return err
+	}
+	*p = result
+	return nil
+}
+
+// Contact represents a saved contact belonging to a user.
+type Contact struct {
+	ID           uuid.UUID         `json:"id" gorm:"primaryKey;type:uuid;" example:"32343a19-da5e-4b1b-a767-3298a73703cb"`
+	UserID       UserID            `json:"user_id" gorm:"index" example:"WB7DRDWrJZRGbYrv2CKGkqbzvqdC"`
+	Name         string            `json:"name" example:"Alice Smith"`
+	Emails       pq.StringArray    `json:"emails" gorm:"type:text[]" swaggertype:"array,string" example:"alice@example.com"`
+	PhoneNumbers pq.StringArray    `json:"phone_numbers" gorm:"type:text[]" swaggertype:"array,string" example:"+18005550199,+18005550100"`
+	Properties   ContactProperties `json:"properties" gorm:"type:jsonb" swaggertype:"object,string"`
+	CreatedAt    time.Time         `json:"created_at" example:"2022-06-05T14:26:02.302718+03:00"`
+	UpdatedAt    time.Time         `json:"updated_at" example:"2022-06-05T14:26:02.302718+03:00"`
+}
+
+// TableName overrides the table name used by Contact.
+func (Contact) TableName() string {
+	return "contacts"
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd api && go test -vet=off ./pkg/entities/ -run TestContactProperties`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/pkg/entities/contact.go api/pkg/entities/contact_test.go
+git commit -m "feat(api): add Contact entity and ContactProperties jsonb type"
+```
+
+---
+
+### Task 2: MessageThread ContactDetails field + AutoMigrate
+
+**Files:**
+- Modify: `api/pkg/entities/message_thread.go`
+- Modify: `api/pkg/di/container.go` (AutoMigrate block ~L413)
+
+**Interfaces:**
+- Produces: `entities.MessageThread.ContactDetails *Contact` (JSON `contact_details`, `gorm:"-"`), `contacts` table auto-migrated.
+
+- [ ] **Step 1: Add the non-persisted field**
+
+In `api/pkg/entities/message_thread.go`, add after the `OrderTimestamp` field inside the `MessageThread` struct:
+
+```go
+	// ContactDetails is resolved at read time and never persisted.
+	ContactDetails *Contact `json:"contact_details,omitempty" gorm:"-"`
+```
+
+- [ ] **Step 2: Register AutoMigrate**
+
+In `api/pkg/di/container.go`, immediately after the `&entities.PhoneAPIKey{}` AutoMigrate block (~L413-415), add:
+
+```go
+	if err = db.AutoMigrate(&entities.Contact{}); err != nil {
+		container.logger.Fatal(stacktrace.Propagatef(err, "cannot migrate %T", &entities.Contact{}))
+	}
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `cd api && go build ./...`
+Expected: builds with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/pkg/entities/message_thread.go api/pkg/di/container.go
+git commit -m "feat(api): add non-persisted ContactDetails on MessageThread and migrate contacts table"
+```
+
+---
+
+### Task 3: ContactRepository interface + GORM implementation
+
+**Files:**
+- Create: `api/pkg/repositories/contact_repository.go`
+- Create: `api/pkg/repositories/gorm_contact_repository.go`
+- Create: `api/pkg/repositories/gorm_contact_repository_test.go`
+
+**Interfaces:**
+- Consumes: `entities.Contact`, `repositories.IndexParams`, `repositories.ErrCodeNotFound`.
+- Produces: `repositories.ContactRepository` with methods:
+  - `Store(ctx context.Context, contacts []*entities.Contact) error`
+  - `Update(ctx context.Context, contact *entities.Contact) error`
+  - `Load(ctx context.Context, userID entities.UserID, contactID uuid.UUID) (*entities.Contact, error)`
+  - `Index(ctx context.Context, userID entities.UserID, params IndexParams) (*[]entities.Contact, error)`
+  - `FetchAll(ctx context.Context, userID entities.UserID) (*[]entities.Contact, error)` (ordered `updated_at ASC` for tie-break)
+  - `Delete(ctx context.Context, userID entities.UserID, contactID uuid.UUID) error`
+  - `DeleteAllForUser(ctx context.Context, userID entities.UserID) error`
+  - Constructor: `NewGormContactRepository(logger, tracer, db) ContactRepository`
+
+- [ ] **Step 1: Write the interface**
+
+Create `api/pkg/repositories/contact_repository.go`:
+
+```go
+package repositories
+
+import (
+	"context"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/google/uuid"
+)
+
+// ContactRepository loads and persists an entities.Contact
+type ContactRepository interface {
+	// Store one or many new entities.Contact
+	Store(ctx context.Context, contacts []*entities.Contact) error
+
+	// Update an existing entities.Contact
+	Update(ctx context.Context, contact *entities.Contact) error
+
+	// Load a contact by ID for a user
+	Load(ctx context.Context, userID entities.UserID, contactID uuid.UUID) (*entities.Contact, error)
+
+	// Index contacts for a user with optional search
+	Index(ctx context.Context, userID entities.UserID, params IndexParams) (*[]entities.Contact, error)
+
+	// FetchAll returns every contact for a user ordered by updated_at ascending
+	FetchAll(ctx context.Context, userID entities.UserID) (*[]entities.Contact, error)
+
+	// Delete a contact by ID for a user
+	Delete(ctx context.Context, userID entities.UserID, contactID uuid.UUID) error
+
+	// DeleteAllForUser deletes all contacts for a user
+	DeleteAllForUser(ctx context.Context, userID entities.UserID) error
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `api/pkg/repositories/gorm_contact_repository_test.go`. Reuse the SQL-capturing conn-pool mock pattern already defined in `api/pkg/repositories/gorm_message_thread_repository_test.go` (the `messageThreadTestConnPool`, `messageThreadTestLogger`, and the `postgres.New(postgres.Config{Conn: ...})` DryRun setup). Add these focused tests:
+
+```go
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func newContactTestRepo(t *testing.T) (ContactRepository, *messageThreadTestConnPool) {
+	pool := &messageThreadTestConnPool{}
+	db, err := gorm.Open(
+		postgres.New(postgres.Config{Conn: pool, WithoutReturning: true}),
+		&gorm.Config{DisableAutomaticPing: true},
+	)
+	require.NoError(t, err)
+	logger := &messageThreadTestLogger{}
+	return NewGormContactRepository(logger, telemetry.NewOtelLogger("test", logger), db), pool
+}
+
+func TestGormContactRepository_Index_FiltersByUserAndQuery(t *testing.T) {
+	repo, _ := newContactTestRepo(t)
+
+	_, err := repo.Index(context.Background(), entities.UserID("user-1"), IndexParams{Query: "alice", Limit: 20, Skip: 0})
+	assert.Nil(t, err)
+}
+
+func TestGormContactRepository_FetchAll_OrdersByUpdatedAtAsc(t *testing.T) {
+	repo, _ := newContactTestRepo(t)
+
+	_, err := repo.FetchAll(context.Background(), entities.UserID("user-1"))
+	assert.Nil(t, err)
+}
+
+func TestGormContactRepository_Store_BuildsContact(t *testing.T) {
+	repo, _ := newContactTestRepo(t)
+
+	err := repo.Store(context.Background(), []*entities.Contact{{
+		ID:           uuid.New(),
+		UserID:       entities.UserID("user-1"),
+		Name:         "Alice",
+		Emails:       pq.StringArray{"alice@example.com"},
+		PhoneNumbers: pq.StringArray{"+18005550199"},
+	}})
+	assert.Nil(t, err)
+}
+```
+
+(The `messageThreadTestConnPool` and `messageThreadTestLogger` types are already defined in `gorm_message_thread_repository_test.go` in the same package, so they are reused directly here.)
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd api && go test -vet=off ./pkg/repositories/ -run TestGormContactRepository`
+Expected: FAIL / build error — `NewGormContactRepository` undefined.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `api/pkg/repositories/gorm_contact_repository.go`:
+
+```go
+package repositories
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// gormContactRepository is responsible for persisting entities.Contact
+type gormContactRepository struct {
+	logger telemetry.Logger
+	tracer telemetry.Tracer
+	db     *gorm.DB
+}
+
+// NewGormContactRepository creates the GORM version of the ContactRepository
+func NewGormContactRepository(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+	db *gorm.DB,
+) ContactRepository {
+	return &gormContactRepository{
+		logger: logger.WithService(fmt.Sprintf("%T", &gormContactRepository{})),
+		tracer: tracer,
+		db:     db,
+	}
+}
+
+func (repository *gormContactRepository) Store(ctx context.Context, contacts []*entities.Contact) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	if len(contacts) == 0 {
+		return nil
+	}
+
+	if err := repository.db.WithContext(ctx).Create(&contacts).Error; err != nil {
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot store [%d] contacts", len(contacts)))
+	}
+	return nil
+}
+
+func (repository *gormContactRepository) Update(ctx context.Context, contact *entities.Contact) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	if err := repository.db.WithContext(ctx).Save(contact).Error; err != nil {
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot update contact with ID [%s]", contact.ID))
+	}
+	return nil
+}
+
+func (repository *gormContactRepository) Load(ctx context.Context, userID entities.UserID, contactID uuid.UUID) (*entities.Contact, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	contact := new(entities.Contact)
+	err := repository.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Where("id = ?", contactID).
+		First(contact).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCodef(err, ErrCodeNotFound, "contact with id [%s] not found for user [%s]", contactID, userID))
+	}
+	if err != nil {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot load contact with id [%s]", contactID))
+	}
+	return contact, nil
+}
+
+func (repository *gormContactRepository) Index(ctx context.Context, userID entities.UserID, params IndexParams) (*[]entities.Contact, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	query := repository.db.WithContext(ctx).Where("user_id = ?", userID)
+
+	if len(params.Query) > 0 {
+		queryPattern := "%" + params.Query + "%"
+		query = query.Where(
+			repository.db.Where("name ILIKE ?", queryPattern).
+				Or("array_to_string(emails, ',') ILIKE ?", queryPattern).
+				Or("array_to_string(phone_numbers, ',') ILIKE ?", queryPattern),
+		)
+	}
+
+	contacts := new([]entities.Contact)
+	if err := query.Order("updated_at DESC").Limit(params.Limit).Offset(params.Skip).Find(contacts).Error; err != nil {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot index contacts for user [%s]", userID))
+	}
+	return contacts, nil
+}
+
+func (repository *gormContactRepository) FetchAll(ctx context.Context, userID entities.UserID) (*[]entities.Contact, error) {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	contacts := new([]entities.Contact)
+	if err := repository.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("updated_at ASC").
+		Find(contacts).Error; err != nil {
+		return nil, repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot fetch all contacts for user [%s]", userID))
+	}
+	return contacts, nil
+}
+
+func (repository *gormContactRepository) Delete(ctx context.Context, userID entities.UserID, contactID uuid.UUID) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	if err := repository.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Where("id = ?", contactID).
+		Delete(&entities.Contact{}).Error; err != nil {
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot delete contact with id [%s] for user [%s]", contactID, userID))
+	}
+	return nil
+}
+
+func (repository *gormContactRepository) DeleteAllForUser(ctx context.Context, userID entities.UserID) error {
+	ctx, span := repository.tracer.Start(ctx)
+	defer span.End()
+
+	if err := repository.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Delete(&entities.Contact{}).Error; err != nil {
+		return repository.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot delete all contacts for user [%s]", userID))
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd api && go test -vet=off ./pkg/repositories/ -run TestGormContactRepository`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/pkg/repositories/contact_repository.go api/pkg/repositories/gorm_contact_repository.go api/pkg/repositories/gorm_contact_repository_test.go
+git commit -m "feat(api): add ContactRepository with GORM implementation"
+```
+
+---
+
+### Task 4: Contact requests (store / update / index)
+
+**Files:**
+- Create: `api/pkg/requests/contact_store.go`
+- Create: `api/pkg/requests/contact_update.go`
+- Create: `api/pkg/requests/contact_index.go`
+- Create: `api/pkg/requests/contact_store_test.go`
+
+**Interfaces:**
+- Produces:
+  - `requests.ContactItem{ Name string; Emails []string; PhoneNumbers []string; Properties map[string]string }`
+  - `requests.ContactStoreRequest{ Contacts []ContactItem }` with `UnmarshalJSON` accepting a JSON array or `{"contacts":[...]}`; methods `Sanitize()` and `ToContacts(userID entities.UserID) []*entities.Contact`.
+  - `requests.ContactUpdateRequest{ Name string; Emails []string; PhoneNumbers []string; Properties map[string]string }` with `Sanitize()` and `ApplyTo(contact *entities.Contact)`.
+  - `requests.ContactIndex{ Skip, Query, Limit string }` with `Sanitize()` and `ToIndexParams() repositories.IndexParams`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `api/pkg/requests/contact_store_test.go`:
+
+```go
+package requests
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContactStoreRequest_UnmarshalArrayForm(t *testing.T) {
+	var request ContactStoreRequest
+	require.NoError(t, json.Unmarshal([]byte(`[{"name":"Alice","phone_numbers":["+18005550199"]}]`), &request))
+	assert.Equal(t, 1, len(request.Contacts))
+	assert.Equal(t, "Alice", request.Contacts[0].Name)
+}
+
+func TestContactStoreRequest_UnmarshalObjectForm(t *testing.T) {
+	var request ContactStoreRequest
+	require.NoError(t, json.Unmarshal([]byte(`{"contacts":[{"name":"Bob","phone_numbers":["+18005550100"]}]}`), &request))
+	assert.Equal(t, 1, len(request.Contacts))
+	assert.Equal(t, "Bob", request.Contacts[0].Name)
+}
+
+func TestContactStoreRequest_SanitizeNormalizesNumbers(t *testing.T) {
+	request := ContactStoreRequest{Contacts: []ContactItem{{
+		Name:         "  Alice  ",
+		PhoneNumbers: []string{"18005550199"},
+		Emails:       []string{" alice@example.com "},
+	}}}
+	request = request.Sanitize()
+	assert.Equal(t, "Alice", request.Contacts[0].Name)
+	assert.Equal(t, "+18005550199", request.Contacts[0].PhoneNumbers[0])
+	assert.Equal(t, "alice@example.com", request.Contacts[0].Emails[0])
+}
+
+func TestContactStoreRequest_ToContacts(t *testing.T) {
+	request := ContactStoreRequest{Contacts: []ContactItem{{
+		Name:         "Alice",
+		PhoneNumbers: []string{"+18005550199"},
+	}}}
+	contacts := request.ToContacts(entities.UserID("user-1"))
+	require.Equal(t, 1, len(contacts))
+	assert.Equal(t, "Alice", contacts[0].Name)
+	assert.Equal(t, entities.UserID("user-1"), contacts[0].UserID)
+	assert.NotEqual(t, "", contacts[0].ID.String())
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd api && go test -vet=off ./pkg/requests/ -run TestContactStoreRequest`
+Expected: FAIL / build error — types undefined.
+
+- [ ] **Step 3: Write the implementations**
+
+Create `api/pkg/requests/contact_store.go`:
+
+```go
+package requests
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+)
+
+// ContactItem is a single contact in a create request.
+type ContactItem struct {
+	Name         string            `json:"name" example:"Alice Smith"`
+	Emails       []string          `json:"emails"`
+	PhoneNumbers []string          `json:"phone_numbers"`
+	Properties   map[string]string `json:"properties"`
+}
+
+// ContactStoreRequest creates one or many contacts.
+type ContactStoreRequest struct {
+	request
+	Contacts []ContactItem `json:"contacts"`
+}
+
+// UnmarshalJSON accepts either a JSON array of contacts or {"contacts":[...]}.
+func (input *ContactStoreRequest) UnmarshalJSON(data []byte) error {
+	trimmed := strings.TrimSpace(string(data))
+	if strings.HasPrefix(trimmed, "[") {
+		var items []ContactItem
+		if err := json.Unmarshal(data, &items); err != nil {
+			return err
+		}
+		input.Contacts = items
+		return nil
+	}
+
+	type alias ContactStoreRequest
+	var wrapper alias
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return err
+	}
+	input.Contacts = wrapper.Contacts
+	return nil
+}
+
+// Sanitize trims and normalizes each contact item.
+func (input ContactStoreRequest) Sanitize() ContactStoreRequest {
+	for index := range input.Contacts {
+		input.Contacts[index] = input.sanitizeItem(input.Contacts[index])
+	}
+	return input
+}
+
+func (input *ContactStoreRequest) sanitizeItem(item ContactItem) ContactItem {
+	item.Name = strings.TrimSpace(item.Name)
+
+	numbers := input.removeStringDuplicates(input.removeEmptyStrings(item.PhoneNumbers))
+	item.PhoneNumbers = input.sanitizeAddresses(numbers)
+
+	emails := input.removeEmptyStrings(item.Emails)
+	for i := range emails {
+		emails[i] = strings.ToLower(strings.TrimSpace(emails[i]))
+	}
+	item.Emails = input.removeStringDuplicates(emails)
+
+	if item.Properties == nil {
+		item.Properties = map[string]string{}
+	}
+	return item
+}
+
+// ToContacts converts the request into persistable entities.Contact records.
+func (input *ContactStoreRequest) ToContacts(userID entities.UserID) []*entities.Contact {
+	now := time.Now().UTC()
+	contacts := make([]*entities.Contact, 0, len(input.Contacts))
+	for _, item := range input.Contacts {
+		contacts = append(contacts, &entities.Contact{
+			ID:           uuid.New(),
+			UserID:       userID,
+			Name:         item.Name,
+			Emails:       pq.StringArray(item.Emails),
+			PhoneNumbers: pq.StringArray(item.PhoneNumbers),
+			Properties:   entities.ContactProperties(item.Properties),
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		})
+	}
+	return contacts
+}
+```
+
+Create `api/pkg/requests/contact_update.go`:
+
+```go
+package requests
+
+import (
+	"strings"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/lib/pq"
+)
+
+// ContactUpdateRequest updates an existing contact.
+type ContactUpdateRequest struct {
+	request
+	Name         string            `json:"name" example:"Alice Smith"`
+	Emails       []string          `json:"emails"`
+	PhoneNumbers []string          `json:"phone_numbers"`
+	Properties   map[string]string `json:"properties"`
+}
+
+// Sanitize trims and normalizes the update request.
+func (input ContactUpdateRequest) Sanitize() ContactUpdateRequest {
+	input.Name = strings.TrimSpace(input.Name)
+
+	numbers := input.removeStringDuplicates(input.removeEmptyStrings(input.PhoneNumbers))
+	input.PhoneNumbers = input.sanitizeAddresses(numbers)
+
+	emails := input.removeEmptyStrings(input.Emails)
+	for i := range emails {
+		emails[i] = strings.ToLower(strings.TrimSpace(emails[i]))
+	}
+	input.Emails = input.removeStringDuplicates(emails)
+
+	if input.Properties == nil {
+		input.Properties = map[string]string{}
+	}
+	return input
+}
+
+// ApplyTo mutates an existing contact with the update values.
+func (input *ContactUpdateRequest) ApplyTo(contact *entities.Contact) {
+	contact.Name = input.Name
+	contact.Emails = pq.StringArray(input.Emails)
+	contact.PhoneNumbers = pq.StringArray(input.PhoneNumbers)
+	contact.Properties = entities.ContactProperties(input.Properties)
+	contact.UpdatedAt = time.Now().UTC()
+}
+```
+
+Create `api/pkg/requests/contact_index.go`:
+
+```go
+package requests
+
+import (
+	"strings"
+
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+)
+
+// ContactIndex lists contacts for a user.
+type ContactIndex struct {
+	request
+	Skip  string `json:"skip" query:"skip"`
+	Query string `json:"query" query:"query"`
+	Limit string `json:"limit" query:"limit"`
+}
+
+// Sanitize sets defaults for the list request.
+func (input *ContactIndex) Sanitize() ContactIndex {
+	if strings.TrimSpace(input.Limit) == "" {
+		input.Limit = "20"
+	}
+	input.Query = strings.TrimSpace(input.Query)
+	input.Skip = strings.TrimSpace(input.Skip)
+	if input.Skip == "" {
+		input.Skip = "0"
+	}
+	return *input
+}
+
+// ToIndexParams converts the request into repositories.IndexParams.
+func (input *ContactIndex) ToIndexParams() repositories.IndexParams {
+	return repositories.IndexParams{
+		Skip:  input.getInt(input.Skip),
+		Query: input.Query,
+		Limit: input.getInt(input.Limit),
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd api && go test -vet=off ./pkg/requests/ -run TestContactStoreRequest`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/pkg/requests/contact_store.go api/pkg/requests/contact_update.go api/pkg/requests/contact_index.go api/pkg/requests/contact_store_test.go
+git commit -m "feat(api): add contact store/update/index requests"
+```
+
+---
+
+### Task 5: ContactHandlerValidator (store / update / index / CSV upload)
+
+**Files:**
+- Create: `api/pkg/validators/contact_handler_validator.go`
+- Create: `api/pkg/validators/contact_handler_validator_test.go`
+
+**Interfaces:**
+- Consumes: `requests.ContactStoreRequest`, `requests.ContactUpdateRequest`, `requests.ContactIndex`, `requests.ContactItem`.
+- Produces: `validators.ContactHandlerValidator` with:
+  - `NewContactHandlerValidator(logger, tracer) *ContactHandlerValidator`
+  - `ValidateStore(ctx, request requests.ContactStoreRequest) url.Values`
+  - `ValidateUpdate(ctx, request requests.ContactUpdateRequest) url.Values`
+  - `ValidateIndex(ctx, request requests.ContactIndex) url.Values`
+  - `ValidateUpload(ctx, userID entities.UserID, header *multipart.FileHeader) ([]requests.ContactItem, url.Values)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `api/pkg/validators/contact_handler_validator_test.go`:
+
+```go
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NdoleStudio/httpsms/pkg/requests"
+	"github.com/stretchr/testify/assert"
+)
+
+func newContactValidator() *ContactHandlerValidator {
+	return &ContactHandlerValidator{}
+}
+
+func TestContactValidator_ValidateStore_Valid(t *testing.T) {
+	v := newContactValidator()
+	errs := v.ValidateStore(context.Background(), requests.ContactStoreRequest{Contacts: []requests.ContactItem{{
+		Name:         "Alice",
+		PhoneNumbers: []string{"+18005550199"},
+		Emails:       []string{"alice@example.com"},
+	}}})
+	assert.Equal(t, 0, len(errs))
+}
+
+func TestContactValidator_ValidateStore_MissingName(t *testing.T) {
+	v := newContactValidator()
+	errs := v.ValidateStore(context.Background(), requests.ContactStoreRequest{Contacts: []requests.ContactItem{{
+		PhoneNumbers: []string{"+18005550199"},
+	}}})
+	assert.NotEqual(t, 0, len(errs))
+}
+
+func TestContactValidator_ValidateStore_InvalidNumber(t *testing.T) {
+	v := newContactValidator()
+	errs := v.ValidateStore(context.Background(), requests.ContactStoreRequest{Contacts: []requests.ContactItem{{
+		Name:         "Alice",
+		PhoneNumbers: []string{"not-a-number"},
+	}}})
+	assert.NotEqual(t, 0, len(errs))
+}
+
+func TestContactValidator_ValidateStore_EmptyBatch(t *testing.T) {
+	v := newContactValidator()
+	errs := v.ValidateStore(context.Background(), requests.ContactStoreRequest{Contacts: nil})
+	assert.NotEqual(t, 0, len(errs))
+}
+
+func TestContactValidator_ValidateStore_InvalidEmail(t *testing.T) {
+	v := newContactValidator()
+	errs := v.ValidateStore(context.Background(), requests.ContactStoreRequest{Contacts: []requests.ContactItem{{
+		Name:         "Alice",
+		PhoneNumbers: []string{"+18005550199"},
+		Emails:       []string{"not-an-email"},
+	}}})
+	assert.NotEqual(t, 0, len(errs))
+}
+```
+
+(If `telemetry.NewOtelLogger` for the tracer differs in your package, `ValidateUpload` is the only method needing a real logger/tracer; the store/update/index tests use a zero-value validator.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd api && go test -vet=off ./pkg/validators/ -run TestContactValidator`
+Expected: FAIL / build error — `NewContactHandlerValidator` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `api/pkg/validators/contact_handler_validator.go`:
+
+```go
+package validators
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/mail"
+	"net/url"
+	"strings"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/requests"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/jszwec/csvutil"
+	"github.com/nyaruka/phonenumbers"
+	"github.com/thedevsaddam/govalidator"
+)
+
+// ContactHandlerValidator validates models used in handlers.ContactHandler
+type ContactHandlerValidator struct {
+	validator
+	logger telemetry.Logger
+	tracer telemetry.Tracer
+}
+
+// NewContactHandlerValidator creates a new handlers.ContactHandler validator
+func NewContactHandlerValidator(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+) *ContactHandlerValidator {
+	return &ContactHandlerValidator{
+		logger: logger.WithService(fmt.Sprintf("%T", &ContactHandlerValidator{})),
+		tracer: tracer,
+	}
+}
+
+const maxContactBatch = 1000
+
+// ValidateStore validates a create request of one or many contacts.
+func (v *ContactHandlerValidator) ValidateStore(_ context.Context, request requests.ContactStoreRequest) url.Values {
+	result := url.Values{}
+	if len(request.Contacts) == 0 {
+		result.Add("contacts", "You must provide at least one contact.")
+		return result
+	}
+	if len(request.Contacts) > maxContactBatch {
+		result.Add("contacts", fmt.Sprintf("You cannot create more than %d contacts in one request.", maxContactBatch))
+		return result
+	}
+	for index, item := range request.Contacts {
+		v.validateItem(result, index, item)
+	}
+	return result
+}
+
+// ValidateUpdate validates a single contact update.
+func (v *ContactHandlerValidator) ValidateUpdate(_ context.Context, request requests.ContactUpdateRequest) url.Values {
+	result := url.Values{}
+	v.validateItem(result, 0, requests.ContactItem{
+		Name:         request.Name,
+		Emails:       request.Emails,
+		PhoneNumbers: request.PhoneNumbers,
+		Properties:   request.Properties,
+	})
+	return result
+}
+
+func (v *ContactHandlerValidator) validateItem(result url.Values, index int, item requests.ContactItem) {
+	row := index + 1
+	if strings.TrimSpace(item.Name) == "" {
+		result.Add("contacts", fmt.Sprintf("Contact [%d]: The name is required.", row))
+	}
+	if len(item.PhoneNumbers) == 0 {
+		result.Add("contacts", fmt.Sprintf("Contact [%d]: At least one phone number is required.", row))
+	}
+	for _, number := range item.PhoneNumbers {
+		if _, err := phonenumbers.Parse(number, phonenumbers.UNKNOWN_REGION); err != nil {
+			result.Add("contacts", fmt.Sprintf("Contact [%d]: The phone number [%s] is not a valid E.164 phone number.", row, number))
+		}
+	}
+	for _, email := range item.Emails {
+		if _, err := mail.ParseAddress(email); err != nil {
+			result.Add("contacts", fmt.Sprintf("Contact [%d]: The email [%s] is not a valid email address.", row, email))
+		}
+	}
+}
+
+// ValidateIndex validates the list request.
+func (v *ContactHandlerValidator) ValidateIndex(_ context.Context, request requests.ContactIndex) url.Values {
+	value := govalidator.New(govalidator.Options{
+		Data: &request,
+		Rules: govalidator.MapData{
+			"limit": []string{"required", "numeric", "min:1", "max:100"},
+			"skip":  []string{"required", "numeric", "min:0"},
+			"query": []string{"max:100"},
+		},
+	})
+	return value.ValidateStruct()
+}
+
+type contactCSVRow struct {
+	Name         string `csv:"Name"`
+	Emails       string `csv:"Emails"`
+	PhoneNumbers string `csv:"PhoneNumbers"`
+}
+
+// ValidateUpload parses and validates a CSV upload (CSV only).
+func (v *ContactHandlerValidator) ValidateUpload(ctx context.Context, userID entities.UserID, header *multipart.FileHeader) ([]requests.ContactItem, url.Values) {
+	ctx, span, ctxLogger := v.tracer.StartWithLogger(ctx, v.logger)
+	defer span.End()
+	_ = ctx
+
+	result := url.Values{}
+
+	if header.Header.Get("Content-Type") != "text/csv" && !strings.HasSuffix(strings.ToLower(header.Filename), ".csv") {
+		result.Add("document", fmt.Sprintf("The file [%s] is not a valid CSV file. Only CSV files are supported.", header.Filename))
+		return nil, result
+	}
+
+	if header.Size >= 500000 {
+		result.Add("document", "The CSV file must be less than 500 KB.")
+		return nil, result
+	}
+
+	file, err := header.Open()
+	if err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot open file [%s] for user [%s]", header.Filename, userID))
+		result.Add("document", fmt.Sprintf("Cannot open the uploaded file [%s].", header.Filename))
+		return nil, result
+	}
+	defer func() { _ = file.Close() }()
+
+	buffer := new(bytes.Buffer)
+	if _, err = io.Copy(buffer, file); err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot read file [%s] for user [%s]", header.Filename, userID))
+		result.Add("document", fmt.Sprintf("Cannot read the uploaded file [%s].", header.Filename))
+		return nil, result
+	}
+
+	var rows []contactCSVRow
+	if err = csvutil.Unmarshal(buffer.Bytes(), &rows); err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot parse CSV file [%s] for user [%s]", header.Filename, userID))
+		result.Add("document", fmt.Sprintf("Cannot parse the uploaded CSV file [%s]. Use the official httpSMS contacts template.", header.Filename))
+		return nil, result
+	}
+
+	if len(rows) > maxContactBatch {
+		result.Add("document", fmt.Sprintf("The uploaded file must contain less than %d records.", maxContactBatch))
+		return nil, result
+	}
+
+	items := make([]requests.ContactItem, 0, len(rows))
+	for _, row := range rows {
+		if strings.TrimSpace(row.Name) == "" && strings.TrimSpace(row.PhoneNumbers) == "" {
+			continue
+		}
+		items = append(items, requests.ContactItem{
+			Name:         strings.TrimSpace(row.Name),
+			Emails:       splitMultiValue(row.Emails),
+			PhoneNumbers: splitMultiValue(row.PhoneNumbers),
+		})
+	}
+
+	if len(items) == 0 {
+		result.Add("document", "The uploaded file doesn't contain any valid records.")
+	}
+	return items, result
+}
+
+func splitMultiValue(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	fields := strings.FieldsFunc(value, func(r rune) bool { return r == ';' || r == ',' })
+	var result []string
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			result = append(result, field)
+		}
+	}
+	return result
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd api && go test -vet=off ./pkg/validators/ -run TestContactValidator`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/pkg/validators/contact_handler_validator.go api/pkg/validators/contact_handler_validator_test.go
+git commit -m "feat(api): add ContactHandlerValidator with CSV-only upload parsing"
+```
+
+---
+
+### Task 6: ContactService (CRUD + contact-map cache + invalidation)
+
+**Files:**
+- Create: `api/pkg/services/contact_service.go`
+- Create: `api/pkg/services/contact_service_test.go`
+
+**Interfaces:**
+- Consumes: `repositories.ContactRepository`, `cache.Cache`, `entities.Contact`, `repositories.IndexParams`.
+- Produces: `services.ContactService` with:
+  - `NewContactService(logger, tracer, repository repositories.ContactRepository, appCache cache.Cache) *ContactService`
+  - `CreateMany(ctx, userID entities.UserID, contacts []*entities.Contact) error`
+  - `Get(ctx, userID entities.UserID, contactID uuid.UUID) (*entities.Contact, error)`
+  - `Index(ctx, userID entities.UserID, params repositories.IndexParams) (*[]entities.Contact, error)`
+  - `Update(ctx, contact *entities.Contact) error`
+  - `Delete(ctx, userID entities.UserID, contactID uuid.UUID) error`
+  - `GetContactMap(ctx, userID entities.UserID) (map[string]*entities.Contact, error)` (cache-backed; most-recently-updated wins)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `api/pkg/services/contact_service_test.go`:
+
+```go
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCache struct {
+	store map[string]string
+}
+
+func newFakeCache() *fakeCache { return &fakeCache{store: map[string]string{}} }
+
+func (c *fakeCache) Get(_ context.Context, key string) (string, error) {
+	value, ok := c.store[key]
+	if !ok {
+		return "", assertMiss{}
+	}
+	return value, nil
+}
+
+func (c *fakeCache) Set(_ context.Context, key, value string, _ time.Duration) error {
+	c.store[key] = value
+	return nil
+}
+
+type assertMiss struct{}
+
+func (assertMiss) Error() string { return "miss" }
+
+type fakeContactRepo struct {
+	contacts  []*entities.Contact
+	fetchAll  int
+}
+
+func (r *fakeContactRepo) Store(_ context.Context, contacts []*entities.Contact) error {
+	r.contacts = append(r.contacts, contacts...)
+	return nil
+}
+func (r *fakeContactRepo) Update(_ context.Context, contact *entities.Contact) error { return nil }
+func (r *fakeContactRepo) Load(_ context.Context, _ entities.UserID, id uuid.UUID) (*entities.Contact, error) {
+	for _, c := range r.contacts {
+		if c.ID == id {
+			return c, nil
+		}
+	}
+	return nil, stacktrace.NewErrorWithCodef(repositories.ErrCodeNotFound, "contact [%s] not found", id)
+}
+func (r *fakeContactRepo) Index(_ context.Context, _ entities.UserID, _ repositories.IndexParams) (*[]entities.Contact, error) {
+	out := []entities.Contact{}
+	return &out, nil
+}
+func (r *fakeContactRepo) FetchAll(_ context.Context, _ entities.UserID) (*[]entities.Contact, error) {
+	r.fetchAll++
+	out := make([]entities.Contact, 0, len(r.contacts))
+	for _, c := range r.contacts {
+		out = append(out, *c)
+	}
+	return &out, nil
+}
+func (r *fakeContactRepo) Delete(_ context.Context, _ entities.UserID, _ uuid.UUID) error { return nil }
+func (r *fakeContactRepo) DeleteAllForUser(_ context.Context, _ entities.UserID) error   { return nil }
+
+func newContactService(repo repositories.ContactRepository, appCache *fakeCache) *ContactService {
+	logger := telemetry.NewZerologLogger("test", nil, nil, nil)
+	return NewContactService(logger, telemetry.NewOtelLogger("test", logger), repo, appCache)
+}
+
+func TestContactService_GetContactMap_TieBreakMostRecentlyUpdated(t *testing.T) {
+	older := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "Old", PhoneNumbers: pq.StringArray{"+18005550199"}, UpdatedAt: time.Now().Add(-time.Hour)}
+	newer := &entities.Contact{ID: uuid.New(), UserID: "u1", Name: "New", PhoneNumbers: pq.StringArray{"+18005550199"}, UpdatedAt: time.Now()}
+	// FetchAll returns ASC by updated_at, so older first then newer.
+	repo := &fakeContactRepo{contacts: []*entities.Contact{older, newer}}
+	service := newContactService(repo, newFakeCache())
+
+	result, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+	require.NotNil(t, result["+18005550199"])
+	assert.Equal(t, "New", result["+18005550199"].Name)
+}
+
+func TestContactService_GetContactMap_UsesCacheOnSecondCall(t *testing.T) {
+	repo := &fakeContactRepo{contacts: []*entities.Contact{{ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}}}}
+	service := newContactService(repo, newFakeCache())
+
+	_, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+	_, err = service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, repo.fetchAll)
+}
+
+func TestContactService_CreateMany_InvalidatesCache(t *testing.T) {
+	repo := &fakeContactRepo{contacts: []*entities.Contact{{ID: uuid.New(), UserID: "u1", Name: "Alice", PhoneNumbers: pq.StringArray{"+18005550199"}}}}
+	appCache := newFakeCache()
+	service := newContactService(repo, appCache)
+
+	_, err := service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+	require.Equal(t, 1, repo.fetchAll)
+
+	require.NoError(t, service.CreateMany(context.Background(), entities.UserID("u1"), []*entities.Contact{{ID: uuid.New(), UserID: "u1", Name: "Bob", PhoneNumbers: pq.StringArray{"+18005550100"}}}))
+
+	_, err = service.GetContactMap(context.Background(), entities.UserID("u1"))
+	require.NoError(t, err)
+	assert.Equal(t, 2, repo.fetchAll)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd api && go test -vet=off ./pkg/services/ -run TestContactService`
+Expected: FAIL / build error — `NewContactService` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `api/pkg/services/contact_service.go`:
+
+```go
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/cache"
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/google/uuid"
+)
+
+const contactMapCacheTTL = 24 * time.Hour
+
+// ContactService handles contact business logic.
+type ContactService struct {
+	service
+	logger     telemetry.Logger
+	tracer     telemetry.Tracer
+	repository repositories.ContactRepository
+	cache      cache.Cache
+}
+
+// NewContactService creates a new ContactService.
+func NewContactService(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+	repository repositories.ContactRepository,
+	appCache cache.Cache,
+) (s *ContactService) {
+	return &ContactService{
+		logger:     logger.WithService(fmt.Sprintf("%T", s)),
+		tracer:     tracer,
+		repository: repository,
+		cache:      appCache,
+	}
+}
+
+func (service *ContactService) cacheKey(userID entities.UserID) string {
+	return fmt.Sprintf("contacts.map.%s", userID)
+}
+
+// CreateMany persists one or many contacts then invalidates the cache.
+func (service *ContactService) CreateMany(ctx context.Context, userID entities.UserID, contacts []*entities.Contact) error {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	if err := service.repository.Store(ctx, contacts); err != nil {
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot store [%d] contacts for user [%s]", len(contacts), userID))
+	}
+	service.invalidate(ctx, userID)
+	return nil
+}
+
+// Get returns a contact by ID.
+func (service *ContactService) Get(ctx context.Context, userID entities.UserID, contactID uuid.UUID) (*entities.Contact, error) {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	contact, err := service.repository.Load(ctx, userID, contactID)
+	if err != nil {
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.PropagateWithCodef(err, stacktrace.GetCode(err), "cannot load contact [%s] for user [%s]", contactID, userID))
+	}
+	return contact, nil
+}
+
+// Index lists contacts for a user.
+func (service *ContactService) Index(ctx context.Context, userID entities.UserID, params repositories.IndexParams) (*[]entities.Contact, error) {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	contacts, err := service.repository.Index(ctx, userID, params)
+	if err != nil {
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot index contacts for user [%s]", userID))
+	}
+	return contacts, nil
+}
+
+// Update saves a contact and invalidates the cache.
+func (service *ContactService) Update(ctx context.Context, contact *entities.Contact) error {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	if err := service.repository.Update(ctx, contact); err != nil {
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot update contact [%s]", contact.ID))
+	}
+	service.invalidate(ctx, contact.UserID)
+	return nil
+}
+
+// Delete removes a contact and invalidates the cache.
+func (service *ContactService) Delete(ctx context.Context, userID entities.UserID, contactID uuid.UUID) error {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	if err := service.repository.Delete(ctx, userID, contactID); err != nil {
+		return service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot delete contact [%s] for user [%s]", contactID, userID))
+	}
+	service.invalidate(ctx, userID)
+	return nil
+}
+
+// GetContactMap returns the cached phone_number -> *Contact map for a user.
+func (service *ContactService) GetContactMap(ctx context.Context, userID entities.UserID) (map[string]*entities.Contact, error) {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	if raw, err := service.cache.Get(ctx, service.cacheKey(userID)); err == nil && raw != "" {
+		result := map[string]*entities.Contact{}
+		if jsonErr := json.Unmarshal([]byte(raw), &result); jsonErr == nil {
+			return result, nil
+		}
+	}
+
+	contacts, err := service.repository.FetchAll(ctx, userID)
+	if err != nil {
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "cannot fetch contacts to build map for user [%s]", userID))
+	}
+
+	// FetchAll returns updated_at ASC, so later (more recently updated) contacts overwrite earlier ones.
+	result := map[string]*entities.Contact{}
+	for index := range *contacts {
+		contact := (*contacts)[index]
+		for _, number := range contact.PhoneNumbers {
+			copied := contact
+			result[number] = &copied
+		}
+	}
+
+	if encoded, encodeErr := json.Marshal(result); encodeErr == nil {
+		_ = service.cache.Set(ctx, service.cacheKey(userID), string(encoded), contactMapCacheTTL)
+	}
+
+	return result, nil
+}
+
+// invalidate overwrites the cache key with an empty marker (Cache has no Delete).
+func (service *ContactService) invalidate(ctx context.Context, userID entities.UserID) {
+	if err := service.cache.Set(ctx, service.cacheKey(userID), "", contactMapCacheTTL); err != nil {
+		service.logger.Error(stacktrace.Propagatef(err, "cannot invalidate contact map cache for user [%s]", userID))
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd api && go test -vet=off ./pkg/services/ -run TestContactService`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/pkg/services/contact_service.go api/pkg/services/contact_service_test.go
+git commit -m "feat(api): add ContactService with cached contact-map resolution"
+```
+
+---
+
+### Task 7: Opt-in contact resolution in GetThreads
+
+**Files:**
+- Modify: `api/pkg/services/message_thread_service.go` (struct, constructor, `MessageThreadGetParams`, `GetThreads`)
+- Modify: `api/pkg/requests/message_thread_index_request.go` (`Contacts` param + `ToGetParams`)
+- Modify: `api/pkg/handlers/message_thread_handler_test.go` (add 6th constructor arg)
+- Create: `api/pkg/services/message_thread_service_contacts_test.go`
+- Create: `api/pkg/requests/message_thread_index_request_test.go`
+
+**Interfaces:**
+- Consumes: `ContactService.GetContactMap(ctx, userID) (map[string]*entities.Contact, error)` (Task 6); `entities.MessageThread.ContactDetails` (Task 2).
+- Produces: `MessageThreadGetParams.WithContacts bool`; `MessageThreadService` gains a `contactService contactMapProvider` field where `contactMapProvider` is:
+  ```go
+  type contactMapProvider interface {
+      GetContactMap(ctx context.Context, userID entities.UserID) (map[string]*entities.Contact, error)
+  }
+  ```
+  `*ContactService` satisfies `contactMapProvider`. New constructor signature:
+  `NewMessageThreadService(logger, tracer, repository, phoneRepository, eventDispatcher, contactService contactMapProvider) *MessageThreadService`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `api/pkg/requests/message_thread_index_request_test.go`:
+
+```go
+package requests
+
+import (
+	"testing"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessageThreadIndex_ToGetParams_WithContacts(t *testing.T) {
+	input := (&MessageThreadIndex{Owner: "+18005550199", Contacts: "true"}).Sanitize()
+	params := input.ToGetParams(entities.UserID("u1"))
+	assert.True(t, params.WithContacts)
+}
+
+func TestMessageThreadIndex_ToGetParams_WithoutContacts(t *testing.T) {
+	input := (&MessageThreadIndex{Owner: "+18005550199"}).Sanitize()
+	params := input.ToGetParams(entities.UserID("u1"))
+	assert.False(t, params.WithContacts)
+}
+```
+
+Create `api/pkg/services/message_thread_service_contacts_test.go`:
+
+```go
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubThreadRepo struct {
+	repositories.MessageThreadRepository
+	threads []entities.MessageThread
+}
+
+func (r *stubThreadRepo) Index(_ context.Context, _ entities.UserID, _ string, _ bool, _ repositories.IndexParams) (*[]entities.MessageThread, error) {
+	out := make([]entities.MessageThread, len(r.threads))
+	copy(out, r.threads)
+	return &out, nil
+}
+
+type stubContactProvider struct {
+	contactMap map[string]*entities.Contact
+	calls      int
+}
+
+func (p *stubContactProvider) GetContactMap(_ context.Context, _ entities.UserID) (map[string]*entities.Contact, error) {
+	p.calls++
+	return p.contactMap, nil
+}
+
+func newThreadServiceWithContacts(repo repositories.MessageThreadRepository, provider contactMapProvider) *MessageThreadService {
+	logger := telemetry.NewZerologLogger("test", nil, nil, nil)
+	return NewMessageThreadService(logger, telemetry.NewOtelLogger("test", logger), repo, nil, nil, provider)
+}
+
+func TestGetThreads_AttachesContactDetailsWhenWithContacts(t *testing.T) {
+	repo := &stubThreadRepo{threads: []entities.MessageThread{{Contact: "+18005550199"}, {Contact: "+18005550100"}}}
+	provider := &stubContactProvider{contactMap: map[string]*entities.Contact{"+18005550199": {Name: "Alice"}}}
+	service := newThreadServiceWithContacts(repo, provider)
+
+	threads, err := service.GetThreads(context.Background(), MessageThreadGetParams{UserID: "u1", WithContacts: true})
+	require.NoError(t, err)
+	require.Len(t, *threads, 2)
+	require.NotNil(t, (*threads)[0].ContactDetails)
+	assert.Equal(t, "Alice", (*threads)[0].ContactDetails.Name)
+	assert.Nil(t, (*threads)[1].ContactDetails)
+}
+
+func TestGetThreads_SkipsContactLookupWhenFlagOff(t *testing.T) {
+	repo := &stubThreadRepo{threads: []entities.MessageThread{{Contact: "+18005550199"}}}
+	provider := &stubContactProvider{contactMap: map[string]*entities.Contact{"+18005550199": {Name: "Alice"}}}
+	service := newThreadServiceWithContacts(repo, provider)
+
+	threads, err := service.GetThreads(context.Background(), MessageThreadGetParams{UserID: "u1", WithContacts: false})
+	require.NoError(t, err)
+	assert.Nil(t, (*threads)[0].ContactDetails)
+	assert.Equal(t, 0, provider.calls)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd api && go test -vet=off ./pkg/requests/ -run TestMessageThreadIndex_ToGetParams && go test -vet=off ./pkg/services/ -run TestGetThreads`
+Expected: FAIL / build error — `Contacts`, `WithContacts`, and the 6-arg constructor do not exist yet.
+
+- [ ] **Step 3: Implement request changes**
+
+In `api/pkg/requests/message_thread_index_request.go`, add the field to the struct:
+
+```go
+	Owner      string `json:"owner" query:"owner"`
+	Contacts   string `json:"contacts" query:"contacts" example:"true"`
+```
+
+Add sanitisation inside `Sanitize()` (before `return *input`):
+
+```go
+	input.Contacts = input.sanitizeBool(input.Contacts)
+```
+
+Add the field to the returned params in `ToGetParams`:
+
+```go
+		UserID:       userID,
+		IsArchived:   input.getBool(input.IsArchived),
+		Owner:        input.Owner,
+		WithContacts: input.getBool(input.Contacts),
+	}
+```
+
+- [ ] **Step 4: Implement service changes**
+
+In `api/pkg/services/message_thread_service.go` add the provider interface (top-level, after imports):
+
+```go
+// contactMapProvider supplies the phone_number -> *Contact map for a user.
+type contactMapProvider interface {
+	GetContactMap(ctx context.Context, userID entities.UserID) (map[string]*entities.Contact, error)
+}
+```
+
+Add the field to the struct:
+
+```go
+	eventDispatcher *EventDispatcher
+	contactService  contactMapProvider
+```
+
+Update the constructor:
+
+```go
+func NewMessageThreadService(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+	repository repositories.MessageThreadRepository,
+	phoneRepository repositories.PhoneRepository,
+	eventDispatcher *EventDispatcher,
+	contactService contactMapProvider,
+) (s *MessageThreadService) {
+	return &MessageThreadService{
+		logger:          logger.WithService(fmt.Sprintf("%T", s)),
+		tracer:          tracer,
+		eventDispatcher: eventDispatcher,
+		repository:      repository,
+		phoneRepository: phoneRepository,
+		contactService:  contactService,
+	}
+}
+```
+
+Add `WithContacts` to the params struct:
+
+```go
+type MessageThreadGetParams struct {
+	repositories.IndexParams
+	IsArchived   bool
+	WithContacts bool
+	UserID       entities.UserID
+	Owner        string
+}
+```
+
+Extend `GetThreads` to attach contact details (replace its body):
+
+```go
+func (service *MessageThreadService) GetThreads(ctx context.Context, params MessageThreadGetParams) (*[]entities.MessageThread, error) {
+	ctx, span := service.tracer.Start(ctx)
+	defer span.End()
+
+	ctxLogger := service.tracer.CtxLogger(service.logger, span)
+
+	threads, err := service.repository.Index(ctx, params.UserID, params.Owner, params.IsArchived, params.IndexParams)
+	if err != nil {
+		return nil, service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(err, "could not fetch messages threads for params [%+#v]", params))
+	}
+
+	if params.WithContacts && service.contactService != nil && len(*threads) > 0 {
+		contactMap, mapErr := service.contactService.GetContactMap(ctx, params.UserID)
+		if mapErr != nil {
+			ctxLogger.Error(service.tracer.WrapErrorSpan(span, stacktrace.Propagatef(mapErr, "cannot build contact map for user [%s]", params.UserID)))
+		} else {
+			for index := range *threads {
+				if contact, ok := contactMap[(*threads)[index].Contact]; ok {
+					(*threads)[index].ContactDetails = contact
+				}
+			}
+		}
+	}
+
+	ctxLogger.Info(fmt.Sprintf("fetched [%d] threads with params [%+#v]", len(*threads), params))
+	return threads, nil
+}
+```
+
+- [ ] **Step 5: Update DI wiring and existing callers**
+
+In `api/pkg/di/container.go`, find `NewMessageThreadService(...)` and append `container.ContactService()` as the final argument (the `ContactService()` getter is added in Task 8; if wiring Task 8 first, this compiles immediately — otherwise temporarily pass `nil` and restore in Task 8).
+
+Also update the existing test `api/pkg/handlers/message_thread_handler_test.go`: its call `services.NewMessageThreadService(logger, tracer, &messageThreadHandlerRepositoryStub{}, nil, nil)` now needs a sixth argument — change it to `services.NewMessageThreadService(logger, tracer, &messageThreadHandlerRepositoryStub{}, nil, nil, nil)`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd api && go test -vet=off ./pkg/requests/ -run TestMessageThreadIndex_ToGetParams && go test -vet=off ./pkg/services/ -run TestGetThreads`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/pkg/services/message_thread_service.go api/pkg/services/message_thread_service_contacts_test.go api/pkg/requests/message_thread_index_request.go api/pkg/requests/message_thread_index_request_test.go api/pkg/handlers/message_thread_handler_test.go api/pkg/di/container.go
+git commit -m "feat(api): opt-in contact resolution for message threads via ?contacts=true"
+```
+
+---
+
+### Task 8: ContactHandler + DI wiring + route registration
+
+**Files:**
+- Create: `api/pkg/handlers/contact_handler.go`
+- Create: `api/pkg/handlers/contact_handler_test.go`
+- Modify: `api/pkg/di/container.go` (getters, AutoMigrate, RegisterContactRoutes, wire ContactService into MessageThreadService)
+
+**Interfaces:**
+- Consumes: `services.ContactService` (Task 6), `validators.ContactHandlerValidator` (Task 5), `requests.*` (Task 4), `repositories.ErrCodeNotFound`.
+- Produces: `handlers.ContactHandler` with `NewContactHandler(logger, tracer, validator *validators.ContactHandlerValidator, service *services.ContactService) *ContactHandler` and `RegisterRoutes(router, ...middlewares)`. Routes: `GET /v1/contacts`, `POST /v1/contacts`, `POST /v1/contacts/upload`, `PUT /v1/contacts/:contactID`, `DELETE /v1/contacts/:contactID`. New DI getters: `container.ContactRepository()`, `container.ContactService()`, `container.ContactHandlerValidator()`, `container.ContactHandler()`, `container.RegisterContactRoutes()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `api/pkg/handlers/contact_handler_test.go`:
+
+```go
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/NdoleStudio/httpsms/pkg/cache"
+	"github.com/NdoleStudio/httpsms/pkg/entities"
+	"github.com/NdoleStudio/httpsms/pkg/middlewares"
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/services"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/httpsms/pkg/validators"
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	ttlCache "github.com/patrickmn/go-cache"
+	"github.com/stretchr/testify/require"
+)
+
+type contactHandlerRepoStub struct {
+	stored []*entities.Contact
+}
+
+func (s *contactHandlerRepoStub) Store(_ context.Context, contacts []*entities.Contact) error {
+	s.stored = append(s.stored, contacts...)
+	return nil
+}
+func (s *contactHandlerRepoStub) Update(context.Context, *entities.Contact) error { return nil }
+func (s *contactHandlerRepoStub) Load(context.Context, entities.UserID, uuid.UUID) (*entities.Contact, error) {
+	return nil, nil
+}
+func (s *contactHandlerRepoStub) Index(context.Context, entities.UserID, repositories.IndexParams) (*[]entities.Contact, error) {
+	out := []entities.Contact{}
+	return &out, nil
+}
+func (s *contactHandlerRepoStub) FetchAll(context.Context, entities.UserID) (*[]entities.Contact, error) {
+	out := []entities.Contact{}
+	return &out, nil
+}
+func (s *contactHandlerRepoStub) Delete(context.Context, entities.UserID, uuid.UUID) error { return nil }
+func (s *contactHandlerRepoStub) DeleteAllForUser(context.Context, entities.UserID) error  { return nil }
+
+func newContactTestApp(repo repositories.ContactRepository) *fiber.App {
+	logger := &messageThreadHandlerNoopLogger{}
+	tracer := telemetry.NewOtelLogger("test", logger)
+	appCache := cache.NewMemoryCache(tracer, ttlCache.New(time.Minute, time.Minute))
+	service := services.NewContactService(logger, tracer, repo, appCache)
+	handler := NewContactHandler(logger, tracer, &validators.ContactHandlerValidator{}, service)
+
+	app := fiber.New()
+	app.Use(func(c fiber.Ctx) error {
+		c.Locals(middlewares.ContextKeyAuthUserID, entities.AuthContext{ID: entities.UserID("user-id"), Email: "user@example.com"})
+		return c.Next()
+	})
+	handler.RegisterRoutes(app)
+	return app
+}
+
+func TestContactHandler_Store_CreatesContacts(t *testing.T) {
+	repo := &contactHandlerRepoStub{}
+	app := newContactTestApp(repo)
+
+	body := `[{"name":"Alice","phone_numbers":["+18005550199"]}]`
+	req := httptest.NewRequest(http.MethodPost, "/v1/contacts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.Len(t, repo.stored, 1)
+	require.Equal(t, "Alice", repo.stored[0].Name)
+}
+
+func TestContactHandler_Store_ValidationError(t *testing.T) {
+	app := newContactTestApp(&contactHandlerRepoStub{})
+
+	body := `[{"name":"","phone_numbers":[]}]`
+	req := httptest.NewRequest(http.MethodPost, "/v1/contacts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+}
+
+func TestContactHandler_Index_ReturnsOK(t *testing.T) {
+	app := newContactTestApp(&contactHandlerRepoStub{})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/contacts", nil)
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: time.Second})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd api && go test -vet=off ./pkg/handlers/ -run TestContactHandler`
+Expected: FAIL / build error — `NewContactHandler` undefined.
+
+- [ ] **Step 3: Write the handler**
+
+Create `api/pkg/handlers/contact_handler.go`:
+
+```go
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/NdoleStudio/httpsms/pkg/repositories"
+	"github.com/NdoleStudio/httpsms/pkg/requests"
+	"github.com/NdoleStudio/httpsms/pkg/services"
+	"github.com/NdoleStudio/httpsms/pkg/telemetry"
+	"github.com/NdoleStudio/httpsms/pkg/validators"
+	"github.com/NdoleStudio/stacktrace"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+)
+
+// ContactHandler handles contact http requests.
+type ContactHandler struct {
+	handler
+	logger    telemetry.Logger
+	tracer    telemetry.Tracer
+	validator *validators.ContactHandlerValidator
+	service   *services.ContactService
+}
+
+// NewContactHandler creates a new ContactHandler.
+func NewContactHandler(
+	logger telemetry.Logger,
+	tracer telemetry.Tracer,
+	validator *validators.ContactHandlerValidator,
+	service *services.ContactService,
+) (h *ContactHandler) {
+	return &ContactHandler{
+		logger:    logger.WithService(fmt.Sprintf("%T", h)),
+		tracer:    tracer,
+		validator: validator,
+		service:   service,
+	}
+}
+
+// RegisterRoutes registers the routes for the ContactHandler.
+func (h *ContactHandler) RegisterRoutes(router fiber.Router, middlewares ...fiber.Handler) {
+	h.register(router, fiber.MethodGet, "/v1/contacts", middlewares, h.Index)
+	h.register(router, fiber.MethodPost, "/v1/contacts", middlewares, h.Store)
+	h.register(router, fiber.MethodPost, "/v1/contacts/upload", middlewares, h.Upload)
+	h.register(router, fiber.MethodPut, "/v1/contacts/:contactID", middlewares, h.Update)
+	h.register(router, fiber.MethodDelete, "/v1/contacts/:contactID", middlewares, h.Delete)
+}
+
+// Index lists contacts for the authenticated user.
+// @Summary      List contacts
+// @Description  Returns the paginated list of contacts for the authenticated user.
+// @Security	 ApiKeyAuth
+// @Tags         Contacts
+// @Accept       json
+// @Produce      json
+// @Param        skip	query  int  	false	"number of contacts to skip"	minimum(0)
+// @Param        query	query  string  	false 	"filter contacts containing query"
+// @Param        limit	query  int  	false	"number of contacts to return"	minimum(1)	maximum(100)
+// @Success      200 	{object}	responses.ContactsResponse
+// @Failure      400	{object}	responses.BadRequest
+// @Failure 	 401    {object}	responses.Unauthorized
+// @Failure      422	{object}	responses.UnprocessableEntity
+// @Failure      500	{object}	responses.InternalServerError
+// @Router       /contacts [get]
+func (h *ContactHandler) Index(c fiber.Ctx) error {
+	ctx, span, ctxLogger := h.tracer.StartFromFiberCtxWithLogger(c, h.logger)
+	defer span.End()
+
+	var request requests.ContactIndex
+	if err := c.Bind().Query(&request); err != nil {
+		ctxLogger.Warn(stacktrace.Propagatef(err, "cannot marshall params [%s] into %T", c.OriginalURL(), request))
+		return h.responseBadRequest(c, err)
+	}
+
+	sanitized := request.Sanitize()
+	if errors := h.validator.ValidateIndex(ctx, sanitized); len(errors) != 0 {
+		ctxLogger.Warn(stacktrace.NewErrorf("validation errors [%s], while listing contacts [%+#v]", spew.Sdump(errors), sanitized))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while listing contacts")
+	}
+
+	contacts, err := h.service.Index(ctx, h.userIDFomContext(c), sanitized.ToIndexParams())
+	if err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot list contacts for user [%s]", h.userIDFomContext(c)))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseOK(c, fmt.Sprintf("fetched %d %s", len(*contacts), h.pluralize("contact", len(*contacts))), contacts)
+}
+
+// Store creates one or many contacts.
+// @Summary      Create one or many contacts
+// @Description  Creates a single contact or a batch of contacts. Accepts a JSON array or an object with a "contacts" array.
+// @Security	 ApiKeyAuth
+// @Tags         Contacts
+// @Accept       json
+// @Produce      json
+// @Param        payload   body 		requests.ContactStoreRequest 	true 	"Contact(s) to create"
+// @Success      201 	{object}	responses.ContactsResponse
+// @Failure      400	{object}	responses.BadRequest
+// @Failure 	 401    {object}	responses.Unauthorized
+// @Failure      422	{object}	responses.UnprocessableEntity
+// @Failure      500	{object}	responses.InternalServerError
+// @Router       /contacts [post]
+func (h *ContactHandler) Store(c fiber.Ctx) error {
+	ctx, span, ctxLogger := h.tracer.StartFromFiberCtxWithLogger(c, h.logger)
+	defer span.End()
+
+	var request requests.ContactStoreRequest
+	if err := c.Bind().Body(&request); err != nil {
+		ctxLogger.Warn(stacktrace.Propagatef(err, "cannot marshall body [%s] into %T", c.Body(), request))
+		return h.responseBadRequest(c, err)
+	}
+
+	sanitized := request.Sanitize()
+	if errors := h.validator.ValidateStore(ctx, sanitized); len(errors) != 0 {
+		ctxLogger.Warn(stacktrace.NewErrorf("validation errors [%s], while creating contacts", spew.Sdump(errors)))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while creating contacts")
+	}
+
+	userID := h.userIDFomContext(c)
+	contacts := sanitized.ToContacts(userID)
+	if err := h.service.CreateMany(ctx, userID, contacts); err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot create [%d] contacts for user [%s]", len(contacts), userID))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseCreated(c, fmt.Sprintf("created %d %s", len(contacts), h.pluralize("contact", len(contacts))), contacts)
+}
+
+// Upload imports contacts from a CSV file.
+// @Summary      Import contacts from CSV
+// @Description  Uploads a CSV file (multipart field "document") of contacts. Columns: Name, Emails, PhoneNumbers (multi-values separated by ";").
+// @Security	 ApiKeyAuth
+// @Tags         Contacts
+// @Accept       multipart/form-data
+// @Produce      json
+// @Param        document	formData	file	true	"CSV file of contacts"
+// @Success      201 	{object}	responses.ContactsResponse
+// @Failure      400	{object}	responses.BadRequest
+// @Failure 	 401    {object}	responses.Unauthorized
+// @Failure      422	{object}	responses.UnprocessableEntity
+// @Failure      500	{object}	responses.InternalServerError
+// @Router       /contacts/upload [post]
+func (h *ContactHandler) Upload(c fiber.Ctx) error {
+	ctx, span, ctxLogger := h.tracer.StartFromFiberCtxWithLogger(c, h.logger)
+	defer span.End()
+
+	file, err := c.FormFile("document")
+	if err != nil {
+		ctxLogger.Warn(stacktrace.Propagatef(err, "cannot fetch file with name [%s] from request", "document"))
+		return h.responseBadRequest(c, err)
+	}
+
+	userID := h.userIDFomContext(c)
+	items, errors := h.validator.ValidateUpload(ctx, userID, file)
+	if len(errors) != 0 {
+		ctxLogger.Warn(stacktrace.NewErrorf("validation errors [%s], while importing contacts from CSV [%s]", spew.Sdump(errors), file.Filename))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while importing contacts")
+	}
+
+	request := (requests.ContactStoreRequest{Contacts: items}).Sanitize()
+	contacts := request.ToContacts(userID)
+	if err = h.service.CreateMany(ctx, userID, contacts); err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot import [%d] contacts for user [%s]", len(contacts), userID))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseCreated(c, fmt.Sprintf("imported %d %s", len(contacts), h.pluralize("contact", len(contacts))), contacts)
+}
+
+// Update updates a single contact.
+// @Summary      Update a contact
+// @Description  Updates the details of a single contact.
+// @Security	 ApiKeyAuth
+// @Tags         Contacts
+// @Accept       json
+// @Produce      json
+// @Param 		 contactID	path		string 							true 	"ID of the contact"
+// @Param        payload   	body 		requests.ContactUpdateRequest 	true 	"Contact details to update"
+// @Success      200 		{object}	responses.ContactResponse
+// @Failure      400		{object}	responses.BadRequest
+// @Failure 	 401    	{object}	responses.Unauthorized
+// @Failure      404		{object}	responses.NotFound
+// @Failure      422		{object}	responses.UnprocessableEntity
+// @Failure      500		{object}	responses.InternalServerError
+// @Router       /contacts/{contactID} [put]
+func (h *ContactHandler) Update(c fiber.Ctx) error {
+	ctx, span, ctxLogger := h.tracer.StartFromFiberCtxWithLogger(c, h.logger)
+	defer span.End()
+
+	contactID := c.Params("contactID")
+	if errors := h.validator.ValidateUUID(contactID, "contactID"); len(errors) != 0 {
+		ctxLogger.Warn(stacktrace.NewErrorf("validation errors [%s], while updating contact [%s]", spew.Sdump(errors), contactID))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while updating contact")
+	}
+
+	var request requests.ContactUpdateRequest
+	if err := c.Bind().Body(&request); err != nil {
+		ctxLogger.Warn(stacktrace.Propagatef(err, "cannot marshall body into %T", request))
+		return h.responseBadRequest(c, err)
+	}
+
+	sanitized := request.Sanitize()
+	if errors := h.validator.ValidateUpdate(ctx, sanitized); len(errors) != 0 {
+		ctxLogger.Warn(stacktrace.NewErrorf("validation errors [%s], while updating contact [%s]", spew.Sdump(errors), contactID))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while updating contact")
+	}
+
+	userID := h.userIDFomContext(c)
+	contact, err := h.service.Get(ctx, userID, uuid.MustParse(contactID))
+	if stacktrace.GetCode(err) == repositories.ErrCodeNotFound {
+		return h.responseNotFound(c, fmt.Sprintf("cannot find contact with ID [%s]", contactID))
+	}
+	if err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot load contact [%s] for user [%s]", contactID, userID))
+		return h.responseInternalServerError(c)
+	}
+
+	sanitized.ApplyTo(contact)
+	if err = h.service.Update(ctx, contact); err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot update contact [%s]", contactID))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseOK(c, "contact updated successfully", contact)
+}
+
+// Delete removes a single contact.
+// @Summary      Delete a contact
+// @Description  Deletes a single contact from the database.
+// @Security	 ApiKeyAuth
+// @Tags         Contacts
+// @Accept       json
+// @Produce      json
+// @Param 		 contactID	path		string 	true	"ID of the contact"
+// @Success      204  	{object} 	responses.NoContent
+// @Failure      400  	{object}  	responses.BadRequest
+// @Failure 	 401    {object}	responses.Unauthorized
+// @Failure 	 404	{object}	responses.NotFound
+// @Failure      422  	{object} 	responses.UnprocessableEntity
+// @Failure      500  	{object}  	responses.InternalServerError
+// @Router       /contacts/{contactID} [delete]
+func (h *ContactHandler) Delete(c fiber.Ctx) error {
+	ctx, span, ctxLogger := h.tracer.StartFromFiberCtxWithLogger(c, h.logger)
+	defer span.End()
+
+	contactID := c.Params("contactID")
+	if errors := h.validator.ValidateUUID(contactID, "contactID"); len(errors) != 0 {
+		ctxLogger.Warn(stacktrace.NewErrorf("validation errors [%s], while deleting contact [%s]", spew.Sdump(errors), contactID))
+		return h.responseUnprocessableEntity(c, errors, "validation errors while deleting contact")
+	}
+
+	userID := h.userIDFomContext(c)
+	if err := h.service.Delete(ctx, userID, uuid.MustParse(contactID)); err != nil {
+		ctxLogger.Error(stacktrace.Propagatef(err, "cannot delete contact [%s] for user [%s]", contactID, userID))
+		return h.responseInternalServerError(c)
+	}
+
+	return h.responseNoContent(c, "contact deleted successfully")
+}
+```
+
+- [ ] **Step 4: Add DI getters and wiring**
+
+In `api/pkg/di/container.go`:
+
+Add a repository getter (near `MessageThreadRepository`):
+
+```go
+// ContactRepository creates a new instance of repositories.ContactRepository
+func (container *Container) ContactRepository() (repository repositories.ContactRepository) {
+	container.logger.Debug("creating GORM repositories.ContactRepository")
+	return repositories.NewGormContactRepository(
+		container.Logger(),
+		container.Tracer(),
+		container.DB(),
+	)
+}
+```
+
+Add a service getter (near `MessageThreadService`):
+
+```go
+// ContactService creates a new instance of services.ContactService
+func (container *Container) ContactService() (service *services.ContactService) {
+	container.logger.Debug(fmt.Sprintf("creating %T", service))
+	return services.NewContactService(
+		container.Logger(),
+		container.Tracer(),
+		container.ContactRepository(),
+		container.Cache(),
+	)
+}
+```
+
+Add a validator getter (near `MessageThreadHandlerValidator`):
+
+```go
+// ContactHandlerValidator creates a new instance of validators.ContactHandlerValidator
+func (container *Container) ContactHandlerValidator() (validator *validators.ContactHandlerValidator) {
+	container.logger.Debug(fmt.Sprintf("creating %T", validator))
+	return validators.NewContactHandlerValidator(
+		container.Logger(),
+		container.Tracer(),
+	)
+}
+```
+
+Add a handler getter (near `MessageThreadHandler`):
+
+```go
+// ContactHandler creates a new instance of handlers.ContactHandler
+func (container *Container) ContactHandler() (h *handlers.ContactHandler) {
+	container.logger.Debug(fmt.Sprintf("creating %T", h))
+	return handlers.NewContactHandler(
+		container.Logger(),
+		container.Tracer(),
+		container.ContactHandlerValidator(),
+		container.ContactService(),
+	)
+}
+```
+
+Add a route registrar (near `RegisterMessageThreadRoutes`):
+
+```go
+// RegisterContactRoutes registers routes for the /contacts prefix
+func (container *Container) RegisterContactRoutes() {
+	container.logger.Debug(fmt.Sprintf("registering %T routes", &handlers.ContactHandler{}))
+	container.ContactHandler().RegisterRoutes(container.App(), container.AuthenticatedMiddleware())
+}
+```
+
+Call the registrar right after `container.RegisterMessageThreadRoutes()` (around line 123):
+
+```go
+	container.RegisterMessageThreadRoutes()
+	container.RegisterContactRoutes()
+```
+
+Wire the ContactService into MessageThreadService (finalise Task 7 Step 5): the `MessageThreadService()` getter's `NewMessageThreadService(...)` call's final argument becomes `container.ContactService()`:
+
+```go
+	return services.NewMessageThreadService(
+		container.Logger(),
+		container.Tracer(),
+		container.MessageThreadRepository(),
+		container.PhoneRepository(),
+		container.EventDispatcher(),
+		container.ContactService(),
+	)
+```
+
+Add the AutoMigrate entry in the AutoMigrate block (around line 413, alongside the other `db.AutoMigrate(&entities.X{})` calls) — this may already be present from Task 2; if not, add:
+
+```go
+	if err = db.AutoMigrate(&entities.Contact{}); err != nil {
+		container.logger.Fatal(stacktrace.Propagatef(err, "cannot migrate %T", &entities.Contact{}))
+	}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd api && go test -vet=off ./pkg/handlers/ -run TestContactHandler`
+Expected: PASS
+
+- [ ] **Step 6: Build the whole API to confirm wiring compiles**
+
+Run: `cd api && go build ./...`
+Expected: no output (success).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/pkg/handlers/contact_handler.go api/pkg/handlers/contact_handler_test.go api/pkg/di/container.go
+git commit -m "feat(api): add ContactHandler and wire contacts into DI container"
+```
+
+---
+
+### Task 9: Swagger regeneration + CSV import template
+
+**Files:**
+- Modify: `api/docs/*` (generated by swag)
+- Create: `web/public/templates/httpsms-contacts.csv`
+- Create/verify: `api/pkg/responses/` contact response types if referenced by Swagger annotations (see Step 1).
+
+**Interfaces:**
+- Consumes: Swagger annotations added on `ContactHandler` (Task 8), which reference `responses.ContactResponse` and `responses.ContactsResponse`.
+- Produces: regenerated `api/docs/swagger.json` / `swagger.yaml` / `docs.go` including the `/contacts` endpoints; a downloadable CSV template served by the web app.
+
+- [ ] **Step 1: Add response wrapper types (if missing)**
+
+Check whether `responses.ContactResponse` and `responses.ContactsResponse` exist:
+
+Run: `cd api && findstr /S /C:"ContactsResponse" pkg\responses\*.go`
+Expected: no matches (they don't exist yet).
+
+Create `api/pkg/responses/contact_responses.go`:
+
+```go
+package responses
+
+import "github.com/NdoleStudio/httpsms/pkg/entities"
+
+// ContactResponse is the response with a single entities.Contact.
+type ContactResponse struct {
+	response
+	Data entities.Contact `json:"data"`
+}
+
+// ContactsResponse is the response with a list of entities.Contact.
+type ContactsResponse struct {
+	response
+	Data []entities.Contact `json:"data"`
+}
+```
+
+(Verify the base embedded type name: open any file in `api/pkg/responses/` and confirm the unexported base struct is `response` with `Status`/`Message` fields; match the exact embed used by e.g. `MessageThreadsResponse`.)
+
+- [ ] **Step 2: Regenerate Swagger docs**
+
+Run:
+
+```bash
+cd api && swag init --requiredByDefault --parseDependency --parseInternal
+```
+
+Expected: `create docs/docs.go`, `create docs/swagger.json`, `create docs/swagger.yaml` with no errors. Confirm `/contacts` appears:
+
+Run: `cd api && findstr /C:"/contacts" docs\swagger.json`
+Expected: matches for `/contacts`, `/contacts/upload`, `/contacts/{contactID}`.
+
+- [ ] **Step 3: Create the CSV import template**
+
+Create `web/public/templates/httpsms-contacts.csv`:
+
+```csv
+Name,Emails,PhoneNumbers
+John Doe,john@example.com,+18005550199
+Jane Smith,jane@example.com;jane.work@example.com,+18005550100;+18005550111
+Acme Support,,+18005550122
+```
+
+(Multiple emails or phone numbers in one cell are separated by `;`, matching the CSV parser in Task 5's `ValidateUpload`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/docs api/pkg/responses/contact_responses.go web/public/templates/httpsms-contacts.csv
+git commit -m "chore(api): regenerate swagger for contacts + add CSV import template"
+```
+
+---
+
+### Task 10: Regenerate web API TypeScript models
+
+**Files:**
+- Modify: `web/shared/types/api.ts` (generated)
+
+**Interfaces:**
+- Consumes: `api/docs/swagger.json` (regenerated in Task 9) with the `Contact` schema and `/contacts` paths.
+- Produces: generated types `EntitiesContact` and (if the response wrappers were added) `ResponsesContactResponse` / `ResponsesContactsResponse` in `web/shared/types/api.ts`; `EntitiesMessageThread` now includes an optional `contact_details?: EntitiesContact`.
+
+> **Note:** This task must run AFTER Task 9 (swagger regen). No new hand-written code — the model file is generated.
+
+- [ ] **Step 1: Regenerate models**
+
+Run:
+
+```bash
+cd web && pnpm api:models
+```
+
+Expected: `web/shared/types/api.ts` rewritten with no errors.
+
+- [ ] **Step 2: Verify the Contact type exists**
+
+Run: `cd web && findstr /C:"EntitiesContact" shared\types\api.ts`
+Expected: matches for `EntitiesContact` interface and `contact_details` on the message-thread interface.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/shared/types/api.ts
+git commit -m "chore(web): regenerate API models with Contact types"
+```
+
+---
+
+### Task 11: Contacts Pinia store
+
+**Files:**
+- Create: `web/app/stores/contacts.ts`
+
+**Interfaces:**
+- Consumes: `useApi()` (`apiFetch`), `useNotificationsStore()`, `getApiErrorMessage`, `EntitiesContact` (Task 10).
+- Produces: `useContactsStore()` exposing state `contacts`, `loading`, `search`; getters `filteredContacts`, `total`; actions `loadContacts(force?)`, `saveContacts(items)`, `updateContact(id, payload)`, `deleteContact(id)`, `uploadCsv(file)`, `resetState()`.
+
+- [ ] **Step 1: Write the store**
+
+Create `web/app/stores/contacts.ts`:
+
+```ts
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import type { EntitiesContact } from '~~/shared/types/api'
+import { getApiErrorMessage } from '~/utils/api-error'
+
+export interface ContactInput {
+  name: string
+  emails: string[]
+  phone_numbers: string[]
+  properties?: Record<string, string>
+}
+
+export const useContactsStore = defineStore('contacts', () => {
+  const contacts = ref<EntitiesContact[]>([])
+  const loading = ref(false)
+  const search = ref('')
+  const { apiFetch } = useApi()
+  const notificationsStore = useNotificationsStore()
+
+  const total = computed(() => contacts.value.length)
+
+  const filteredContacts = computed<EntitiesContact[]>(() => {
+    const term = search.value.trim().toLowerCase()
+    if (!term) return contacts.value
+    return contacts.value.filter((contact) => {
+      const name = (contact.name ?? '').toLowerCase()
+      const emails = (contact.emails ?? []).join(' ').toLowerCase()
+      const numbers = (contact.phone_numbers ?? []).join(' ').toLowerCase()
+      return (
+        name.includes(term) ||
+        emails.includes(term) ||
+        numbers.includes(term)
+      )
+    })
+  })
+
+  async function loadContacts(force = false) {
+    if (contacts.value.length > 0 && !force) return
+    loading.value = true
+    try {
+      const response = await apiFetch<{ data: EntitiesContact[] }>(
+        '/v1/contacts',
+        { params: { limit: 100 } },
+      )
+      contacts.value = response.data ?? []
+    } catch (error: unknown) {
+      notificationsStore.addNotification({
+        message: getApiErrorMessage(error, 'Error while loading contacts'),
+        type: 'error',
+      })
+      throw error
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function saveContacts(items: ContactInput[]) {
+    try {
+      await apiFetch('/v1/contacts', { method: 'POST', body: items })
+      notificationsStore.addNotification({
+        message:
+          items.length > 1 ? 'Contacts created' : 'Contact created',
+        type: 'success',
+      })
+      await loadContacts(true)
+    } catch (error: unknown) {
+      notificationsStore.addNotification({
+        message: getApiErrorMessage(error, 'Error while saving contacts'),
+        type: 'error',
+      })
+      throw error
+    }
+  }
+
+  async function updateContact(id: string, payload: ContactInput) {
+    try {
+      await apiFetch(`/v1/contacts/${id}`, { method: 'PUT', body: payload })
+      notificationsStore.addNotification({
+        message: 'Contact updated',
+        type: 'success',
+      })
+      await loadContacts(true)
+    } catch (error: unknown) {
+      notificationsStore.addNotification({
+        message: getApiErrorMessage(error, 'Error while updating contact'),
+        type: 'error',
+      })
+      throw error
+    }
+  }
+
+  async function deleteContact(id: string) {
+    try {
+      await apiFetch(`/v1/contacts/${id}`, { method: 'DELETE' })
+      contacts.value = contacts.value.filter((contact) => contact.id !== id)
+      notificationsStore.addNotification({
+        message: 'Contact deleted',
+        type: 'success',
+      })
+    } catch (error: unknown) {
+      notificationsStore.addNotification({
+        message: getApiErrorMessage(error, 'Error while deleting contact'),
+        type: 'error',
+      })
+      throw error
+    }
+  }
+
+  async function uploadCsv(file: File) {
+    try {
+      const formData = new FormData()
+      formData.append('document', file)
+      await apiFetch('/v1/contacts/upload', {
+        method: 'POST',
+        body: formData,
+      })
+      notificationsStore.addNotification({
+        message: 'Contacts imported successfully',
+        type: 'success',
+      })
+      await loadContacts(true)
+    } catch (error: unknown) {
+      notificationsStore.addNotification({
+        message: getApiErrorMessage(error, 'Error while importing contacts'),
+        type: 'error',
+      })
+      throw error
+    }
+  }
+
+  function resetState() {
+    contacts.value = []
+    loading.value = false
+    search.value = ''
+  }
+
+  return {
+    contacts,
+    loading,
+    search,
+    total,
+    filteredContacts,
+    loadContacts,
+    saveContacts,
+    updateContact,
+    deleteContact,
+    uploadCsv,
+    resetState,
+  }
+})
+```
+
+- [ ] **Step 2: Lint the new store**
+
+Run: `cd web && pnpm lint:js`
+Expected: no errors for `app/stores/contacts.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/app/stores/contacts.ts
+git commit -m "feat(web): add contacts Pinia store"
+```
+
+---
+
+### Task 12: Contacts page with add/edit/delete/import dialogs
+
+**Files:**
+- Create: `web/app/pages/contacts/index.vue`
+
+**Interfaces:**
+- Consumes: `useContactsStore()` (Task 11), `useFilters()` (`formatPhoneNumber`), `EntitiesContact` (Task 10).
+- Produces: the `/contacts` route (Nuxt file-based routing infers `name: 'contacts'`, used by the nav link in Task 13).
+
+**UI requirements (from spec section 7 / reference screenshot):**
+- Page title `text-display-large` (NO gradient/glow — theme text only); subtitle showing total contact count.
+- Top-right actions: "Import CSV" (outlined button) + "Add Contact" (filled `color="primary"` button).
+- Debounced search field filtering by name/email/phone.
+- Table of contacts (Name, Emails, Phone Numbers) with edit + delete icon actions per row.
+- Add/Edit/Delete/Import are `VDialog`s. **Every `VDialog` MUST set `opacity="0.9"` and its Close button MUST use `color="warning"`.**
+
+- [ ] **Step 1: Write the page**
+
+Create `web/app/pages/contacts/index.vue`:
+
+```vue
+<script setup lang="ts">
+import {
+  mdiArrowLeft,
+  mdiPlus,
+  mdiFileUpload,
+  mdiPencil,
+  mdiDelete,
+  mdiMagnify,
+  mdiClose,
+} from '@mdi/js'
+import { ref, computed, onMounted } from 'vue'
+import type { EntitiesContact } from '~~/shared/types/api'
+import { useContactsStore, type ContactInput } from '~/stores/contacts'
+import { useFilters } from '~/composables/useFilters'
+
+definePageMeta({
+  middleware: ['auth'],
+})
+
+useHead({
+  title: 'Contacts - httpSMS',
+})
+
+const contactsStore = useContactsStore()
+const { formatPhoneNumber } = useFilters()
+
+const editDialog = ref(false)
+const deleteDialog = ref(false)
+const importDialog = ref(false)
+const saving = ref(false)
+const editingId = ref<string | null>(null)
+const pendingDeleteId = ref<string | null>(null)
+const importFile = ref<File | null>(null)
+
+const form = ref<{ name: string; emails: string; phone_numbers: string }>({
+  name: '',
+  emails: '',
+  phone_numbers: '',
+})
+
+const dialogTitle = computed(() =>
+  editingId.value ? 'Edit Contact' : 'Add Contact',
+)
+
+function splitList(value: string): string[] {
+  return value
+    .split(/[,;]/)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+}
+
+function openAdd() {
+  editingId.value = null
+  form.value = { name: '', emails: '', phone_numbers: '' }
+  editDialog.value = true
+}
+
+function openEdit(contact: EntitiesContact) {
+  editingId.value = contact.id ?? null
+  form.value = {
+    name: contact.name ?? '',
+    emails: (contact.emails ?? []).join(', '),
+    phone_numbers: (contact.phone_numbers ?? []).join(', '),
+  }
+  editDialog.value = true
+}
+
+function openDelete(contact: EntitiesContact) {
+  pendingDeleteId.value = contact.id ?? null
+  deleteDialog.value = true
+}
+
+async function submitForm() {
+  saving.value = true
+  const payload: ContactInput = {
+    name: form.value.name.trim(),
+    emails: splitList(form.value.emails),
+    phone_numbers: splitList(form.value.phone_numbers),
+  }
+  try {
+    if (editingId.value) {
+      await contactsStore.updateContact(editingId.value, payload)
+    } else {
+      await contactsStore.saveContacts([payload])
+    }
+    editDialog.value = false
+  } catch {
+    // notification already surfaced by the store
+  } finally {
+    saving.value = false
+  }
+}
+
+async function confirmDelete() {
+  if (!pendingDeleteId.value) return
+  saving.value = true
+  try {
+    await contactsStore.deleteContact(pendingDeleteId.value)
+    deleteDialog.value = false
+  } catch {
+    // notification already surfaced by the store
+  } finally {
+    saving.value = false
+    pendingDeleteId.value = null
+  }
+}
+
+async function submitImport() {
+  if (!importFile.value) return
+  saving.value = true
+  try {
+    await contactsStore.uploadCsv(importFile.value)
+    importDialog.value = false
+    importFile.value = null
+  } catch {
+    // notification already surfaced by the store
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(() => {
+  contactsStore.loadContacts(true).catch(() => {})
+})
+</script>
+
+<template>
+  <VContainer fluid class="px-0 pt-0">
+    <VAppBar>
+      <VBtn icon to="/threads">
+        <VIcon :icon="mdiArrowLeft" />
+      </VBtn>
+      <VToolbarTitle>Contacts</VToolbarTitle>
+      <VProgressLinear
+        :active="contactsStore.loading"
+        color="primary"
+        :indeterminate="contactsStore.loading"
+        location="bottom"
+        absolute
+      />
+    </VAppBar>
+
+    <VContainer>
+      <VRow>
+        <VCol cols="12" md="10" offset-md="1" xxl="8" offset-xxl="2">
+          <div
+            class="d-flex flex-column flex-md-row align-md-center mb-6 mt-3"
+          >
+            <div>
+              <h1 class="text-display-large">Contacts</h1>
+              <p class="text-medium-emphasis mb-0">
+                {{ contactsStore.total }}
+                {{ contactsStore.total === 1 ? 'contact' : 'contacts' }}
+              </p>
+            </div>
+            <VSpacer />
+            <div class="d-flex mt-4 mt-md-0">
+              <VBtn
+                variant="outlined"
+                color="primary"
+                :prepend-icon="mdiFileUpload"
+                class="mr-3"
+                @click="importDialog = true"
+              >
+                Import CSV
+              </VBtn>
+              <VBtn
+                color="primary"
+                :prepend-icon="mdiPlus"
+                @click="openAdd"
+              >
+                Add Contact
+              </VBtn>
+            </div>
+          </div>
+
+          <VTextField
+            v-model="contactsStore.search"
+            :prepend-inner-icon="mdiMagnify"
+            label="Search contacts"
+            variant="outlined"
+            density="comfortable"
+            clearable
+            hide-details
+            class="mb-4"
+          />
+
+          <VTable density="comfortable">
+            <thead>
+              <tr class="text-uppercase text-medium-emphasis">
+                <th class="text-left">Name</th>
+                <th class="text-left">Emails</th>
+                <th class="text-left">Phone Numbers</th>
+                <th class="text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="contact in contactsStore.filteredContacts"
+                :key="contact.id"
+              >
+                <td class="text-left">{{ contact.name }}</td>
+                <td class="text-left">
+                  {{ (contact.emails ?? []).join(', ') }}
+                </td>
+                <td class="text-left">
+                  {{
+                    (contact.phone_numbers ?? [])
+                      .map((number) => formatPhoneNumber(number))
+                      .join(', ')
+                  }}
+                </td>
+                <td class="text-right">
+                  <VBtn
+                    icon
+                    variant="text"
+                    size="small"
+                    @click="openEdit(contact)"
+                  >
+                    <VIcon :icon="mdiPencil" />
+                  </VBtn>
+                  <VBtn
+                    icon
+                    variant="text"
+                    size="small"
+                    color="error"
+                    @click="openDelete(contact)"
+                  >
+                    <VIcon :icon="mdiDelete" />
+                  </VBtn>
+                </td>
+              </tr>
+              <tr v-if="contactsStore.filteredContacts.length === 0">
+                <td colspan="4" class="text-center text-medium-emphasis py-8">
+                  No contacts found.
+                </td>
+              </tr>
+            </tbody>
+          </VTable>
+        </VCol>
+      </VRow>
+    </VContainer>
+
+    <!-- Add / Edit dialog -->
+    <VDialog v-model="editDialog" max-width="560" opacity="0.9">
+      <VCard>
+        <VCardTitle class="d-flex align-center">
+          <span>{{ dialogTitle }}</span>
+          <VSpacer />
+          <VBtn
+            icon
+            variant="text"
+            color="warning"
+            @click="editDialog = false"
+          >
+            <VIcon :icon="mdiClose" />
+          </VBtn>
+        </VCardTitle>
+        <VCardText>
+          <VTextField
+            v-model="form.name"
+            label="Name"
+            variant="outlined"
+            class="mb-2"
+          />
+          <VTextField
+            v-model="form.emails"
+            label="Emails (comma separated)"
+            variant="outlined"
+            class="mb-2"
+          />
+          <VTextField
+            v-model="form.phone_numbers"
+            label="Phone numbers (comma separated)"
+            variant="outlined"
+          />
+        </VCardText>
+        <VCardActions>
+          <VSpacer />
+          <VBtn color="warning" variant="text" @click="editDialog = false">
+            Close
+          </VBtn>
+          <VBtn
+            color="primary"
+            :loading="saving"
+            :disabled="saving"
+            @click="submitForm"
+          >
+            Save
+          </VBtn>
+        </VCardActions>
+      </VCard>
+    </VDialog>
+
+    <!-- Delete dialog -->
+    <VDialog v-model="deleteDialog" max-width="460" opacity="0.9">
+      <VCard>
+        <VCardTitle class="d-flex align-center">
+          <span>Delete Contact</span>
+          <VSpacer />
+          <VBtn
+            icon
+            variant="text"
+            color="warning"
+            @click="deleteDialog = false"
+          >
+            <VIcon :icon="mdiClose" />
+          </VBtn>
+        </VCardTitle>
+        <VCardText>
+          Are you sure you want to delete this contact? This action cannot be
+          undone.
+        </VCardText>
+        <VCardActions>
+          <VSpacer />
+          <VBtn color="warning" variant="text" @click="deleteDialog = false">
+            Close
+          </VBtn>
+          <VBtn
+            color="error"
+            :loading="saving"
+            :disabled="saving"
+            @click="confirmDelete"
+          >
+            Delete
+          </VBtn>
+        </VCardActions>
+      </VCard>
+    </VDialog>
+
+    <!-- Import CSV dialog -->
+    <VDialog v-model="importDialog" max-width="560" opacity="0.9">
+      <VCard>
+        <VCardTitle class="d-flex align-center">
+          <span>Import Contacts from CSV</span>
+          <VSpacer />
+          <VBtn
+            icon
+            variant="text"
+            color="warning"
+            @click="importDialog = false"
+          >
+            <VIcon :icon="mdiClose" />
+          </VBtn>
+        </VCardTitle>
+        <VCardText>
+          <p class="mb-3">
+            Download our
+            <a
+              class="text-decoration-none hover:text-decoration-underline"
+              download
+              href="/templates/httpsms-contacts.csv"
+              >CSV template</a
+            >, fill it in and upload it here. Columns: Name, Emails,
+            PhoneNumbers (multiple values separated by ";").
+          </p>
+          <VFileInput
+            v-model="importFile"
+            label="CSV file"
+            color="primary"
+            accept=".csv,text/csv"
+            variant="outlined"
+            hide-details
+          />
+        </VCardText>
+        <VCardActions>
+          <VSpacer />
+          <VBtn color="warning" variant="text" @click="importDialog = false">
+            Close
+          </VBtn>
+          <VBtn
+            color="primary"
+            :loading="saving"
+            :disabled="saving || !importFile"
+            @click="submitImport"
+          >
+            Import
+          </VBtn>
+        </VCardActions>
+      </VCard>
+    </VDialog>
+  </VContainer>
+</template>
+```
+
+- [ ] **Step 2: Lint the page**
+
+Run: `cd web && pnpm lint:js && pnpm lint:prettier`
+Expected: no errors for `app/pages/contacts/index.vue`. If Prettier reports formatting, run `pnpm lintfix` and re-check.
+
+- [ ] **Step 3: Build the site to confirm it compiles**
+
+Run: `cd web && pnpm generate`
+Expected: build completes without type errors (the `/contacts` route is emitted).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/app/pages/contacts/index.vue
+git commit -m "feat(web): add contacts page with add/edit/delete/import dialogs"
+```
+
+---
+
+### Task 13: Show contact names on threads + Contacts nav link
+
+**Files:**
+- Modify: `web/app/stores/threads.ts` (send `contacts: true`)
+- Modify: `web/app/components/MessageThread.vue` (list title + avatar initial)
+- Modify: `web/app/pages/threads/[id]/index.vue` (toolbar title)
+- Modify: `web/app/components/MessageThreadHeader.vue` (Contacts nav item + icon import)
+
+**Interfaces:**
+- Consumes: `EntitiesMessageThread.contact_details?: EntitiesContact` (Task 10), the `/contacts` route (Task 12).
+- Produces: no new exports — UI wiring only.
+
+- [ ] **Step 1: Request contact resolution when loading threads**
+
+In `web/app/stores/threads.ts`, add `contacts: true` to the `loadThreads` request params:
+
+```ts
+    const response = await apiFetch<{ data: EntitiesMessageThread[] }>(
+      '/v1/message-threads',
+      {
+        params: {
+          owner: phonesStore.owner ?? phonesStore.phones[0]?.phone_number,
+          limit: 100,
+          is_archived: archivedThreads.value,
+          contacts: true,
+        },
+      },
+    )
+```
+
+- [ ] **Step 2: Show the contact name in the threads list**
+
+In `web/app/components/MessageThread.vue`, replace the list-item title expression:
+
+```vue
+        <v-list-item-title :class="{ 'font-weight-bold': !thread.is_read }">{{
+          thread.contact_details?.name ?? formatPhoneNumber(thread.contact)
+        }}</v-list-item-title>
+```
+
+And update the avatar initial to prefer the contact name (replace the existing `<template #prepend>` avatar content):
+
+```vue
+        <template #prepend>
+          <v-avatar
+            :color="thread.color"
+            size="40"
+            :badge="thread.is_read ? false : { color: 'primary', dotSize: 12 }"
+          >
+            <v-icon
+              v-if="!(thread.contact_details?.name || startsWithLetter(thread.contact))"
+              color="white"
+              >{{ mdiAccount }}</v-icon
+            >
+            <span v-else class="text-white text-headline-small">{{
+              (thread.contact_details?.name ?? thread.contact).substring(0, 1)
+            }}</span>
+          </v-avatar>
+        </template>
+```
+
+- [ ] **Step 3: Show the contact name in the thread header**
+
+In `web/app/pages/threads/[id]/index.vue`, replace the toolbar title expression (around line 271):
+
+```vue
+        <VToolbarTitle v-if="threadsStore.currentThread">
+          {{
+            threadsStore.currentThread.contact_details?.name ??
+            formatPhoneNumber(threadsStore.currentThread.contact)
+          }}
+        </VToolbarTitle>
+```
+
+- [ ] **Step 4: Add the Contacts navigation item**
+
+In `web/app/components/MessageThreadHeader.vue`, add `mdiAccountMultiple` to the `@mdi/js` import block:
+
+```ts
+  mdiCommentTextMultipleOutline,
+  mdiAccountMultiple,
+  mdiCircle,
+```
+
+Add a nav item right after the "Search Messages" `v-list-item` (before the Settings item):
+
+```vue
+        <v-list-item :to="{ name: 'contacts' }">
+          <template #prepend><v-icon :icon="mdiAccountMultiple" /></template>
+          <v-list-item-title>Contacts</v-list-item-title>
+        </v-list-item>
+```
+
+- [ ] **Step 5: Lint and build**
+
+Run: `cd web && pnpm lint:js && pnpm generate`
+Expected: no errors; the build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/app/stores/threads.ts web/app/components/MessageThread.vue web/app/pages/threads/[id]/index.vue web/app/components/MessageThreadHeader.vue
+git commit -m "feat(web): display contact names on threads and add Contacts nav link"
+```
+
+---
+
+## Final Verification
+
+- [ ] **API full test + build**
+
+```bash
+cd api && go test -vet=off ./... && go build ./...
+```
+Expected: all packages pass; build succeeds.
+
+- [ ] **Web lint + build**
+
+```bash
+cd web && pnpm lint && pnpm generate
+```
+Expected: lint clean; static build succeeds.
+
+- [ ] **Manual smoke test (optional, with Docker stack)**
+
+```bash
+docker compose up --build
+```
+Then: create a contact via `POST /v1/contacts`, load `/threads` and confirm the contact name shows for a matching phone number; open `/contacts` and exercise add/edit/delete/import.

--- a/docs/superpowers/specs/2026-08-21-contact-phone-input-design.md
+++ b/docs/superpowers/specs/2026-08-21-contact-phone-input-design.md
@@ -1,0 +1,29 @@
+# Contact Phone Input Design
+
+## Goal
+
+Use the existing `v-phone-input` component for phone numbers in the contact
+add/edit dialog.
+
+## Design
+
+Represent each form phone row with a phone number value and its own country.
+Bind those fields to `v-phone-input` using `v-model` and `v-model:country`,
+following the messages page configuration.
+
+Existing E.164 phone numbers derive their country with `libphonenumber-js`.
+Numbers without a detectable country and newly added rows default to `US`.
+Removing a row removes both its number and country because they are stored in
+one object.
+
+## Behavior
+
+- Keep support for multiple phone numbers.
+- Preserve current required-phone validation and server error display.
+- Submit only trimmed, non-empty phone number values to the API.
+- Keep add, edit, and remove behavior unchanged apart from the country-aware
+  input.
+
+## Validation
+
+Run ESLint, Stylelint, and Prettier against the changed contact page.

--- a/docs/superpowers/specs/2026-08-21-contacts-table-header-design.md
+++ b/docs/superpowers/specs/2026-08-21-contacts-table-header-design.md
@@ -1,0 +1,29 @@
+# Contacts Table Header Styling Design
+
+## Goal
+
+Make every header in the contacts data table uppercase and grey using Vuetify's
+standard text utility classes.
+
+## Design
+
+Add the `headers` slot to the existing `VDataTableServer` in
+`web/app/pages/contacts/index.vue`. Render each header title with
+`text-uppercase text-medium-emphasis` while retaining Vuetify's existing header
+layout and per-column alignment.
+
+This approach keeps presentation in the template, avoids brittle selectors
+against Vuetify internals, and leaves the header definitions and table data flow
+unchanged.
+
+## Scope
+
+- Apply the styling to Name, Phone Numbers, Emails, Created, Updated, and
+  Actions.
+- Preserve the existing data, pagination, loading, and item slot behavior.
+- Do not introduce component-level CSS or change the displayed header labels.
+
+## Validation
+
+Run the existing web lint command and confirm the contacts page template passes
+Vue and TypeScript validation.

--- a/tests/.env.test
+++ b/tests/.env.test
@@ -30,4 +30,5 @@ GCS_BUCKET_NAME=
 UPTRACE_DSN=
 CLOUDFLARE_TURNSTILE_SECRET_KEY=
 HEARTBEAT_DB_BACKEND=mongodb
+CONTACT_DB_BACKEND=mongodb
 MONGODB_URI=mongodb://httpsms:testpassword@mongodb:27017/?authSource=admin&appName=httpsms

--- a/tests/README.md
+++ b/tests/README.md
@@ -55,6 +55,7 @@ The API's Firebase SDK is configured (via `FCM_ENDPOINT` env var) to redirect al
 - [x] **Receive SMS E2E** — Phone submits received message to API → message is stored and retrievable via GET endpoint
 - [x] **Message thread read receipts E2E** — Incoming SMS and missed calls mark a thread unread, the existing thread update endpoint marks it read, and outbound activity preserves unread state
 - [x] **Unarchive Thread on Receive E2E** — Archived thread returns to the inbox on inbound message when the phone's `unarchive_thread` setting is enabled, and stays archived when disabled
+- [x] **Contacts E2E** — JSON CRUD, search and pagination totals, CSV import normalization, and contact details attached to message threads
 
 ## Prerequisites
 

--- a/tests/contacts_integration_test.go
+++ b/tests/contacts_integration_test.go
@@ -1,0 +1,332 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type integrationContact struct {
+	ID           string            `json:"id"`
+	Name         string            `json:"name"`
+	Emails       []string          `json:"emails"`
+	PhoneNumbers []string          `json:"phone_numbers"`
+	Properties   map[string]string `json:"properties"`
+}
+
+type integrationContactsResponse struct {
+	Data  []integrationContact `json:"data"`
+	Total int64                `json:"total"`
+}
+
+type integrationContactResponse struct {
+	Data integrationContact `json:"data"`
+}
+
+type integrationContactThread struct {
+	ID             string              `json:"id"`
+	Contact        string              `json:"contact"`
+	ContactDetails *integrationContact `json:"contact_details"`
+}
+
+func createIntegrationContacts(
+	ctx context.Context,
+	t *testing.T,
+	contacts []map[string]any,
+) []integrationContact {
+	t.Helper()
+
+	var response integrationContactsResponse
+	requestJSON(
+		ctx,
+		t,
+		http.MethodPost,
+		"/v1/contacts",
+		userAPIKey,
+		contacts,
+		http.StatusCreated,
+		&response,
+	)
+	require.Len(t, response.Data, len(contacts))
+	return response.Data
+}
+
+func deleteIntegrationContact(ctx context.Context, t *testing.T, contactID string) {
+	t.Helper()
+
+	requestJSON(
+		ctx,
+		t,
+		http.MethodDelete,
+		"/v1/contacts/"+contactID,
+		userAPIKey,
+		nil,
+		http.StatusNoContent,
+		nil,
+	)
+}
+
+func cleanupIntegrationContact(t *testing.T, contactID string) {
+	t.Helper()
+
+	request, err := http.NewRequest(
+		http.MethodDelete,
+		apiBaseURL+"/v1/contacts/"+contactID,
+		nil,
+	)
+	require.NoError(t, err)
+	request.Header.Set("x-api-key", userAPIKey)
+
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.Contains(
+		t,
+		[]int{http.StatusNoContent, http.StatusNotFound},
+		response.StatusCode,
+		"response: %s",
+		string(responseBody),
+	)
+}
+
+func listIntegrationContacts(
+	ctx context.Context,
+	t *testing.T,
+	query string,
+	skip int,
+	limit int,
+) integrationContactsResponse {
+	t.Helper()
+
+	path := fmt.Sprintf(
+		"/v1/contacts?query=%s&skip=%d&limit=%d",
+		url.QueryEscape(query),
+		skip,
+		limit,
+	)
+	var response integrationContactsResponse
+	requestJSON(ctx, t, http.MethodGet, path, userAPIKey, nil, http.StatusOK, &response)
+	return response
+}
+
+func uploadIntegrationContactsCSV(
+	ctx context.Context,
+	t *testing.T,
+	contents string,
+) integrationContactsResponse {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("document", "contacts.csv")
+	require.NoError(t, err)
+	_, err = part.Write([]byte(contents))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		apiBaseURL+"/v1/contacts/upload",
+		&body,
+	)
+	require.NoError(t, err)
+	request.Header.Set("x-api-key", userAPIKey)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, response.StatusCode, "response: %s", string(responseBody))
+
+	var result integrationContactsResponse
+	require.NoError(t, json.Unmarshal(responseBody, &result))
+	return result
+}
+
+func waitForThreadWithContact(
+	ctx context.Context,
+	t *testing.T,
+	owner string,
+	phoneNumber string,
+	timeout time.Duration,
+) integrationContactThread {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		path := fmt.Sprintf(
+			"/v1/message-threads?owner=%s&contacts=true&skip=0&limit=20",
+			url.QueryEscape(owner),
+		)
+		var response struct {
+			Data []integrationContactThread `json:"data"`
+		}
+		requestJSON(ctx, t, http.MethodGet, path, userAPIKey, nil, http.StatusOK, &response)
+		for _, thread := range response.Data {
+			if thread.Contact == phoneNumber && thread.ContactDetails != nil {
+				return thread
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	t.Fatalf("thread for %s did not include contact details within %v", phoneNumber, timeout)
+	return integrationContactThread{}
+}
+
+func TestContacts_CRUDSearchAndPagination(t *testing.T) {
+	ctx := context.Background()
+	marker := strings.ToLower(uuid.New().String())
+	firstPhone := randomPhoneNumber()
+	secondPhone := randomPhoneNumber()
+
+	created := createIntegrationContacts(ctx, t, []map[string]any{
+		{
+			"name":          "  Alice " + marker + "  ",
+			"emails":        []string{" ALICE-" + marker + "@EXAMPLE.COM "},
+			"phone_numbers": []string{strings.TrimPrefix(firstPhone, "+")},
+			"properties":    map[string]string{"company": "Acme"},
+		},
+		{
+			"name":          "Bob " + marker,
+			"emails":        []string{"bob-" + marker + "@example.com"},
+			"phone_numbers": []string{secondPhone},
+		},
+	})
+	for _, contact := range created {
+		contactID := contact.ID
+		t.Cleanup(func() {
+			cleanupIntegrationContact(t, contactID)
+		})
+	}
+
+	require.Len(t, created, 2)
+	assert.Equal(t, "Alice "+marker, created[0].Name)
+	assert.Equal(t, []string{"alice-" + marker + "@example.com"}, created[0].Emails)
+	assert.Equal(t, []string{firstPhone}, created[0].PhoneNumbers)
+	assert.Equal(t, map[string]string{"company": "Acme"}, created[0].Properties)
+
+	page := listIntegrationContacts(ctx, t, marker, 0, 1)
+	assert.EqualValues(t, 2, page.Total)
+	require.Len(t, page.Data, 1)
+
+	emailMatch := listIntegrationContacts(ctx, t, "ALICE-"+marker+"@EXAMPLE.COM", 0, 20)
+	assert.EqualValues(t, 1, emailMatch.Total)
+	require.Len(t, emailMatch.Data, 1)
+	assert.Equal(t, created[0].ID, emailMatch.Data[0].ID)
+
+	var updated integrationContactResponse
+	requestJSON(
+		ctx,
+		t,
+		http.MethodPut,
+		"/v1/contacts/"+created[0].ID,
+		userAPIKey,
+		map[string]any{
+			"name":          "Updated " + marker,
+			"emails":        []string{"updated-" + marker + "@example.com"},
+			"phone_numbers": []string{firstPhone},
+			"properties":    map[string]string{"company": "NdoleStudio"},
+		},
+		http.StatusOK,
+		&updated,
+	)
+	assert.Equal(t, "Updated "+marker, updated.Data.Name)
+	assert.Equal(t, []string{"updated-" + marker + "@example.com"}, updated.Data.Emails)
+	assert.Equal(t, map[string]string{"company": "NdoleStudio"}, updated.Data.Properties)
+
+	deleteIntegrationContact(ctx, t, created[0].ID)
+
+	deletedMatch := listIntegrationContacts(ctx, t, "updated-"+marker+"@example.com", 0, 20)
+	assert.Zero(t, deletedMatch.Total)
+	assert.Empty(t, deletedMatch.Data)
+}
+
+func TestContacts_CSVUpload(t *testing.T) {
+	ctx := context.Background()
+	marker := strings.ToLower(uuid.New().String())
+	phoneNumber := randomPhoneNumber()
+	csv := fmt.Sprintf(
+		"Name,Emails,PhoneNumbers\nCSV %s,\"FIRST-%s@EXAMPLE.COM;second-%s@example.com\",%s\n",
+		marker,
+		marker,
+		marker,
+		strings.TrimPrefix(phoneNumber, "+"),
+	)
+
+	response := uploadIntegrationContactsCSV(ctx, t, csv)
+	require.Len(t, response.Data, 1)
+	contact := response.Data[0]
+	t.Cleanup(func() {
+		cleanupIntegrationContact(t, contact.ID)
+	})
+
+	assert.Equal(t, "CSV "+marker, contact.Name)
+	assert.Equal(t, []string{
+		"first-" + marker + "@example.com",
+		"second-" + marker + "@example.com",
+	}, contact.Emails)
+	assert.Equal(t, []string{phoneNumber}, contact.PhoneNumbers)
+
+	listed := listIntegrationContacts(ctx, t, marker, 0, 20)
+	assert.EqualValues(t, 1, listed.Total)
+	require.Len(t, listed.Data, 1)
+	assert.Equal(t, contact.ID, listed.Data[0].ID)
+}
+
+func TestContacts_MessageThreadsIncludeContactDetails(t *testing.T) {
+	ctx := context.Background()
+	phone := setupPhone(ctx, t, 60)
+	contactPhone := randomPhoneNumber()
+	marker := strings.ToLower(uuid.New().String())
+
+	created := createIntegrationContacts(ctx, t, []map[string]any{
+		{
+			"name":          "Thread Contact " + marker,
+			"emails":        []string{"thread-" + marker + "@example.com"},
+			"phone_numbers": []string{contactPhone},
+			"properties":    map[string]string{"source": "integration-test"},
+		},
+	})
+	contact := created[0]
+	t.Cleanup(func() {
+		cleanupIntegrationContact(t, contact.ID)
+	})
+
+	messageID := receiveInbound(
+		ctx,
+		t,
+		phone.PhoneAPIKey,
+		contactPhone,
+		phone.PhoneNumber,
+		"Contact enrichment "+marker,
+		time.Now(),
+	)
+	pollMessageStatus(ctx, t, messageID, "received", 15*time.Second)
+
+	thread := waitForThreadWithContact(ctx, t, phone.PhoneNumber, contactPhone, 20*time.Second)
+	require.NotNil(t, thread.ContactDetails)
+	assert.Equal(t, contact.ID, thread.ContactDetails.ID)
+	assert.Equal(t, contact.Name, thread.ContactDetails.Name)
+	assert.Equal(t, contact.PhoneNumbers, thread.ContactDetails.PhoneNumbers)
+	assert.Equal(t, contact.Properties, thread.ContactDetails.Properties)
+}

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -110,11 +110,62 @@ func setupPhone(ctx context.Context, t *testing.T, messagesPerMinute uint) testP
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.HTTPResponse.StatusCode, "fcm token bind failed")
 
+	waitForPhoneAuthorization(ctx, t, phoneAPIKeyValue, phoneNumber, 20*time.Second)
+
 	return testPhone{
 		PhoneNumber: phoneNumber,
 		PhoneAPIKey: phoneAPIKeyValue,
 		FcmToken:    fcmToken,
 	}
+}
+
+func waitForPhoneAuthorization(
+	ctx context.Context,
+	t *testing.T,
+	phoneAPIKey string,
+	phoneNumber string,
+	timeout time.Duration,
+) {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]interface{}{
+		"phone_numbers": []string{phoneNumber},
+		"charging":      true,
+	})
+	require.NoError(t, err)
+
+	var responseBody []byte
+	var statusCode int
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		request, requestErr := http.NewRequestWithContext(
+			ctx,
+			http.MethodPost,
+			apiBaseURL+"/v1/heartbeats",
+			bytes.NewReader(body),
+		)
+		require.NoError(t, requestErr)
+		request.Header.Set("Content-Type", "application/json")
+		request.Header.Set("x-api-key", phoneAPIKey)
+
+		response, requestErr := http.DefaultClient.Do(request)
+		require.NoError(t, requestErr)
+		responseBody, requestErr = io.ReadAll(response.Body)
+		response.Body.Close()
+		require.NoError(t, requestErr)
+
+		statusCode = response.StatusCode
+		if statusCode == http.StatusCreated {
+			return
+		}
+		if statusCode != http.StatusUnauthorized {
+			require.Equal(t, http.StatusCreated, statusCode, "phone authorization check failed: %s", string(responseBody))
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	require.Equal(t, http.StatusCreated, statusCode, "phone authorization was not ready within %v: %s", timeout, string(responseBody))
 }
 
 func setupWebhook(ctx context.Context, t *testing.T, phoneNumber string, events []string) (signingKey string, webhookPath string) {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -56,7 +56,7 @@ func TestSendSMS_Encrypted(t *testing.T) {
 	assert.NotEqual(t, plaintext, outstanding["content"])
 
 	fireEvent(ctx, t, phone.PhoneAPIKey, messageID, "SENT")
-	time.Sleep(200 * time.Millisecond)
+	pollMessageStatus(ctx, t, messageID, "sent", 15*time.Second)
 	fireEvent(ctx, t, phone.PhoneAPIKey, messageID, "DELIVERED")
 
 	msg := pollMessageStatus(ctx, t, messageID, "delivered", 30*time.Second)
@@ -200,8 +200,10 @@ func TestSendSMS_RateLimit(t *testing.T) {
 	assert.GreaterOrEqual(t, gapMs, int64(5500), "rate limit gap should be >= 5500ms (6s minus timing tolerance), got %dms", gapMs)
 
 	fireEvent(ctx, t, phone.PhoneAPIKey, msgID1, "SENT")
-	fireEvent(ctx, t, phone.PhoneAPIKey, msgID1, "DELIVERED")
+	pollMessageStatus(ctx, t, msgID1, "sent", 15*time.Second)
 	fireEvent(ctx, t, phone.PhoneAPIKey, msgID2, "SENT")
+	pollMessageStatus(ctx, t, msgID2, "sent", 15*time.Second)
+	fireEvent(ctx, t, phone.PhoneAPIKey, msgID1, "DELIVERED")
 	fireEvent(ctx, t, phone.PhoneAPIKey, msgID2, "DELIVERED")
 
 	msg1 := pollMessageStatus(ctx, t, msgID1, "delivered", 15*time.Second)
@@ -335,7 +337,7 @@ func TestSendSMS_OutstandingFlow(t *testing.T) {
 	assert.Equal(t, contactNumber, outstanding["contact"])
 
 	fireEvent(ctx, t, phone.PhoneAPIKey, messageID, "SENT")
-	time.Sleep(200 * time.Millisecond)
+	pollMessageStatus(ctx, t, messageID, "sent", 15*time.Second)
 	fireEvent(ctx, t, phone.PhoneAPIKey, messageID, "DELIVERED")
 
 	msg := pollMessageStatus(ctx, t, messageID, "delivered", 30*time.Second)
@@ -538,7 +540,7 @@ func TestBulkSMS_Excel(t *testing.T) {
 
 	// Fire SENT then DELIVERED on message 1, leave message 2 pending
 	fireEvent(ctx, t, phone.PhoneAPIKey, msgID1, "SENT")
-	time.Sleep(200 * time.Millisecond)
+	pollMessageStatus(ctx, t, msgID1, "sent", 15*time.Second)
 	fireEvent(ctx, t, phone.PhoneAPIKey, msgID1, "DELIVERED")
 
 	// Poll until message 1 reaches "delivered"

--- a/web/app/components/ContactDialog.vue
+++ b/web/app/components/ContactDialog.vue
@@ -1,0 +1,411 @@
+<script setup lang="ts">
+import {
+  mdiAccount,
+  mdiAlertCircleOutline,
+  mdiClose,
+  mdiContentSaveCheck,
+  mdiEmailOutline,
+  mdiPlus,
+} from '@mdi/js'
+import { parsePhoneNumberFromString } from 'libphonenumber-js'
+import type { EntitiesContact } from '~~/shared/types/api'
+import { useContactsStore, type ContactInput } from '~/stores/contacts'
+import { toApiError } from '~/utils/api-error'
+import { ErrorMessages } from '~/utils/errors'
+
+interface PropertyRow {
+  key: string
+  value: string
+}
+
+interface PhoneNumberRow {
+  value: string
+  country: string
+}
+
+interface ContactForm {
+  name: string
+  phoneNumbers: PhoneNumberRow[]
+  emails: string[]
+  properties: PropertyRow[]
+}
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean
+    contact?: EntitiesContact | null
+    initialPhoneNumber?: string
+    refreshContacts?: boolean
+  }>(),
+  {
+    contact: null,
+    initialPhoneNumber: '',
+    refreshContacts: true,
+  },
+)
+
+const emit = defineEmits<{
+  saved: []
+  'update:modelValue': [value: boolean]
+}>()
+
+const contactsStore = useContactsStore()
+const saving = ref(false)
+const form = ref<ContactForm>(emptyForm())
+const formErrors = ref(new ErrorMessages())
+
+const dialogTitle = computed(() =>
+  props.contact ? 'Edit Contact' : 'Add Contact',
+)
+
+function phoneNumberRow(value = ''): PhoneNumberRow {
+  return {
+    value,
+    country: parsePhoneNumberFromString(value)?.country ?? 'US',
+  }
+}
+
+function emptyForm(): ContactForm {
+  return {
+    name: '',
+    phoneNumbers: [phoneNumberRow(props?.initialPhoneNumber)],
+    emails: [''],
+    properties: [{ key: '', value: '' }],
+  }
+}
+
+function resetForm() {
+  const contact = props.contact
+  if (!contact) {
+    form.value = emptyForm()
+  } else {
+    const propertyEntries = Object.entries(contact.properties ?? {}).map(
+      ([key, value]) => ({ key, value }),
+    )
+    form.value = {
+      name: contact.name ?? '',
+      phoneNumbers: contact.phone_numbers?.length
+        ? contact.phone_numbers.map((value) => phoneNumberRow(value))
+        : [phoneNumberRow()],
+      emails: contact.emails?.length ? [...contact.emails] : [''],
+      properties: propertyEntries.length
+        ? propertyEntries
+        : [{ key: '', value: '' }],
+    }
+  }
+  formErrors.value = new ErrorMessages()
+}
+
+function closeDialog() {
+  emit('update:modelValue', false)
+}
+
+function addPhoneNumber() {
+  form.value.phoneNumbers.push(phoneNumberRow())
+}
+
+function removePhoneNumber(index: number) {
+  form.value.phoneNumbers.splice(index, 1)
+  if (form.value.phoneNumbers.length === 0) {
+    form.value.phoneNumbers.push(phoneNumberRow())
+  }
+}
+
+function addEmail() {
+  form.value.emails.push('')
+}
+
+function removeEmail(index: number) {
+  form.value.emails.splice(index, 1)
+  if (form.value.emails.length === 0) {
+    form.value.emails.push('')
+  }
+}
+
+function addProperty() {
+  form.value.properties.push({ key: '', value: '' })
+}
+
+function removeProperty(index: number) {
+  form.value.properties.splice(index, 1)
+  if (form.value.properties.length === 0) {
+    form.value.properties.push({ key: '', value: '' })
+  }
+}
+
+function buildPayload(): ContactInput {
+  const properties: Record<string, string> = {}
+  form.value.properties.forEach((row) => {
+    const key = row.key.trim()
+    if (key) {
+      properties[key] = row.value
+    }
+  })
+  return {
+    name: form.value.name.trim(),
+    phone_numbers: form.value.phoneNumbers
+      .map(({ value }) => value.trim())
+      .filter((value) => value.length > 0),
+    emails: form.value.emails
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0),
+    properties,
+  }
+}
+
+function validateForm(): boolean {
+  const bag = new ErrorMessages()
+  if (form.value.name.trim() === '') {
+    bag.add('name', 'The name is required.')
+  }
+  const hasPhone = form.value.phoneNumbers.some(
+    ({ value }) => value.trim().length > 0,
+  )
+  if (!hasPhone) {
+    bag.add('phone_numbers', 'At least one phone number is required.')
+  }
+  formErrors.value = bag
+  return bag.size() === 0
+}
+
+function fieldErrorsFromApi(error: unknown): string[] {
+  const data = toApiError(error).data?.data
+  if (!data || typeof data !== 'object') {
+    return []
+  }
+  return Object.values(data).flat()
+}
+
+async function submitForm() {
+  if (!validateForm()) {
+    return
+  }
+  const payload = buildPayload()
+  saving.value = true
+  try {
+    if (props.contact) {
+      await contactsStore.updateContact(props.contact.id, payload, {
+        refresh: props.refreshContacts,
+      })
+    } else {
+      await contactsStore.saveContacts([payload], {
+        refresh: props.refreshContacts,
+      })
+    }
+    closeDialog()
+    emit('saved')
+  } catch (error: unknown) {
+    const bag = new ErrorMessages()
+    const messages = fieldErrorsFromApi(error)
+    if (messages.length > 0) {
+      bag.addMany('contacts', messages)
+    }
+    formErrors.value = bag
+  } finally {
+    saving.value = false
+  }
+}
+
+watch(
+  () => props.modelValue,
+  (isOpen) => {
+    if (isOpen) {
+      resetForm()
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <VDialog
+    :model-value="modelValue"
+    max-width="640"
+    opacity="0.9"
+    @update:model-value="emit('update:modelValue', $event)"
+  >
+    <VCard>
+      <VCardTitle class="d-flex align-center">
+        <span>{{ dialogTitle }}</span>
+        <VSpacer />
+        <VBtn
+          :icon="mdiClose"
+          variant="text"
+          color="warning"
+          size="small"
+          aria-label="Close dialog"
+          @click="closeDialog"
+        />
+      </VCardTitle>
+      <VCardText>
+        <VAlert
+          v-if="formErrors.get('contacts').length"
+          type="error"
+          variant="tonal"
+          density="comfortable"
+          class="mb-4"
+          :icon="mdiAlertCircleOutline"
+        >
+          <ul class="pl-4 mb-0">
+            <li v-for="message in formErrors.get('contacts')" :key="message">
+              {{ message }}
+            </li>
+          </ul>
+        </VAlert>
+
+        <VTextField
+          v-model="form.name"
+          label="Name"
+          variant="outlined"
+          density="comfortable"
+          persistent-placeholder
+          placeholder="e.g John Doe"
+          :prepend-inner-icon="mdiAccount"
+          :error="formErrors.has('name')"
+          :error-messages="formErrors.get('name')"
+          class="mb-2"
+        />
+
+        <div class="d-flex align-center mt-2 mb-1">
+          <span class="text-subtitle-2">Phone Numbers</span>
+          <VSpacer />
+          <VBtn
+            variant="text"
+            color="primary"
+            size="small"
+            :prepend-icon="mdiPlus"
+            @click="addPhoneNumber"
+          >
+            Add
+          </VBtn>
+        </div>
+        <div
+          v-for="(phone, index) in form.phoneNumbers"
+          :key="`phone-${index}`"
+          class="d-flex align-start ga-2"
+        >
+          <div class="mt-2" style="flex: 0 0 92%">
+            <v-phone-input
+              v-model="phone.value"
+              v-model:country="phone.country"
+              :label="`Phone number ${index + 1}`"
+              country-label="Country"
+              placeholder="Phone number e.g 18005550199"
+              variant="outlined"
+              density="comfortable"
+              color="primary"
+              persistent-placeholder
+              :error="index === 0 && formErrors.has('phone_numbers')"
+              :error-messages="
+                index === 0 ? formErrors.get('phone_numbers') : []
+              "
+            />
+          </div>
+          <div style="flex: 0 0 8%">
+            <VBtn
+              :icon="mdiClose"
+              variant="text"
+              size="small"
+              class="mt-1"
+              aria-label="Remove phone number"
+              @click="removePhoneNumber(index)"
+            />
+          </div>
+        </div>
+
+        <div class="d-flex align-center mt-2 mb-1">
+          <span class="text-subtitle-2">Email Addresses</span>
+          <VSpacer />
+          <VBtn
+            variant="text"
+            color="primary"
+            size="small"
+            :prepend-icon="mdiPlus"
+            @click="addEmail"
+          >
+            Add
+          </VBtn>
+        </div>
+        <div
+          v-for="(email, index) in form.emails"
+          :key="`email-${email}-${index}`"
+          class="d-flex align-start ga-2"
+        >
+          <VTextField
+            v-model="form.emails[index]"
+            :label="`Email ${index + 1}`"
+            placeholder="e.g alice@example.com"
+            variant="outlined"
+            autocomplete="email"
+            type="email"
+            persistent-placeholder
+            density="comfortable"
+            :prepend-inner-icon="mdiEmailOutline"
+          />
+          <VBtn
+            :icon="mdiClose"
+            variant="text"
+            size="small"
+            class="mt-1"
+            aria-label="Remove email"
+            @click="removeEmail(index)"
+          />
+        </div>
+
+        <div class="d-flex align-center mt-2 mb-1">
+          <span class="text-subtitle-2">Properties</span>
+          <VSpacer />
+          <VBtn
+            variant="text"
+            color="primary"
+            size="small"
+            :prepend-icon="mdiPlus"
+            @click="addProperty"
+          >
+            Add
+          </VBtn>
+        </div>
+        <div
+          v-for="(property, index) in form.properties"
+          :key="`property-${index}`"
+          class="d-flex align-start ga-2"
+        >
+          <VTextField
+            v-model="property.key"
+            label="Key"
+            variant="outlined"
+            density="comfortable"
+          />
+          <VTextField
+            v-model="property.value"
+            label="Value"
+            variant="outlined"
+            density="comfortable"
+          />
+          <VBtn
+            :icon="mdiClose"
+            variant="text"
+            size="small"
+            class="mt-1"
+            aria-label="Remove property"
+            @click="removeProperty(index)"
+          />
+        </div>
+      </VCardText>
+      <VCardActions class="pb-4">
+        <VBtn
+          color="primary"
+          variant="flat"
+          :loading="saving"
+          :disabled="saving"
+          :prepend-icon="mdiContentSaveCheck"
+          @click="submitForm"
+        >
+          Save Contact
+        </VBtn>
+        <VSpacer />
+        <VBtn color="warning" variant="text" @click="closeDialog">Close</VBtn>
+      </VCardActions>
+    </VCard>
+  </VDialog>
+</template>

--- a/web/app/components/MessageThread.vue
+++ b/web/app/components/MessageThread.vue
@@ -7,12 +7,13 @@ import {
   mdiAlert,
   mdiAccount,
 } from '@mdi/js'
-import { formatPhoneNumber, startsWithLetter } from '~/utils/filters'
+import type { EntitiesMessageThread } from '~~/shared/types/api'
 
 const threadsStore = useThreadsStore()
 const phonesStore = usePhonesStore()
 const appStore = useAppStore()
 const notificationsStore = useNotificationsStore()
+const { formatPhoneNumber, startsWithLetter } = useFilters()
 
 function threadDate(date: string): string {
   return new Date(date).toLocaleString(undefined, {
@@ -26,6 +27,21 @@ function onInstallApp() {
     type: 'info',
     message: 'Downloading the httpSMS Android App',
   })
+}
+
+function threadContactName(thread: EntitiesMessageThread): string {
+  return thread.contact_details?.name?.trim() ?? ''
+}
+
+function threadContactTitle(thread: EntitiesMessageThread): string {
+  return threadContactName(thread) || formatPhoneNumber(thread.contact)
+}
+
+function threadAvatarInitial(thread: EntitiesMessageThread): string {
+  const contactName = threadContactName(thread)
+  if (contactName) return contactName.substring(0, 1)
+
+  return startsWithLetter(thread.contact) ? thread.contact.substring(0, 1) : ''
 }
 </script>
 
@@ -104,16 +120,16 @@ function onInstallApp() {
             size="40"
             :badge="thread.is_read ? false : { color: 'primary', dotSize: 12 }"
           >
-            <v-icon v-if="!startsWithLetter(thread.contact)" color="white">{{
+            <v-icon v-if="!threadAvatarInitial(thread)" color="white">{{
               mdiAccount
             }}</v-icon>
             <span v-else class="text-white text-headline-small">{{
-              thread.contact.substring(0, 1)
+              threadAvatarInitial(thread)
             }}</span>
           </v-avatar>
         </template>
         <v-list-item-title :class="{ 'font-weight-bold': !thread.is_read }">{{
-          formatPhoneNumber(thread.contact)
+          threadContactTitle(thread)
         }}</v-list-item-title>
         <v-list-item-subtitle
           class="text-truncate mt-1"

--- a/web/app/components/MessageThreadHeader.vue
+++ b/web/app/components/MessageThreadHeader.vue
@@ -14,9 +14,9 @@ import {
   mdiDotsVertical,
   mdiMagnify,
   mdiCommentTextMultipleOutline,
+  mdiAccountMultiple,
   mdiCircle,
 } from '@mdi/js'
-import { formatPhoneNumber, phoneCountry, humanizeTime } from '~/utils/filters'
 import type { EntitiesPhone } from '~~/shared/types/api'
 
 const router = useRouter()
@@ -28,6 +28,7 @@ const threadsStore = useThreadsStore()
 const appStore = useAppStore()
 const notificationsStore = useNotificationsStore()
 const redirectPreferenceStore = useRedirectPreferenceStore()
+const { formatPhoneNumber, phoneCountry, humanizeTime } = useFilters()
 
 const selectedMenuItem = ref(-1)
 
@@ -179,6 +180,10 @@ async function logout() {
         <v-list-item v-if="phonesStore.owner" :to="{ name: 'search-messages' }">
           <template #prepend><v-icon :icon="mdiMagnify" /></template>
           <v-list-item-title>Search Messages</v-list-item-title>
+        </v-list-item>
+        <v-list-item :to="{ name: 'contacts' }">
+          <template #prepend><v-icon :icon="mdiAccountMultiple" /></template>
+          <v-list-item-title>Contacts</v-list-item-title>
         </v-list-item>
         <v-list-item :to="{ name: 'settings' }">
           <template #prepend><v-icon :icon="mdiAccountCog" /></template>

--- a/web/app/composables/useFilters.ts
+++ b/web/app/composables/useFilters.ts
@@ -7,6 +7,7 @@ import {
   formatBillingPeriod,
   formatBillingPeriodDateOrdinal,
   humanizeTime,
+  startsWithLetter,
 } from '../utils/filters'
 import { capitalize } from '../utils/capitalize'
 
@@ -20,6 +21,7 @@ export function useFilters() {
     formatBillingPeriod,
     formatBillingPeriodDateOrdinal,
     humanizeTime,
+    startsWithLetter,
     capitalize,
   }
 }

--- a/web/app/composables/useFilters.ts
+++ b/web/app/composables/useFilters.ts
@@ -7,6 +7,7 @@ import {
   formatBillingPeriod,
   formatBillingPeriodDateOrdinal,
   humanizeTime,
+  humanizeTimeShort,
   startsWithLetter,
 } from '../utils/filters'
 import { capitalize } from '../utils/capitalize'

--- a/web/app/composables/useFilters.ts
+++ b/web/app/composables/useFilters.ts
@@ -19,6 +19,7 @@ export function useFilters() {
     formatMoney,
     formatDecimal,
     formatBillingPeriod,
+    humanizeTimeShort,
     formatBillingPeriodDateOrdinal,
     humanizeTime,
     startsWithLetter,

--- a/web/app/pages/billing/index.vue
+++ b/web/app/pages/billing/index.vue
@@ -27,7 +27,7 @@ useHead({
 })
 
 const config = useRuntimeConfig()
-const { lgAndUp } = useDisplay()
+const { lgAndUp } = useVDisplay()
 const authStore = useAuthStore()
 const billingStore = useBillingStore()
 const notificationsStore = useNotificationsStore()

--- a/web/app/pages/blog/end-to-end-encryption-to-sms-messages.vue
+++ b/web/app/pages/blog/end-to-end-encryption-to-sms-messages.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
-import { useDisplay } from 'vuetify'
-
 import { mdiLanguageGo, mdiLanguageJavascript } from '@mdi/js'
 import { ref } from 'vue'
 
-const { mdAndUp } = useDisplay()
+const { mdAndUp } = useVDisplay()
 
 const encryptTab = ref('javascript')
 const sendTab = ref('javascript')

--- a/web/app/pages/blog/forward-incoming-sms-from-phone-to-webhook.vue
+++ b/web/app/pages/blog/forward-incoming-sms-from-phone-to-webhook.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { useDisplay } from 'vuetify'
-
-const { mdAndUp } = useDisplay()
+const { mdAndUp } = useVDisplay()
 
 definePageMeta({ layout: 'website' })
 

--- a/web/app/pages/blog/grant-send-and-read-sms-permissions-on-android.vue
+++ b/web/app/pages/blog/grant-send-and-read-sms-permissions-on-android.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { mdiDotsVertical } from '@mdi/js'
-import { useDisplay } from 'vuetify'
 
-const { mdAndUp } = useDisplay()
+const { mdAndUp } = useVDisplay()
 
 definePageMeta({ layout: 'website' })
 

--- a/web/app/pages/blog/how-to-send-sms-messages-from-excel.vue
+++ b/web/app/pages/blog/how-to-send-sms-messages-from-excel.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import { useDisplay } from 'vuetify'
-
 import { mdiCommentTextMultipleOutline } from '@mdi/js'
 
-const { mdAndUp } = useDisplay()
+const { mdAndUp } = useVDisplay()
 
 definePageMeta({ layout: 'website' })
 

--- a/web/app/pages/blog/index.vue
+++ b/web/app/pages/blog/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { mdAndUp, smAndDown } = useDisplay()
+const { mdAndUp, smAndDown } = useVDisplay()
 
 definePageMeta({
   layout: 'website',

--- a/web/app/pages/blog/send-bulk-sms-from-csv-file-with-no-code.vue
+++ b/web/app/pages/blog/send-bulk-sms-from-csv-file-with-no-code.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import { useDisplay } from 'vuetify'
-
 import { mdiCommentTextMultipleOutline } from '@mdi/js'
 
-const { mdAndUp } = useDisplay()
+const { mdAndUp } = useVDisplay()
 
 definePageMeta({ layout: 'website' })
 

--- a/web/app/pages/blog/send-sms-from-android-phone-with-python.vue
+++ b/web/app/pages/blog/send-sms-from-android-phone-with-python.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { useDisplay } from 'vuetify'
-
-const { mdAndUp } = useDisplay()
+const { mdAndUp } = useVDisplay()
 
 definePageMeta({ layout: 'website' })
 

--- a/web/app/pages/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier.vue
+++ b/web/app/pages/blog/send-sms-when-new-row-is-added-to-google-sheets-using-zapier.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { useDisplay } from 'vuetify'
-
-const { mdAndUp } = useDisplay()
+const { mdAndUp } = useVDisplay()
 
 definePageMeta({ layout: 'website' })
 

--- a/web/app/pages/bulk-messages/index.vue
+++ b/web/app/pages/bulk-messages/index.vue
@@ -14,7 +14,7 @@ useHead({
 })
 
 const router = useRouter()
-const { mdAndUp } = useDisplay()
+const { mdAndUp } = useVDisplay()
 const authStore = useAuthStore()
 const notificationsStore = useNotificationsStore()
 const { formatTimestamp } = useFilters()

--- a/web/app/pages/contacts/index.vue
+++ b/web/app/pages/contacts/index.vue
@@ -69,6 +69,13 @@ const deleteDialog = ref(false)
 const importDialog = ref(false)
 const saving = ref(false)
 
+// Server-driven pagination state for VDataTableServer.
+const page = ref(1)
+const itemsPerPage = ref(10)
+// initialLoadComplete gates the table's initial @update:options emit so the
+// first fetch is driven by onMounted rather than firing twice on mount.
+const initialLoadComplete = ref(false)
+
 const editingId = ref<string | null>(null)
 const pendingDelete = ref<EntitiesContact | null>(null)
 
@@ -143,9 +150,10 @@ function openEdit(contact: EntitiesContact) {
   editingId.value = contact.id
   form.value = {
     name: contact.name ?? '',
-    phoneNumbers:
-      contact.phone_numbers.length > 0 ? [...contact.phone_numbers] : [''],
-    emails: contact.emails.length > 0 ? [...contact.emails] : [''],
+    phoneNumbers: contact.phone_numbers?.length
+      ? [...contact.phone_numbers]
+      : [''],
+    emails: contact.emails?.length ? [...contact.emails] : [''],
     properties: Object.entries(contact.properties ?? {}).map(
       ([key, value]) => ({ key, value }),
     ),
@@ -300,6 +308,27 @@ async function submitImport() {
   }
 }
 
+function fetchContacts() {
+  const skip = (page.value - 1) * itemsPerPage.value
+  return contactsStore
+    .loadContacts({ force: true, skip, limit: itemsPerPage.value })
+    .catch(() => {
+      // The store already surfaced the failure via a notification.
+    })
+}
+
+function onUpdateOptions(options: { page: number; itemsPerPage: number }) {
+  page.value = options.page
+  itemsPerPage.value = options.itemsPerPage
+
+  // Ignore the initial emit fired while the table mounts; onMounted owns the
+  // first fetch so the request is not duplicated.
+  if (!initialLoadComplete.value) {
+    return
+  }
+  fetchContacts()
+}
+
 watch(
   () => contactsStore.search,
   () => {
@@ -307,17 +336,22 @@ watch(
       clearTimeout(searchTimer)
     }
     searchTimer = setTimeout(() => {
-      contactsStore.loadContacts(true).catch(() => {
-        // The store already surfaced the failure via a notification.
-      })
+      // A new query always resets to the first page. If we are already on
+      // page 1 the page ref does not change, so no @update:options fires and
+      // we fetch directly; otherwise resetting the page drives the fetch via
+      // onUpdateOptions. Either way exactly one request is made.
+      if (page.value !== 1) {
+        page.value = 1
+      } else {
+        fetchContacts()
+      }
     }, 350)
   },
 )
 
 onMounted(() => {
-  contactsStore.loadContacts(true).catch(() => {
-    // The store already surfaced the failure via a notification.
-  })
+  initialLoadComplete.value = true
+  fetchContacts()
 })
 
 onBeforeUnmount(() => {
@@ -386,15 +420,18 @@ onBeforeUnmount(() => {
           />
 
           <VCard variant="outlined">
-            <VDataTable
+            <VDataTableServer
+              v-model:page="page"
+              v-model:items-per-page="itemsPerPage"
               :headers="headers"
               :items="contactsStore.contacts"
+              :items-length="contactsStore.total"
               :loading="contactsStore.loading"
-              :items-per-page="10"
               :items-per-page-options="itemsPerPageOptions"
               item-value="id"
               hover
               loading-text="Loading contacts…"
+              @update:options="onUpdateOptions"
             >
               <template #[`item.name`]="{ item }">
                 <div class="d-flex align-center py-2">
@@ -416,11 +453,11 @@ onBeforeUnmount(() => {
 
               <template #[`item.phone_numbers`]="{ item }">
                 <div
-                  v-if="item.phone_numbers.length"
+                  v-if="item.phone_numbers?.length"
                   class="d-flex flex-column ga-1 py-2"
                 >
                   <VChip
-                    v-for="phone in item.phone_numbers"
+                    v-for="phone in item.phone_numbers ?? []"
                     :key="phone"
                     size="small"
                     variant="tonal"
@@ -435,11 +472,11 @@ onBeforeUnmount(() => {
 
               <template #[`item.emails`]="{ item }">
                 <div
-                  v-if="item.emails.length"
+                  v-if="item.emails?.length"
                   class="d-flex flex-column ga-1 py-2"
                 >
                   <span
-                    v-for="email in item.emails"
+                    v-for="email in item.emails ?? []"
                     :key="email"
                     class="d-flex align-center text-body-2"
                   >
@@ -518,7 +555,7 @@ onBeforeUnmount(() => {
                   </VBtn>
                 </div>
               </template>
-            </VDataTable>
+            </VDataTableServer>
           </VCard>
         </VCol>
       </VRow>

--- a/web/app/pages/contacts/index.vue
+++ b/web/app/pages/contacts/index.vue
@@ -49,11 +49,11 @@ const { formatPhoneNumber, humanizeTime, formatTimestamp } = useFilters()
 const avatarPalette = ['primary', 'secondary', 'info', 'success']
 
 const headers = [
-  { title: 'Name', key: 'name', sortable: true },
+  { title: 'Name', key: 'name', sortable: false },
   { title: 'Phone Numbers', key: 'phone_numbers', sortable: false },
   { title: 'Emails', key: 'emails', sortable: false },
-  { title: 'Created', key: 'created_at', sortable: true },
-  { title: 'Updated', key: 'updated_at', sortable: true },
+  { title: 'Created', key: 'created_at', sortable: false },
+  { title: 'Updated', key: 'updated_at', sortable: false },
   { title: 'Actions', key: 'actions', sortable: false, align: 'end' as const },
 ]
 
@@ -98,6 +98,8 @@ const searchTerm = computed({
     contactsStore.search = value ?? ''
   },
 })
+
+const trimmedSearchTerm = computed(() => contactsStore.search.trim())
 
 const dialogTitle = computed(() =>
   editingId.value ? 'Edit Contact' : 'Add Contact',
@@ -384,7 +386,12 @@ onBeforeUnmount(() => {
             <div>
               <h1 class="text-display-large mb-1">Contacts</h1>
               <p class="text-medium-emphasis mb-0">
-                Manage your contacts. {{ contactsStore.total }} total
+                Manage your contacts.
+                {{
+                  trimmedSearchTerm
+                    ? `${contactsStore.total} found`
+                    : `${contactsStore.total} total`
+                }}
               </p>
             </div>
             <VSpacer />

--- a/web/app/pages/contacts/index.vue
+++ b/web/app/pages/contacts/index.vue
@@ -1,0 +1,819 @@
+<script setup lang="ts">
+import {
+  mdiAccount,
+  mdiAccountGroupOutline,
+  mdiAccountPlus,
+  mdiAlertCircleOutline,
+  mdiArrowLeft,
+  mdiClose,
+  mdiDelete,
+  mdiEmailOutline,
+  mdiFileUpload,
+  mdiMagnify,
+  mdiPencil,
+  mdiPhone,
+  mdiPlus,
+} from '@mdi/js'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import type { EntitiesContact } from '~~/shared/types/api'
+import { useContactsStore, type ContactInput } from '~/stores/contacts'
+import { useFilters } from '~/composables/useFilters'
+import { ErrorMessages } from '~/utils/errors'
+import { toApiError } from '~/utils/api-error'
+
+definePageMeta({
+  middleware: ['auth'],
+})
+
+useHead({
+  title: 'Contacts - httpSMS',
+})
+
+interface PropertyRow {
+  key: string
+  value: string
+}
+
+interface ContactForm {
+  name: string
+  phoneNumbers: string[]
+  emails: string[]
+  properties: PropertyRow[]
+}
+
+const contactsStore = useContactsStore()
+const { formatPhoneNumber, humanizeTime, formatTimestamp } = useFilters()
+
+// Avatar backgrounds are picked deterministically from the Vuetify theme
+// palette so the table reads like an address book without inventing colors.
+const avatarPalette = ['primary', 'secondary', 'info', 'success']
+
+const headers = [
+  { title: 'Name', key: 'name', sortable: true },
+  { title: 'Phone Numbers', key: 'phone_numbers', sortable: false },
+  { title: 'Emails', key: 'emails', sortable: false },
+  { title: 'Created', key: 'created_at', sortable: true },
+  { title: 'Updated', key: 'updated_at', sortable: true },
+  { title: 'Actions', key: 'actions', sortable: false, align: 'end' as const },
+]
+
+const itemsPerPageOptions = [
+  { value: 10, title: '10' },
+  { value: 25, title: '25' },
+  { value: 50, title: '50' },
+  { value: 100, title: '100' },
+]
+
+const editDialog = ref(false)
+const deleteDialog = ref(false)
+const importDialog = ref(false)
+const saving = ref(false)
+
+const editingId = ref<string | null>(null)
+const pendingDelete = ref<EntitiesContact | null>(null)
+
+const form = ref<ContactForm>({
+  name: '',
+  phoneNumbers: [''],
+  emails: [''],
+  properties: [],
+})
+const formErrors = ref(new ErrorMessages())
+
+const importFile = ref<File | null>(null)
+const importErrors = ref<string[]>([])
+
+let searchTimer: ReturnType<typeof setTimeout> | undefined
+
+const searchTerm = computed({
+  get: () => contactsStore.search,
+  set: (value: string | null) => {
+    contactsStore.search = value ?? ''
+  },
+})
+
+const dialogTitle = computed(() =>
+  editingId.value ? 'Edit Contact' : 'Add Contact',
+)
+
+function emptyForm(): ContactForm {
+  return {
+    name: '',
+    phoneNumbers: [''],
+    emails: [''],
+    properties: [],
+  }
+}
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) {
+    return ''
+  }
+  const first = parts[0] ?? ''
+  const last = parts.length > 1 ? (parts[parts.length - 1] ?? '') : ''
+  return (first.charAt(0) + last.charAt(0)).toUpperCase()
+}
+
+function avatarColor(name: string): string {
+  const key = name.trim()
+  if (!key) {
+    return 'primary'
+  }
+  let hash = 0
+  for (let index = 0; index < key.length; index += 1) {
+    hash = (hash + key.charCodeAt(index)) % avatarPalette.length
+  }
+  return avatarPalette[hash] ?? 'primary'
+}
+
+function relativeTime(value: string): string {
+  const humanized = humanizeTime(value)
+  return humanized ? `${humanized} ago` : 'just now'
+}
+
+function openAdd() {
+  editingId.value = null
+  form.value = emptyForm()
+  formErrors.value = new ErrorMessages()
+  editDialog.value = true
+}
+
+function openEdit(contact: EntitiesContact) {
+  editingId.value = contact.id
+  form.value = {
+    name: contact.name ?? '',
+    phoneNumbers:
+      contact.phone_numbers.length > 0 ? [...contact.phone_numbers] : [''],
+    emails: contact.emails.length > 0 ? [...contact.emails] : [''],
+    properties: Object.entries(contact.properties ?? {}).map(
+      ([key, value]) => ({ key, value }),
+    ),
+  }
+  formErrors.value = new ErrorMessages()
+  editDialog.value = true
+}
+
+function openDelete(contact: EntitiesContact) {
+  pendingDelete.value = contact
+  deleteDialog.value = true
+}
+
+function openImport() {
+  importFile.value = null
+  importErrors.value = []
+  importDialog.value = true
+}
+
+function addPhoneNumber() {
+  form.value.phoneNumbers.push('')
+}
+
+function removePhoneNumber(index: number) {
+  form.value.phoneNumbers.splice(index, 1)
+  if (form.value.phoneNumbers.length === 0) {
+    form.value.phoneNumbers.push('')
+  }
+}
+
+function addEmail() {
+  form.value.emails.push('')
+}
+
+function removeEmail(index: number) {
+  form.value.emails.splice(index, 1)
+  if (form.value.emails.length === 0) {
+    form.value.emails.push('')
+  }
+}
+
+function addProperty() {
+  form.value.properties.push({ key: '', value: '' })
+}
+
+function removeProperty(index: number) {
+  form.value.properties.splice(index, 1)
+}
+
+function buildPayload(): ContactInput {
+  const properties: Record<string, string> = {}
+  form.value.properties.forEach((row) => {
+    const key = row.key.trim()
+    if (key) {
+      properties[key] = row.value
+    }
+  })
+  return {
+    name: form.value.name.trim(),
+    phone_numbers: form.value.phoneNumbers
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0),
+    emails: form.value.emails
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0),
+    properties,
+  }
+}
+
+function validateForm(): boolean {
+  const bag = new ErrorMessages()
+  if (form.value.name.trim() === '') {
+    bag.add('name', 'The name is required.')
+  }
+  const hasPhone = form.value.phoneNumbers.some(
+    (value) => value.trim().length > 0,
+  )
+  if (!hasPhone) {
+    bag.add('phone_numbers', 'At least one phone number is required.')
+  }
+  formErrors.value = bag
+  return bag.size() === 0
+}
+
+function fieldErrorsFromApi(error: unknown): string[] {
+  const data = toApiError(error).data?.data
+  if (!data || typeof data !== 'object') {
+    return []
+  }
+  return Object.values(data).flat()
+}
+
+async function submitForm() {
+  if (!validateForm()) {
+    return
+  }
+  const payload = buildPayload()
+  saving.value = true
+  try {
+    if (editingId.value) {
+      await contactsStore.updateContact(editingId.value, payload)
+    } else {
+      await contactsStore.saveContacts([payload])
+    }
+    editDialog.value = false
+  } catch (error: unknown) {
+    // The store already surfaced a toast; retain the API field messages so the
+    // user can correct them inline instead of only seeing a transient toast.
+    const bag = new ErrorMessages()
+    const messages = fieldErrorsFromApi(error)
+    if (messages.length > 0) {
+      bag.addMany('contacts', messages)
+    }
+    formErrors.value = bag
+  } finally {
+    saving.value = false
+  }
+}
+
+async function confirmDelete() {
+  if (!pendingDelete.value?.id) {
+    return
+  }
+  saving.value = true
+  try {
+    await contactsStore.deleteContact(pendingDelete.value.id)
+    deleteDialog.value = false
+    pendingDelete.value = null
+  } catch {
+    // The store already surfaced the failure via a notification.
+  } finally {
+    saving.value = false
+  }
+}
+
+async function submitImport() {
+  if (!importFile.value) {
+    return
+  }
+  importErrors.value = []
+  saving.value = true
+  try {
+    await contactsStore.uploadCsv(importFile.value)
+    importDialog.value = false
+    importFile.value = null
+  } catch (error: unknown) {
+    // The store already surfaced a toast; keep the row-indexed messages inline
+    // so the user can see exactly which CSV rows failed validation.
+    importErrors.value = fieldErrorsFromApi(error)
+  } finally {
+    saving.value = false
+  }
+}
+
+watch(
+  () => contactsStore.search,
+  () => {
+    if (searchTimer) {
+      clearTimeout(searchTimer)
+    }
+    searchTimer = setTimeout(() => {
+      contactsStore.loadContacts(true).catch(() => {
+        // The store already surfaced the failure via a notification.
+      })
+    }, 350)
+  },
+)
+
+onMounted(() => {
+  contactsStore.loadContacts(true).catch(() => {
+    // The store already surfaced the failure via a notification.
+  })
+})
+
+onBeforeUnmount(() => {
+  if (searchTimer) {
+    clearTimeout(searchTimer)
+  }
+})
+</script>
+
+<template>
+  <VContainer fluid class="px-0 pt-0">
+    <VAppBar>
+      <VBtn icon to="/threads" aria-label="Back to messages">
+        <VIcon :icon="mdiArrowLeft" />
+      </VBtn>
+      <VToolbarTitle>Contacts</VToolbarTitle>
+      <VProgressLinear
+        :active="contactsStore.loading"
+        :indeterminate="contactsStore.loading"
+        color="primary"
+        location="bottom"
+        absolute
+      />
+    </VAppBar>
+
+    <VContainer class="pt-0">
+      <VRow>
+        <VCol cols="12" md="10" offset-md="1" xxl="8" offset-xxl="2">
+          <div class="d-flex flex-column flex-md-row align-md-center mb-6 mt-3">
+            <div>
+              <h1 class="text-display-large mb-1">Contacts</h1>
+              <p class="text-medium-emphasis mb-0">
+                Manage your contacts. {{ contactsStore.total }} total
+              </p>
+            </div>
+            <VSpacer />
+            <div class="d-flex flex-column flex-sm-row ga-3 mt-4 mt-md-0">
+              <VBtn
+                variant="outlined"
+                color="primary"
+                :prepend-icon="mdiFileUpload"
+                @click="openImport"
+              >
+                Import CSV
+              </VBtn>
+              <VBtn
+                color="primary"
+                variant="flat"
+                :prepend-icon="mdiAccountPlus"
+                @click="openAdd"
+              >
+                Add Contact
+              </VBtn>
+            </div>
+          </div>
+
+          <VTextField
+            v-model="searchTerm"
+            :prepend-inner-icon="mdiMagnify"
+            label="Search by name, phone number or email"
+            variant="outlined"
+            density="comfortable"
+            clearable
+            hide-details
+            class="mb-4"
+          />
+
+          <VCard variant="outlined">
+            <VDataTable
+              :headers="headers"
+              :items="contactsStore.contacts"
+              :loading="contactsStore.loading"
+              :items-per-page="10"
+              :items-per-page-options="itemsPerPageOptions"
+              item-value="id"
+              hover
+              loading-text="Loading contacts…"
+            >
+              <template #[`item.name`]="{ item }">
+                <div class="d-flex align-center py-2">
+                  <VAvatar
+                    :color="avatarColor(item.name)"
+                    size="40"
+                    class="mr-3"
+                  >
+                    <span
+                      v-if="initials(item.name)"
+                      class="text-body-1 font-weight-medium"
+                      >{{ initials(item.name) }}</span
+                    >
+                    <VIcon v-else :icon="mdiAccount" />
+                  </VAvatar>
+                  <span class="font-weight-medium">{{ item.name }}</span>
+                </div>
+              </template>
+
+              <template #[`item.phone_numbers`]="{ item }">
+                <div
+                  v-if="item.phone_numbers.length"
+                  class="d-flex flex-column ga-1 py-2"
+                >
+                  <VChip
+                    v-for="phone in item.phone_numbers"
+                    :key="phone"
+                    size="small"
+                    variant="tonal"
+                    color="primary"
+                    :prepend-icon="mdiPhone"
+                  >
+                    {{ formatPhoneNumber(phone) }}
+                  </VChip>
+                </div>
+                <span v-else class="text-medium-emphasis">—</span>
+              </template>
+
+              <template #[`item.emails`]="{ item }">
+                <div
+                  v-if="item.emails.length"
+                  class="d-flex flex-column ga-1 py-2"
+                >
+                  <span
+                    v-for="email in item.emails"
+                    :key="email"
+                    class="d-flex align-center text-body-2"
+                  >
+                    <VIcon
+                      :icon="mdiEmailOutline"
+                      size="x-small"
+                      class="mr-1 text-medium-emphasis"
+                    />
+                    {{ email }}
+                  </span>
+                </div>
+                <span v-else class="text-medium-emphasis">—</span>
+              </template>
+
+              <template #[`item.created_at`]="{ item }">
+                <span :title="formatTimestamp(item.created_at)">{{
+                  relativeTime(item.created_at)
+                }}</span>
+              </template>
+
+              <template #[`item.updated_at`]="{ item }">
+                <span :title="formatTimestamp(item.updated_at)">{{
+                  relativeTime(item.updated_at)
+                }}</span>
+              </template>
+
+              <template #[`item.actions`]="{ item }">
+                <div class="d-flex justify-end">
+                  <VBtn
+                    :icon="mdiPencil"
+                    variant="text"
+                    size="small"
+                    aria-label="Edit contact"
+                    @click="openEdit(item)"
+                  />
+                  <VBtn
+                    :icon="mdiDelete"
+                    variant="text"
+                    size="small"
+                    color="error"
+                    aria-label="Delete contact"
+                    @click="openDelete(item)"
+                  />
+                </div>
+              </template>
+
+              <template #no-data>
+                <div class="text-center py-12">
+                  <VIcon
+                    :icon="mdiAccountGroupOutline"
+                    size="64"
+                    class="text-medium-emphasis mb-3"
+                  />
+                  <p class="text-title-medium mb-1">
+                    {{
+                      searchTerm
+                        ? 'No contacts match your search'
+                        : 'No contacts yet'
+                    }}
+                  </p>
+                  <p class="text-medium-emphasis mb-4">
+                    {{
+                      searchTerm
+                        ? 'Try a different name, phone number or email.'
+                        : 'Add your first contact or import them from a CSV file.'
+                    }}
+                  </p>
+                  <VBtn
+                    v-if="!searchTerm"
+                    color="primary"
+                    variant="flat"
+                    :prepend-icon="mdiAccountPlus"
+                    @click="openAdd"
+                  >
+                    Add Contact
+                  </VBtn>
+                </div>
+              </template>
+            </VDataTable>
+          </VCard>
+        </VCol>
+      </VRow>
+    </VContainer>
+
+    <!-- Add / Edit contact dialog -->
+    <VDialog v-model="editDialog" max-width="640" opacity="0.9">
+      <VCard>
+        <VCardTitle class="d-flex align-center">
+          <span>{{ dialogTitle }}</span>
+          <VSpacer />
+          <VBtn
+            :icon="mdiClose"
+            variant="text"
+            color="warning"
+            size="small"
+            aria-label="Close dialog"
+            @click="editDialog = false"
+          />
+        </VCardTitle>
+        <VCardText>
+          <VAlert
+            v-if="formErrors.get('contacts').length"
+            type="error"
+            variant="tonal"
+            density="comfortable"
+            class="mb-4"
+            :icon="mdiAlertCircleOutline"
+          >
+            <ul class="pl-4 mb-0">
+              <li v-for="message in formErrors.get('contacts')" :key="message">
+                {{ message }}
+              </li>
+            </ul>
+          </VAlert>
+
+          <VTextField
+            v-model="form.name"
+            label="Name"
+            variant="outlined"
+            density="comfortable"
+            :prepend-inner-icon="mdiAccount"
+            :error="formErrors.has('name')"
+            :error-messages="formErrors.get('name')"
+            class="mb-2"
+          />
+
+          <div class="d-flex align-center mt-2 mb-1">
+            <span class="text-subtitle-2">Phone Numbers</span>
+            <VSpacer />
+            <VBtn
+              variant="text"
+              color="primary"
+              size="small"
+              :prepend-icon="mdiPlus"
+              @click="addPhoneNumber"
+            >
+              Add
+            </VBtn>
+          </div>
+          <div
+            v-for="(phone, index) in form.phoneNumbers"
+            :key="`phone-${index}`"
+            class="d-flex align-start ga-2"
+          >
+            <VTextField
+              v-model="form.phoneNumbers[index]"
+              :label="`Phone number ${index + 1}`"
+              placeholder="+18005550199"
+              variant="outlined"
+              density="comfortable"
+              :prepend-inner-icon="mdiPhone"
+              :error="index === 0 && formErrors.has('phone_numbers')"
+              :error-messages="
+                index === 0 ? formErrors.get('phone_numbers') : []
+              "
+            />
+            <VBtn
+              :icon="mdiClose"
+              variant="text"
+              size="small"
+              class="mt-1"
+              aria-label="Remove phone number"
+              @click="removePhoneNumber(index)"
+            />
+          </div>
+
+          <div class="d-flex align-center mt-2 mb-1">
+            <span class="text-subtitle-2">Email Addresses</span>
+            <VSpacer />
+            <VBtn
+              variant="text"
+              color="primary"
+              size="small"
+              :prepend-icon="mdiPlus"
+              @click="addEmail"
+            >
+              Add
+            </VBtn>
+          </div>
+          <div
+            v-for="(email, index) in form.emails"
+            :key="`email-${index}`"
+            class="d-flex align-start ga-2"
+          >
+            <VTextField
+              v-model="form.emails[index]"
+              :label="`Email ${index + 1}`"
+              placeholder="alice@example.com"
+              variant="outlined"
+              density="comfortable"
+              :prepend-inner-icon="mdiEmailOutline"
+            />
+            <VBtn
+              :icon="mdiClose"
+              variant="text"
+              size="small"
+              class="mt-1"
+              aria-label="Remove email"
+              @click="removeEmail(index)"
+            />
+          </div>
+
+          <div class="d-flex align-center mt-2 mb-1">
+            <span class="text-subtitle-2">Properties</span>
+            <VSpacer />
+            <VBtn
+              variant="text"
+              color="primary"
+              size="small"
+              :prepend-icon="mdiPlus"
+              @click="addProperty"
+            >
+              Add
+            </VBtn>
+          </div>
+          <p
+            v-if="!form.properties.length"
+            class="text-medium-emphasis text-body-2 mb-2"
+          >
+            Add custom key/value details such as company or address.
+          </p>
+          <div
+            v-for="(property, index) in form.properties"
+            :key="`property-${index}`"
+            class="d-flex align-start ga-2"
+          >
+            <VTextField
+              v-model="property.key"
+              label="Key"
+              variant="outlined"
+              density="comfortable"
+            />
+            <VTextField
+              v-model="property.value"
+              label="Value"
+              variant="outlined"
+              density="comfortable"
+            />
+            <VBtn
+              :icon="mdiClose"
+              variant="text"
+              size="small"
+              class="mt-1"
+              aria-label="Remove property"
+              @click="removeProperty(index)"
+            />
+          </div>
+        </VCardText>
+        <VCardActions>
+          <VSpacer />
+          <VBtn color="warning" variant="text" @click="editDialog = false">
+            Close
+          </VBtn>
+          <VBtn
+            color="primary"
+            variant="flat"
+            :loading="saving"
+            :disabled="saving"
+            @click="submitForm"
+          >
+            Save
+          </VBtn>
+        </VCardActions>
+      </VCard>
+    </VDialog>
+
+    <!-- Delete contact dialog -->
+    <VDialog v-model="deleteDialog" max-width="480" opacity="0.9">
+      <VCard>
+        <VCardTitle class="d-flex align-center">
+          <span>Delete Contact</span>
+          <VSpacer />
+          <VBtn
+            :icon="mdiClose"
+            variant="text"
+            color="warning"
+            size="small"
+            aria-label="Close dialog"
+            @click="deleteDialog = false"
+          />
+        </VCardTitle>
+        <VCardText>
+          Are you sure you want to delete
+          <strong>{{ pendingDelete?.name }}</strong
+          >? This action cannot be undone.
+        </VCardText>
+        <VCardActions>
+          <VSpacer />
+          <VBtn color="warning" variant="text" @click="deleteDialog = false">
+            Close
+          </VBtn>
+          <VBtn
+            color="error"
+            variant="flat"
+            :prepend-icon="mdiDelete"
+            :loading="saving"
+            :disabled="saving"
+            @click="confirmDelete"
+          >
+            Delete
+          </VBtn>
+        </VCardActions>
+      </VCard>
+    </VDialog>
+
+    <!-- Import CSV dialog -->
+    <VDialog v-model="importDialog" max-width="600" opacity="0.9">
+      <VCard>
+        <VCardTitle class="d-flex align-center">
+          <span>Import Contacts from CSV</span>
+          <VSpacer />
+          <VBtn
+            :icon="mdiClose"
+            variant="text"
+            color="warning"
+            size="small"
+            aria-label="Close dialog"
+            @click="importDialog = false"
+          />
+        </VCardTitle>
+        <VCardText>
+          <p class="mb-4">
+            Download the
+            <a
+              class="text-decoration-none hover:text-decoration-underline"
+              href="/templates/httpsms-contacts.csv"
+              download
+              >CSV template</a
+            >, fill it in and upload it here. Separate multiple emails or phone
+            numbers within a cell using a semicolon (<code>;</code>).
+          </p>
+          <VFileInput
+            v-model="importFile"
+            label="CSV file"
+            color="primary"
+            accept=".csv,text/csv"
+            variant="outlined"
+            density="comfortable"
+            :prepend-icon="mdiFileUpload"
+            hide-details="auto"
+          />
+          <VAlert
+            v-if="importErrors.length"
+            type="error"
+            variant="tonal"
+            density="comfortable"
+            class="mt-4"
+            :icon="mdiAlertCircleOutline"
+          >
+            <p class="font-weight-medium mb-1">We couldn't import your file:</p>
+            <ul class="pl-4 mb-0">
+              <li v-for="message in importErrors" :key="message">
+                {{ message }}
+              </li>
+            </ul>
+          </VAlert>
+        </VCardText>
+        <VCardActions>
+          <VSpacer />
+          <VBtn color="warning" variant="text" @click="importDialog = false">
+            Close
+          </VBtn>
+          <VBtn
+            color="primary"
+            variant="flat"
+            :prepend-icon="mdiFileUpload"
+            :loading="saving"
+            :disabled="saving || !importFile"
+            @click="submitImport"
+          >
+            Import
+          </VBtn>
+        </VCardActions>
+      </VCard>
+    </VDialog>
+  </VContainer>
+</template>

--- a/web/app/pages/contacts/index.vue
+++ b/web/app/pages/contacts/index.vue
@@ -14,6 +14,7 @@ import {
   mdiEmailCheckOutline,
   mdiSquareEditOutline,
   mdiPlus,
+  mdiContentSaveCheck,
 } from '@mdi/js'
 import { parsePhoneNumberFromString } from 'libphonenumber-js'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
@@ -52,11 +53,11 @@ const contactsStore = useContactsStore()
 const { formatPhoneNumber, formatTimestamp, humanizeTimeShort } = useFilters()
 
 const headers = [
-  { title: 'Name', key: 'name', sortable: false },
+  { title: 'Name', key: 'name', sortable: true },
   { title: 'Phone Numbers', key: 'phone_numbers', sortable: false },
   { title: 'Emails', key: 'emails', sortable: false },
   { title: 'Created', key: 'created_at', sortable: false },
-  { title: 'Updated', key: 'updated_at', sortable: false },
+  { title: 'Updated', key: 'updated_at', sortable: true },
   { title: 'Actions', key: 'actions', sortable: false, align: 'end' as const },
 ]
 
@@ -75,6 +76,9 @@ const saving = ref(false)
 // Server-driven pagination state for VDataTableServer.
 const page = ref(1)
 const itemsPerPage = ref(10)
+const sortBy = ref<{ key: string; order: 'asc' | 'desc' }[]>([
+  { key: 'updated_at', order: 'desc' },
+])
 // initialLoadComplete gates the table's initial @update:options emit so the
 // first fetch is driven by onMounted rather than firing twice on mount.
 const initialLoadComplete = ref(false)
@@ -299,16 +303,30 @@ async function submitImport() {
 
 function fetchContacts() {
   const skip = (page.value - 1) * itemsPerPage.value
+  const sort = sortBy.value[0]
   return contactsStore
-    .loadContacts({ force: true, skip, limit: itemsPerPage.value })
+    .loadContacts({
+      force: true,
+      skip,
+      limit: itemsPerPage.value,
+      sortBy: sort?.key === 'name' ? 'name' : 'updated_at',
+      sortDescending: sort ? sort.order === 'desc' : true,
+    })
     .catch(() => {
       // The store already surfaced the failure via a notification.
     })
 }
 
-function onUpdateOptions(options: { page: number; itemsPerPage: number }) {
+function onUpdateOptions(options: {
+  page: number
+  itemsPerPage: number
+  sortBy: { key: string; order: 'asc' | 'desc' }[]
+}) {
   page.value = options.page
   itemsPerPage.value = options.itemsPerPage
+  sortBy.value = options.sortBy.length
+    ? options.sortBy
+    : [{ key: 'updated_at', order: 'desc' }]
 
   // Ignore the initial emit fired while the table mounts; onMounted owns the
   // first fetch so the request is not duplicated.
@@ -413,6 +431,7 @@ onBeforeUnmount(() => {
             variant="outlined"
             density="compact"
             clearable
+            color="primary"
             hide-details
             class="mb-4"
           />
@@ -420,9 +439,10 @@ onBeforeUnmount(() => {
           <VDataTableServer
             v-model:page="page"
             v-model:items-per-page="itemsPerPage"
+            v-model:sort-by="sortBy"
             :headers="headers"
             :header-props="{
-              class: 'text-uppercase text-medium-emphasis bg-black',
+              class: 'text-uppercase text-medium-emphasis',
             }"
             :items="contactsStore.contacts"
             :items-length="contactsStore.total"
@@ -597,6 +617,8 @@ onBeforeUnmount(() => {
             label="Name"
             variant="outlined"
             density="comfortable"
+            persistent-placeholder
+            placeholder="e.g John Doe"
             :prepend-inner-icon="mdiAccount"
             :error="formErrors.has('name')"
             :error-messages="formErrors.get('name')"
@@ -621,29 +643,33 @@ onBeforeUnmount(() => {
             :key="`phone-${index}`"
             class="d-flex align-start ga-2"
           >
-            <v-phone-input
-              v-model="phone.value"
-              v-model:country="phone.country"
-              :label="`Phone number ${index + 1}`"
-              country-label="Country"
-              placeholder="Phone number e.g 18005550199"
-              variant="outlined"
-              density="comfortable"
-              color="primary"
-              persistent-placeholder
-              :error="index === 0 && formErrors.has('phone_numbers')"
-              :error-messages="
-                index === 0 ? formErrors.get('phone_numbers') : []
-              "
-            />
-            <VBtn
-              :icon="mdiClose"
-              variant="text"
-              size="small"
-              class="mt-1"
-              aria-label="Remove phone number"
-              @click="removePhoneNumber(index)"
-            />
+            <div class="mt-2" style="flex: 0 0 92%">
+              <v-phone-input
+                v-model="phone.value"
+                v-model:country="phone.country"
+                :label="`Phone number ${index + 1}`"
+                country-label="Country"
+                placeholder="Phone number e.g 18005550199"
+                variant="outlined"
+                density="comfortable"
+                color="primary"
+                persistent-placeholder
+                :error="index === 0 && formErrors.has('phone_numbers')"
+                :error-messages="
+                  index === 0 ? formErrors.get('phone_numbers') : []
+                "
+              />
+            </div>
+            <div style="flex: 0 0 8%">
+              <VBtn
+                :icon="mdiClose"
+                variant="text"
+                size="small"
+                class="mt-1"
+                aria-label="Remove phone number"
+                @click="removePhoneNumber(index)"
+              />
+            </div>
           </div>
 
           <div class="d-flex align-center mt-2 mb-1">
@@ -661,14 +687,15 @@ onBeforeUnmount(() => {
           </div>
           <div
             v-for="(email, index) in form.emails"
-            :key="`email-${index}`"
+            :key="`email-${email}-${index}`"
             class="d-flex align-start ga-2"
           >
             <VTextField
               v-model="form.emails[index]"
               :label="`Email ${index + 1}`"
-              placeholder="alice@example.com"
+              placeholder="e.g alice@example.com"
               variant="outlined"
+              persistent-placeholder
               density="comfortable"
               :prepend-inner-icon="mdiEmailOutline"
             />
@@ -722,19 +749,20 @@ onBeforeUnmount(() => {
             />
           </div>
         </VCardText>
-        <VCardActions>
-          <VSpacer />
-          <VBtn color="warning" variant="text" @click="editDialog = false">
-            Close
-          </VBtn>
+        <VCardActions class="pb-4">
           <VBtn
             color="primary"
             variant="flat"
             :loading="saving"
             :disabled="saving"
+            :prepend-icon="mdiContentSaveCheck"
             @click="submitForm"
           >
-            Save
+            Save Contact
+          </VBtn>
+          <VSpacer />
+          <VBtn color="warning" variant="text" @click="editDialog = false">
+            Close
           </VBtn>
         </VCardActions>
       </VCard>
@@ -755,16 +783,12 @@ onBeforeUnmount(() => {
             @click="deleteDialog = false"
           />
         </VCardTitle>
-        <VCardText>
+        <VCardText class="mt-n2 text-medium-emphasis">
           Are you sure you want to delete
-          <strong>{{ pendingDelete?.name }}</strong
+          <v-code>{{ pendingDelete?.name }}</v-code
           >? This action cannot be undone.
         </VCardText>
-        <VCardActions>
-          <VSpacer />
-          <VBtn color="warning" variant="text" @click="deleteDialog = false">
-            Close
-          </VBtn>
+        <VCardActions class="mb-2">
           <VBtn
             color="error"
             variant="flat"
@@ -773,7 +797,11 @@ onBeforeUnmount(() => {
             :disabled="saving"
             @click="confirmDelete"
           >
-            Delete
+            Delete Contact
+          </VBtn>
+          <VSpacer />
+          <VBtn color="warning" variant="text" @click="deleteDialog = false">
+            Close
           </VBtn>
         </VCardActions>
       </VCard>
@@ -795,7 +823,7 @@ onBeforeUnmount(() => {
           />
         </VCardTitle>
         <VCardText>
-          <p class="mb-4">
+          <p class="mb-4 mt-n2 text-medium-emphasis">
             Download the
             <a
               class="text-decoration-none hover:text-decoration-underline"
@@ -831,11 +859,7 @@ onBeforeUnmount(() => {
             </ul>
           </VAlert>
         </VCardText>
-        <VCardActions>
-          <VSpacer />
-          <VBtn color="warning" variant="text" @click="importDialog = false">
-            Close
-          </VBtn>
+        <VCardActions class="pb-4">
           <VBtn
             color="primary"
             variant="flat"
@@ -845,6 +869,10 @@ onBeforeUnmount(() => {
             @click="submitImport"
           >
             Import
+          </VBtn>
+          <v-spacer />
+          <VBtn color="warning" variant="text" @click="importDialog = false">
+            Close
           </VBtn>
         </VCardActions>
       </VCard>

--- a/web/app/pages/contacts/index.vue
+++ b/web/app/pages/contacts/index.vue
@@ -1,27 +1,21 @@
 <script setup lang="ts">
 import {
-  mdiAccount,
   mdiAccountGroupOutline,
   mdiAccountPlus,
   mdiAlertCircleOutline,
   mdiArrowLeft,
   mdiClose,
   mdiDelete,
-  mdiEmailOutline,
   mdiFileUpload,
   mdiMagnify,
   mdiPhoneCheck,
   mdiEmailCheckOutline,
   mdiSquareEditOutline,
-  mdiPlus,
-  mdiContentSaveCheck,
 } from '@mdi/js'
-import { parsePhoneNumberFromString } from 'libphonenumber-js'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import type { EntitiesContact } from '~~/shared/types/api'
-import { useContactsStore, type ContactInput } from '~/stores/contacts'
+import { useContactsStore } from '~/stores/contacts'
 import { useFilters } from '~/composables/useFilters'
-import { ErrorMessages } from '~/utils/errors'
 import { toApiError } from '~/utils/api-error'
 
 definePageMeta({
@@ -31,23 +25,6 @@ definePageMeta({
 useHead({
   title: 'Contacts - httpSMS',
 })
-
-interface PropertyRow {
-  key: string
-  value: string
-}
-
-interface PhoneNumberRow {
-  value: string
-  country: string
-}
-
-interface ContactForm {
-  name: string
-  phoneNumbers: PhoneNumberRow[]
-  emails: string[]
-  properties: PropertyRow[]
-}
 
 const contactsStore = useContactsStore()
 const { formatPhoneNumber, formatTimestamp, humanizeTimeShort } = useFilters()
@@ -68,7 +45,7 @@ const itemsPerPageOptions = [
   { value: 100, title: '100' },
 ]
 
-const editDialog = ref(false)
+const contactDialog = ref(false)
 const deleteDialog = ref(false)
 const importDialog = ref(false)
 const saving = ref(false)
@@ -83,16 +60,8 @@ const sortBy = ref<{ key: string; order: 'asc' | 'desc' }[]>([
 // first fetch is driven by onMounted rather than firing twice on mount.
 const initialLoadComplete = ref(false)
 
-const editingId = ref<string | null>(null)
+const editingContact = ref<EntitiesContact | null>(null)
 const pendingDelete = ref<EntitiesContact | null>(null)
-
-const form = ref<ContactForm>({
-  name: '',
-  phoneNumbers: [{ value: '', country: 'US' }],
-  emails: [''],
-  properties: [{ key: '', value: '' }],
-})
-const formErrors = ref(new ErrorMessages())
 
 const importFile = ref<File | null>(null)
 const importErrors = ref<string[]>([])
@@ -106,50 +75,14 @@ const searchTerm = computed({
   },
 })
 
-const dialogTitle = computed(() =>
-  editingId.value ? 'Edit Contact' : 'Add Contact',
-)
-
-function emptyForm(): ContactForm {
-  return {
-    name: '',
-    phoneNumbers: [{ value: '', country: 'US' }],
-    emails: [''],
-    properties: [{ key: '', value: '' }],
-  }
-}
-
-function phoneNumberRow(value = ''): PhoneNumberRow {
-  return {
-    value,
-    country: parsePhoneNumberFromString(value)?.country ?? 'US',
-  }
-}
-
 function openAdd() {
-  editingId.value = null
-  form.value = emptyForm()
-  formErrors.value = new ErrorMessages()
-  editDialog.value = true
+  editingContact.value = null
+  contactDialog.value = true
 }
 
 function openEdit(contact: EntitiesContact) {
-  editingId.value = contact.id
-  const propertyEntries = Object.entries(contact.properties ?? {}).map(
-    ([key, value]) => ({ key, value }),
-  )
-  form.value = {
-    name: contact.name ?? '',
-    phoneNumbers: contact.phone_numbers?.length
-      ? contact.phone_numbers.map((value) => phoneNumberRow(value))
-      : [phoneNumberRow()],
-    emails: contact.emails?.length ? [...contact.emails] : [''],
-    properties: propertyEntries.length
-      ? propertyEntries
-      : [{ key: '', value: '' }],
-  }
-  formErrors.value = new ErrorMessages()
-  editDialog.value = true
+  editingContact.value = contact
+  contactDialog.value = true
 }
 
 function openDelete(contact: EntitiesContact) {
@@ -163,107 +96,12 @@ function openImport() {
   importDialog.value = true
 }
 
-function addPhoneNumber() {
-  form.value.phoneNumbers.push(phoneNumberRow())
-}
-
-function removePhoneNumber(index: number) {
-  form.value.phoneNumbers.splice(index, 1)
-  if (form.value.phoneNumbers.length === 0) {
-    form.value.phoneNumbers.push(phoneNumberRow())
-  }
-}
-
-function addEmail() {
-  form.value.emails.push('')
-}
-
-function removeEmail(index: number) {
-  form.value.emails.splice(index, 1)
-  if (form.value.emails.length === 0) {
-    form.value.emails.push('')
-  }
-}
-
-function addProperty() {
-  form.value.properties.push({ key: '', value: '' })
-}
-
-function removeProperty(index: number) {
-  form.value.properties.splice(index, 1)
-  if (form.value.properties.length === 0) {
-    form.value.properties.push({ key: '', value: '' })
-  }
-}
-
-function buildPayload(): ContactInput {
-  const properties: Record<string, string> = {}
-  form.value.properties.forEach((row) => {
-    const key = row.key.trim()
-    if (key) {
-      properties[key] = row.value
-    }
-  })
-  return {
-    name: form.value.name.trim(),
-    phone_numbers: form.value.phoneNumbers
-      .map(({ value }) => value.trim())
-      .filter((value) => value.length > 0),
-    emails: form.value.emails
-      .map((value) => value.trim())
-      .filter((value) => value.length > 0),
-    properties,
-  }
-}
-
-function validateForm(): boolean {
-  const bag = new ErrorMessages()
-  if (form.value.name.trim() === '') {
-    bag.add('name', 'The name is required.')
-  }
-  const hasPhone = form.value.phoneNumbers.some(
-    ({ value }) => value.trim().length > 0,
-  )
-  if (!hasPhone) {
-    bag.add('phone_numbers', 'At least one phone number is required.')
-  }
-  formErrors.value = bag
-  return bag.size() === 0
-}
-
 function fieldErrorsFromApi(error: unknown): string[] {
   const data = toApiError(error).data?.data
   if (!data || typeof data !== 'object') {
     return []
   }
   return Object.values(data).flat()
-}
-
-async function submitForm() {
-  if (!validateForm()) {
-    return
-  }
-  const payload = buildPayload()
-  saving.value = true
-  try {
-    if (editingId.value) {
-      await contactsStore.updateContact(editingId.value, payload)
-    } else {
-      await contactsStore.saveContacts([payload])
-    }
-    editDialog.value = false
-  } catch (error: unknown) {
-    // The store already surfaced a toast; retain the API field messages so the
-    // user can correct them inline instead of only seeing a transient toast.
-    const bag = new ErrorMessages()
-    const messages = fieldErrorsFromApi(error)
-    if (messages.length > 0) {
-      bag.addMany('contacts', messages)
-    }
-    formErrors.value = bag
-  } finally {
-    saving.value = false
-  }
 }
 
 async function confirmDelete() {
@@ -582,194 +420,7 @@ onBeforeUnmount(() => {
       </VRow>
     </VContainer>
 
-    <!-- Add / Edit contact dialog -->
-    <VDialog v-model="editDialog" max-width="640" opacity="0.9">
-      <VCard>
-        <VCardTitle class="d-flex align-center">
-          <span>{{ dialogTitle }}</span>
-          <VSpacer />
-          <VBtn
-            :icon="mdiClose"
-            variant="text"
-            color="warning"
-            size="small"
-            aria-label="Close dialog"
-            @click="editDialog = false"
-          />
-        </VCardTitle>
-        <VCardText>
-          <VAlert
-            v-if="formErrors.get('contacts').length"
-            type="error"
-            variant="tonal"
-            density="comfortable"
-            class="mb-4"
-            :icon="mdiAlertCircleOutline"
-          >
-            <ul class="pl-4 mb-0">
-              <li v-for="message in formErrors.get('contacts')" :key="message">
-                {{ message }}
-              </li>
-            </ul>
-          </VAlert>
-
-          <VTextField
-            v-model="form.name"
-            label="Name"
-            variant="outlined"
-            density="comfortable"
-            persistent-placeholder
-            placeholder="e.g John Doe"
-            :prepend-inner-icon="mdiAccount"
-            :error="formErrors.has('name')"
-            :error-messages="formErrors.get('name')"
-            class="mb-2"
-          />
-
-          <div class="d-flex align-center mt-2 mb-1">
-            <span class="text-subtitle-2">Phone Numbers</span>
-            <VSpacer />
-            <VBtn
-              variant="text"
-              color="primary"
-              size="small"
-              :prepend-icon="mdiPlus"
-              @click="addPhoneNumber"
-            >
-              Add
-            </VBtn>
-          </div>
-          <div
-            v-for="(phone, index) in form.phoneNumbers"
-            :key="`phone-${index}`"
-            class="d-flex align-start ga-2"
-          >
-            <div class="mt-2" style="flex: 0 0 92%">
-              <v-phone-input
-                v-model="phone.value"
-                v-model:country="phone.country"
-                :label="`Phone number ${index + 1}`"
-                country-label="Country"
-                placeholder="Phone number e.g 18005550199"
-                variant="outlined"
-                density="comfortable"
-                color="primary"
-                persistent-placeholder
-                :error="index === 0 && formErrors.has('phone_numbers')"
-                :error-messages="
-                  index === 0 ? formErrors.get('phone_numbers') : []
-                "
-              />
-            </div>
-            <div style="flex: 0 0 8%">
-              <VBtn
-                :icon="mdiClose"
-                variant="text"
-                size="small"
-                class="mt-1"
-                aria-label="Remove phone number"
-                @click="removePhoneNumber(index)"
-              />
-            </div>
-          </div>
-
-          <div class="d-flex align-center mt-2 mb-1">
-            <span class="text-subtitle-2">Email Addresses</span>
-            <VSpacer />
-            <VBtn
-              variant="text"
-              color="primary"
-              size="small"
-              :prepend-icon="mdiPlus"
-              @click="addEmail"
-            >
-              Add
-            </VBtn>
-          </div>
-          <div
-            v-for="(email, index) in form.emails"
-            :key="`email-${email}-${index}`"
-            class="d-flex align-start ga-2"
-          >
-            <VTextField
-              v-model="form.emails[index]"
-              :label="`Email ${index + 1}`"
-              placeholder="e.g alice@example.com"
-              variant="outlined"
-              autocomplete="email"
-              type="email"
-              persistent-placeholder
-              density="comfortable"
-              :prepend-inner-icon="mdiEmailOutline"
-            />
-            <VBtn
-              :icon="mdiClose"
-              variant="text"
-              size="small"
-              class="mt-1"
-              aria-label="Remove email"
-              @click="removeEmail(index)"
-            />
-          </div>
-
-          <div class="d-flex align-center mt-2 mb-1">
-            <span class="text-subtitle-2">Properties</span>
-            <VSpacer />
-            <VBtn
-              variant="text"
-              color="primary"
-              size="small"
-              :prepend-icon="mdiPlus"
-              @click="addProperty"
-            >
-              Add
-            </VBtn>
-          </div>
-          <div
-            v-for="(property, index) in form.properties"
-            :key="`property-${index}`"
-            class="d-flex align-start ga-2"
-          >
-            <VTextField
-              v-model="property.key"
-              label="Key"
-              variant="outlined"
-              density="comfortable"
-            />
-            <VTextField
-              v-model="property.value"
-              label="Value"
-              variant="outlined"
-              density="comfortable"
-            />
-            <VBtn
-              :icon="mdiClose"
-              variant="text"
-              size="small"
-              class="mt-1"
-              aria-label="Remove property"
-              @click="removeProperty(index)"
-            />
-          </div>
-        </VCardText>
-        <VCardActions class="pb-4">
-          <VBtn
-            color="primary"
-            variant="flat"
-            :loading="saving"
-            :disabled="saving"
-            :prepend-icon="mdiContentSaveCheck"
-            @click="submitForm"
-          >
-            Save Contact
-          </VBtn>
-          <VSpacer />
-          <VBtn color="warning" variant="text" @click="editDialog = false">
-            Close
-          </VBtn>
-        </VCardActions>
-      </VCard>
-    </VDialog>
+    <ContactDialog v-model="contactDialog" :contact="editingContact" />
 
     <!-- Delete contact dialog -->
     <VDialog v-model="deleteDialog" max-width="480" opacity="0.9">

--- a/web/app/pages/contacts/index.vue
+++ b/web/app/pages/contacts/index.vue
@@ -430,6 +430,7 @@ onBeforeUnmount(() => {
             label="Search by name, phone number or email"
             variant="outlined"
             density="compact"
+            autocomplete="search-query"
             clearable
             color="primary"
             hide-details
@@ -695,6 +696,8 @@ onBeforeUnmount(() => {
               :label="`Email ${index + 1}`"
               placeholder="e.g alice@example.com"
               variant="outlined"
+              autocomplete="email"
+              type="email"
               persistent-placeholder
               density="comfortable"
               :prepend-inner-icon="mdiEmailOutline"

--- a/web/app/pages/contacts/index.vue
+++ b/web/app/pages/contacts/index.vue
@@ -102,8 +102,6 @@ const searchTerm = computed({
   },
 })
 
-const trimmedSearchTerm = computed(() => contactsStore.search.trim())
-
 const dialogTitle = computed(() =>
   editingId.value ? 'Edit Contact' : 'Add Contact',
 )
@@ -371,28 +369,20 @@ onBeforeUnmount(() => {
     <VContainer class="pt-0">
       <VRow>
         <VCol cols="12">
-          <div class="d-flex flex-column flex-md-row align-md-center mb-6 mt-3">
-            <div>
-              <h1 class="text-display-large mb-1">Contacts</h1>
-              <p class="text-medium-emphasis mb-0">
-                Manage your contacts.
-                {{
-                  trimmedSearchTerm
-                    ? `${contactsStore.total} found`
-                    : `${contactsStore.total} total`
-                }}
-              </p>
-            </div>
+          <div class="d-flex align-center">
+            <h1 class="text-display-large mb-1">Contacts</h1>
             <VSpacer />
-            <div class="d-flex flex-column flex-sm-row ga-3 mt-4 mt-md-0">
+            <div class="mt-12">
               <VBtn
                 variant="tonal"
+                class="ml-4 mb-4"
                 :prepend-icon="mdiFileUpload"
                 @click="openImport"
               >
                 Import CSV
               </VBtn>
               <VBtn
+                class="ml-4 mb-4"
                 color="primary"
                 variant="flat"
                 :prepend-icon="mdiAccountPlus"
@@ -402,6 +392,19 @@ onBeforeUnmount(() => {
               </VBtn>
             </div>
           </div>
+          <p class="text-medium-emphasis mb-6">
+            Use httpSMS as a lightweight CRM by adding your contacts here. Your
+            message threads will show contact names instead of phone numbers,
+            making conversations easier to recognize and manage. Add contacts
+            individually, or fill in our
+            <a
+              class="text-decoration-none hover:text-decoration-underline"
+              href="/templates/httpsms-contacts.csv"
+              download
+              >CSV template</a
+            >
+            and upload it to import your contact list in bulk.
+          </p>
 
           <VTextField
             v-model="searchTerm"

--- a/web/app/pages/contacts/index.vue
+++ b/web/app/pages/contacts/index.vue
@@ -10,7 +10,9 @@ import {
   mdiEmailOutline,
   mdiFileUpload,
   mdiMagnify,
-  mdiPencil,
+  mdiPhoneCheck,
+  mdiEmailCheckOutline,
+  mdiSquareEditOutline,
   mdiPhone,
   mdiPlus,
 } from '@mdi/js'
@@ -42,11 +44,7 @@ interface ContactForm {
 }
 
 const contactsStore = useContactsStore()
-const { formatPhoneNumber, humanizeTime, formatTimestamp } = useFilters()
-
-// Avatar backgrounds are picked deterministically from the Vuetify theme
-// palette so the table reads like an address book without inventing colors.
-const avatarPalette = ['primary', 'secondary', 'info', 'success']
+const { formatPhoneNumber, formatTimestamp, humanizeTimeShort } = useFilters()
 
 const headers = [
   { title: 'Name', key: 'name', sortable: false },
@@ -112,33 +110,6 @@ function emptyForm(): ContactForm {
     emails: [''],
     properties: [],
   }
-}
-
-function initials(name: string): string {
-  const parts = name.trim().split(/\s+/).filter(Boolean)
-  if (parts.length === 0) {
-    return ''
-  }
-  const first = parts[0] ?? ''
-  const last = parts.length > 1 ? (parts[parts.length - 1] ?? '') : ''
-  return (first.charAt(0) + last.charAt(0)).toUpperCase()
-}
-
-function avatarColor(name: string): string {
-  const key = name.trim()
-  if (!key) {
-    return 'primary'
-  }
-  let hash = 0
-  for (let index = 0; index < key.length; index += 1) {
-    hash = (hash + key.charCodeAt(index)) % avatarPalette.length
-  }
-  return avatarPalette[hash] ?? 'primary'
-}
-
-function relativeTime(value: string): string {
-  const humanized = humanizeTime(value)
-  return humanized ? `${humanized} ago` : 'just now'
 }
 
 function openAdd() {
@@ -381,7 +352,7 @@ onBeforeUnmount(() => {
 
     <VContainer class="pt-0">
       <VRow>
-        <VCol cols="12" md="10" offset-md="1" xxl="8" offset-xxl="2">
+        <VCol cols="12">
           <div class="d-flex flex-column flex-md-row align-md-center mb-6 mt-3">
             <div>
               <h1 class="text-display-large mb-1">Contacts</h1>
@@ -397,8 +368,7 @@ onBeforeUnmount(() => {
             <VSpacer />
             <div class="d-flex flex-column flex-sm-row ga-3 mt-4 mt-md-0">
               <VBtn
-                variant="outlined"
-                color="primary"
+                variant="tonal"
                 :prepend-icon="mdiFileUpload"
                 @click="openImport"
               >
@@ -420,150 +390,148 @@ onBeforeUnmount(() => {
             :prepend-inner-icon="mdiMagnify"
             label="Search by name, phone number or email"
             variant="outlined"
-            density="comfortable"
+            density="compact"
             clearable
             hide-details
             class="mb-4"
           />
 
-          <VCard variant="outlined">
-            <VDataTableServer
-              v-model:page="page"
-              v-model:items-per-page="itemsPerPage"
-              :headers="headers"
-              :items="contactsStore.contacts"
-              :items-length="contactsStore.total"
-              :loading="contactsStore.loading"
-              :items-per-page-options="itemsPerPageOptions"
-              item-value="id"
-              hover
-              loading-text="Loading contacts…"
-              @update:options="onUpdateOptions"
-            >
-              <template #[`item.name`]="{ item }">
-                <div class="d-flex align-center py-2">
-                  <VAvatar
-                    :color="avatarColor(item.name)"
-                    size="40"
-                    class="mr-3"
-                  >
-                    <span
-                      v-if="initials(item.name)"
-                      class="text-body-1 font-weight-medium"
-                      >{{ initials(item.name) }}</span
-                    >
-                    <VIcon v-else :icon="mdiAccount" />
-                  </VAvatar>
-                  <span class="font-weight-medium">{{ item.name }}</span>
-                </div>
-              </template>
+          <VDataTableServer
+            v-model:page="page"
+            v-model:items-per-page="itemsPerPage"
+            :headers="headers"
+            :header-props="{
+              class: 'text-uppercase text-medium-emphasis',
+            }"
+            :items="contactsStore.contacts"
+            :items-length="contactsStore.total"
+            :loading="contactsStore.loading"
+            :items-per-page-options="itemsPerPageOptions"
+            item-value="id"
+            hover
+            loading-text="Loading contacts…"
+            @update:options="onUpdateOptions"
+          >
+            <template #[`item.name`]="{ item }">
+              <div class="d-flex align-center py-2">
+                <span class="font-weight-medium">{{ item.name }}</span>
+              </div>
+            </template>
 
-              <template #[`item.phone_numbers`]="{ item }">
+            <template #[`item.phone_numbers`]="{ item }">
+              <div
+                v-if="item.phone_numbers?.length"
+                class="d-flex flex-column ga-1 py-2"
+              >
                 <div
-                  v-if="item.phone_numbers?.length"
-                  class="d-flex flex-column ga-1 py-2"
+                  v-for="phone in item.phone_numbers ?? []"
+                  :key="phone"
+                  class="d-flex"
                 >
-                  <VChip
-                    v-for="phone in item.phone_numbers ?? []"
-                    :key="phone"
-                    size="small"
-                    variant="tonal"
-                    color="primary"
-                    :prepend-icon="mdiPhone"
-                  >
-                    {{ formatPhoneNumber(phone) }}
-                  </VChip>
-                </div>
-                <span v-else class="text-medium-emphasis">—</span>
-              </template>
-
-              <template #[`item.emails`]="{ item }">
-                <div
-                  v-if="item.emails?.length"
-                  class="d-flex flex-column ga-1 py-2"
-                >
-                  <span
-                    v-for="email in item.emails ?? []"
-                    :key="email"
-                    class="d-flex align-center text-body-2"
-                  >
-                    <VIcon
-                      :icon="mdiEmailOutline"
-                      size="x-small"
-                      class="mr-1 text-medium-emphasis"
-                    />
-                    {{ email }}
-                  </span>
-                </div>
-                <span v-else class="text-medium-emphasis">—</span>
-              </template>
-
-              <template #[`item.created_at`]="{ item }">
-                <span :title="formatTimestamp(item.created_at)">{{
-                  relativeTime(item.created_at)
-                }}</span>
-              </template>
-
-              <template #[`item.updated_at`]="{ item }">
-                <span :title="formatTimestamp(item.updated_at)">{{
-                  relativeTime(item.updated_at)
-                }}</span>
-              </template>
-
-              <template #[`item.actions`]="{ item }">
-                <div class="d-flex justify-end">
-                  <VBtn
-                    :icon="mdiPencil"
-                    variant="text"
-                    size="small"
-                    aria-label="Edit contact"
-                    @click="openEdit(item)"
-                  />
-                  <VBtn
-                    :icon="mdiDelete"
-                    variant="text"
-                    size="small"
-                    color="error"
-                    aria-label="Delete contact"
-                    @click="openDelete(item)"
-                  />
-                </div>
-              </template>
-
-              <template #no-data>
-                <div class="text-center py-12">
                   <VIcon
-                    :icon="mdiAccountGroupOutline"
-                    size="64"
-                    class="text-medium-emphasis mb-3"
+                    :icon="mdiPhoneCheck"
+                    size="small"
+                    color="info"
+                    class="mr-1 text-medium-emphasis"
                   />
-                  <p class="text-title-medium mb-1">
-                    {{
-                      searchTerm
-                        ? 'No contacts match your search'
-                        : 'No contacts yet'
-                    }}
-                  </p>
-                  <p class="text-medium-emphasis mb-4">
-                    {{
-                      searchTerm
-                        ? 'Try a different name, phone number or email.'
-                        : 'Add your first contact or import them from a CSV file.'
-                    }}
-                  </p>
-                  <VBtn
-                    v-if="!searchTerm"
-                    color="primary"
-                    variant="flat"
-                    :prepend-icon="mdiAccountPlus"
-                    @click="openAdd"
-                  >
-                    Add Contact
-                  </VBtn>
+                  {{ formatPhoneNumber(phone) }}
                 </div>
-              </template>
-            </VDataTableServer>
-          </VCard>
+              </div>
+              <span v-else class="text-medium-emphasis">—</span>
+            </template>
+
+            <template #[`item.emails`]="{ item }">
+              <div
+                v-if="item.emails?.length"
+                class="d-flex flex-column ga-1 py-2"
+              >
+                <span
+                  v-for="email in item.emails ?? []"
+                  :key="email"
+                  class="d-flex align-center text-body-2"
+                >
+                  <VIcon
+                    :icon="mdiEmailCheckOutline"
+                    size="small"
+                    color="info"
+                    class="mr-1 text-medium-emphasis"
+                  />
+                  {{ email }}
+                </span>
+              </div>
+              <span v-else class="text-medium-emphasis">—</span>
+            </template>
+
+            <template #[`item.created_at`]="{ item }">
+              <span
+                class="text-medium-emphasis"
+                :title="formatTimestamp(item.created_at)"
+                >{{ humanizeTimeShort(item.created_at) }}</span
+              >
+            </template>
+
+            <template #[`item.updated_at`]="{ item }">
+              <span
+                class="text-medium-emphasis"
+                :title="formatTimestamp(item.updated_at)"
+                >{{ humanizeTimeShort(item.updated_at) }}</span
+              >
+            </template>
+
+            <template #[`item.actions`]="{ item }">
+              <div class="d-flex justify-end">
+                <VBtn
+                  :icon="mdiSquareEditOutline"
+                  variant="text"
+                  class="mr-2"
+                  density="comfortable"
+                  aria-label="Edit contact"
+                  @click="openEdit(item)"
+                />
+                <VBtn
+                  :icon="mdiDelete"
+                  variant="text"
+                  density="comfortable"
+                  color="error"
+                  aria-label="Delete contact"
+                  @click="openDelete(item)"
+                />
+              </div>
+            </template>
+
+            <template #no-data>
+              <div class="text-center py-12">
+                <VIcon
+                  :icon="mdiAccountGroupOutline"
+                  size="64"
+                  class="text-medium-emphasis mb-3"
+                />
+                <p class="text-title-medium mb-1">
+                  {{
+                    searchTerm
+                      ? 'No contacts match your search'
+                      : 'No contacts yet'
+                  }}
+                </p>
+                <p class="text-medium-emphasis mb-4">
+                  {{
+                    searchTerm
+                      ? 'Try a different name, phone number or email.'
+                      : 'Add your first contact or import them from a CSV file.'
+                  }}
+                </p>
+                <VBtn
+                  v-if="!searchTerm"
+                  color="primary"
+                  variant="flat"
+                  :prepend-icon="mdiAccountPlus"
+                  @click="openAdd"
+                >
+                  Add Contact
+                </VBtn>
+              </div>
+            </template>
+          </VDataTableServer>
         </VCol>
       </VRow>
     </VContainer>

--- a/web/app/pages/contacts/index.vue
+++ b/web/app/pages/contacts/index.vue
@@ -13,9 +13,9 @@ import {
   mdiPhoneCheck,
   mdiEmailCheckOutline,
   mdiSquareEditOutline,
-  mdiPhone,
   mdiPlus,
 } from '@mdi/js'
+import { parsePhoneNumberFromString } from 'libphonenumber-js'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import type { EntitiesContact } from '~~/shared/types/api'
 import { useContactsStore, type ContactInput } from '~/stores/contacts'
@@ -36,9 +36,14 @@ interface PropertyRow {
   value: string
 }
 
+interface PhoneNumberRow {
+  value: string
+  country: string
+}
+
 interface ContactForm {
   name: string
-  phoneNumbers: string[]
+  phoneNumbers: PhoneNumberRow[]
   emails: string[]
   properties: PropertyRow[]
 }
@@ -79,9 +84,9 @@ const pendingDelete = ref<EntitiesContact | null>(null)
 
 const form = ref<ContactForm>({
   name: '',
-  phoneNumbers: [''],
+  phoneNumbers: [{ value: '', country: 'US' }],
   emails: [''],
-  properties: [],
+  properties: [{ key: '', value: '' }],
 })
 const formErrors = ref(new ErrorMessages())
 
@@ -106,9 +111,16 @@ const dialogTitle = computed(() =>
 function emptyForm(): ContactForm {
   return {
     name: '',
-    phoneNumbers: [''],
+    phoneNumbers: [{ value: '', country: 'US' }],
     emails: [''],
-    properties: [],
+    properties: [{ key: '', value: '' }],
+  }
+}
+
+function phoneNumberRow(value = ''): PhoneNumberRow {
+  return {
+    value,
+    country: parsePhoneNumberFromString(value)?.country ?? 'US',
   }
 }
 
@@ -121,15 +133,18 @@ function openAdd() {
 
 function openEdit(contact: EntitiesContact) {
   editingId.value = contact.id
+  const propertyEntries = Object.entries(contact.properties ?? {}).map(
+    ([key, value]) => ({ key, value }),
+  )
   form.value = {
     name: contact.name ?? '',
     phoneNumbers: contact.phone_numbers?.length
-      ? [...contact.phone_numbers]
-      : [''],
+      ? contact.phone_numbers.map((value) => phoneNumberRow(value))
+      : [phoneNumberRow()],
     emails: contact.emails?.length ? [...contact.emails] : [''],
-    properties: Object.entries(contact.properties ?? {}).map(
-      ([key, value]) => ({ key, value }),
-    ),
+    properties: propertyEntries.length
+      ? propertyEntries
+      : [{ key: '', value: '' }],
   }
   formErrors.value = new ErrorMessages()
   editDialog.value = true
@@ -147,13 +162,13 @@ function openImport() {
 }
 
 function addPhoneNumber() {
-  form.value.phoneNumbers.push('')
+  form.value.phoneNumbers.push(phoneNumberRow())
 }
 
 function removePhoneNumber(index: number) {
   form.value.phoneNumbers.splice(index, 1)
   if (form.value.phoneNumbers.length === 0) {
-    form.value.phoneNumbers.push('')
+    form.value.phoneNumbers.push(phoneNumberRow())
   }
 }
 
@@ -174,6 +189,9 @@ function addProperty() {
 
 function removeProperty(index: number) {
   form.value.properties.splice(index, 1)
+  if (form.value.properties.length === 0) {
+    form.value.properties.push({ key: '', value: '' })
+  }
 }
 
 function buildPayload(): ContactInput {
@@ -187,7 +205,7 @@ function buildPayload(): ContactInput {
   return {
     name: form.value.name.trim(),
     phone_numbers: form.value.phoneNumbers
-      .map((value) => value.trim())
+      .map(({ value }) => value.trim())
       .filter((value) => value.length > 0),
     emails: form.value.emails
       .map((value) => value.trim())
@@ -202,7 +220,7 @@ function validateForm(): boolean {
     bag.add('name', 'The name is required.')
   }
   const hasPhone = form.value.phoneNumbers.some(
-    (value) => value.trim().length > 0,
+    ({ value }) => value.trim().length > 0,
   )
   if (!hasPhone) {
     bag.add('phone_numbers', 'At least one phone number is required.')
@@ -401,7 +419,7 @@ onBeforeUnmount(() => {
             v-model:items-per-page="itemsPerPage"
             :headers="headers"
             :header-props="{
-              class: 'text-uppercase text-medium-emphasis',
+              class: 'text-uppercase text-medium-emphasis bg-black',
             }"
             :items="contactsStore.contacts"
             :items-length="contactsStore.total"
@@ -463,19 +481,23 @@ onBeforeUnmount(() => {
             </template>
 
             <template #[`item.created_at`]="{ item }">
-              <span
-                class="text-medium-emphasis"
-                :title="formatTimestamp(item.created_at)"
-                >{{ humanizeTimeShort(item.created_at) }}</span
-              >
+              <VTooltip :text="formatTimestamp(item.created_at)">
+                <template #activator="{ props }">
+                  <span v-bind="props" class="text-medium-emphasis">
+                    {{ humanizeTimeShort(item.created_at) }}
+                  </span>
+                </template>
+              </VTooltip>
             </template>
 
             <template #[`item.updated_at`]="{ item }">
-              <span
-                class="text-medium-emphasis"
-                :title="formatTimestamp(item.updated_at)"
-                >{{ humanizeTimeShort(item.updated_at) }}</span
-              >
+              <VTooltip :text="formatTimestamp(item.updated_at)">
+                <template #activator="{ props }">
+                  <span v-bind="props" class="text-medium-emphasis">
+                    {{ humanizeTimeShort(item.updated_at) }}
+                  </span>
+                </template>
+              </VTooltip>
             </template>
 
             <template #[`item.actions`]="{ item }">
@@ -596,13 +618,16 @@ onBeforeUnmount(() => {
             :key="`phone-${index}`"
             class="d-flex align-start ga-2"
           >
-            <VTextField
-              v-model="form.phoneNumbers[index]"
+            <v-phone-input
+              v-model="phone.value"
+              v-model:country="phone.country"
               :label="`Phone number ${index + 1}`"
-              placeholder="+18005550199"
+              country-label="Country"
+              placeholder="Phone number e.g 18005550199"
               variant="outlined"
               density="comfortable"
-              :prepend-inner-icon="mdiPhone"
+              color="primary"
+              persistent-placeholder
               :error="index === 0 && formErrors.has('phone_numbers')"
               :error-messages="
                 index === 0 ? formErrors.get('phone_numbers') : []
@@ -667,12 +692,6 @@ onBeforeUnmount(() => {
               Add
             </VBtn>
           </div>
-          <p
-            v-if="!form.properties.length"
-            class="text-medium-emphasis text-body-2 mb-2"
-          >
-            Add custom key/value details such as company or address.
-          </p>
           <div
             v-for="(property, index) in form.properties"
             :key="`property-${index}`"

--- a/web/app/pages/heartbeats/[id].vue
+++ b/web/app/pages/heartbeats/[id].vue
@@ -17,7 +17,7 @@ useHead({
 })
 
 const route = useRoute()
-const { mdAndDown, mdAndUp, lgAndUp } = useDisplay()
+const { mdAndDown, mdAndUp, lgAndUp } = useVDisplay()
 const authStore = useAuthStore()
 const phonesStore = usePhonesStore()
 const { formatPhoneNumber, formatTimestamp } = useFilters()

--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -43,7 +43,7 @@ useSeoMeta({
 })
 
 const config = useRuntimeConfig()
-const { lgAndUp, mdAndUp, mdAndDown, md, smAndDown, xl } = useDisplay()
+const { lgAndUp, mdAndUp, mdAndDown, md, smAndDown, xl } = useVDisplay()
 
 const selectedTab = ref('javascript')
 const yearlyPricing = ref(false)

--- a/web/app/pages/messages/index.vue
+++ b/web/app/pages/messages/index.vue
@@ -17,7 +17,7 @@ useHead({
 })
 
 const router = useRouter()
-const { mdAndDown, mdAndUp } = useDisplay()
+const { mdAndDown, mdAndUp } = useVDisplay()
 const notificationsStore = useNotificationsStore()
 const phonesStore = usePhonesStore()
 const { useApi } = useApiComposable()

--- a/web/app/pages/phone-api-keys/index.vue
+++ b/web/app/pages/phone-api-keys/index.vue
@@ -16,7 +16,7 @@ useHead({
 })
 
 const config = useRuntimeConfig()
-const { lgAndUp } = useDisplay()
+const { lgAndUp } = useVDisplay()
 const authStore = useAuthStore()
 const appStore = useAppStore()
 const phonesStore = usePhonesStore()

--- a/web/app/pages/search-messages/index.vue
+++ b/web/app/pages/search-messages/index.vue
@@ -42,7 +42,7 @@ useHead({
 
 const route = useRoute()
 const config = useRuntimeConfig()
-const { mdAndUp, smAndDown, lgAndUp } = useDisplay()
+const { mdAndUp, smAndDown, lgAndUp } = useVDisplay()
 const messagesStore = useMessagesStore()
 const phonesStore = usePhonesStore()
 const authStore = useAuthStore()

--- a/web/app/pages/settings/index.vue
+++ b/web/app/pages/settings/index.vue
@@ -42,7 +42,7 @@ useHead({
 const config = useRuntimeConfig()
 const route = useRoute()
 const router = useRouter()
-const { mdAndDown, mdAndUp, lgAndUp, xlAndUp, smAndUp } = useDisplay()
+const { mdAndDown, mdAndUp, lgAndUp, xlAndUp, smAndUp } = useVDisplay()
 const authStore = useAuthStore()
 const phonesStore = usePhonesStore()
 const billingStore = useBillingStore()

--- a/web/app/pages/threads/[id]/index.vue
+++ b/web/app/pages/threads/[id]/index.vue
@@ -19,7 +19,6 @@ import Pusher from 'pusher-js'
 import type { Channel } from 'pusher-js'
 import { isValidPhoneNumber } from 'libphonenumber-js'
 import type { EntitiesMessage } from '~~/shared/types/api'
-import { startsWithLetter } from '~/utils/filters'
 
 definePageMeta({
   middleware: ['auth'],
@@ -33,7 +32,7 @@ const route = useRoute()
 const router = useRouter()
 const config = useRuntimeConfig()
 const { lgAndUp, mdAndDown, mdAndUp } = useDisplay()
-const { formatPhoneNumber } = useFilters()
+const { formatPhoneNumber, startsWithLetter } = useFilters()
 const notificationsStore = useNotificationsStore()
 const authStore = useAuthStore()
 const phonesStore = usePhonesStore()
@@ -102,6 +101,14 @@ function formatAttachmentName(url: string): string {
   const parts = url.split('/')
   if (parts.length >= 2) return '/' + parts.slice(-2).join('/')
   return url
+}
+
+function currentThreadContactTitle(): string {
+  const thread = threadsStore.currentThread
+  if (!thread) return ''
+  return (
+    thread.contact_details?.name?.trim() || formatPhoneNumber(thread.contact)
+  )
 }
 
 function scrollToElement() {
@@ -268,7 +275,7 @@ onBeforeUnmount(() => {
           <VIcon :icon="mdiArrowLeft" />
         </VBtn>
         <VToolbarTitle v-if="threadsStore.currentThread">
-          {{ formatPhoneNumber(threadsStore.currentThread.contact) }}
+          {{ currentThreadContactTitle() }}
         </VToolbarTitle>
         <VMenu>
           <template #activator="{ props }">

--- a/web/app/pages/threads/[id]/index.vue
+++ b/web/app/pages/threads/[id]/index.vue
@@ -14,6 +14,8 @@ import {
   mdiAccount,
   mdiRefresh,
   mdiContentCopy,
+  mdiAccountPlus,
+  mdiSquareEditOutline,
 } from '@mdi/js'
 import Pusher from 'pusher-js'
 import type { Channel } from 'pusher-js'
@@ -47,6 +49,7 @@ const loadingMessages = ref(false)
 const hideMessages = ref(true)
 const messages = ref<EntitiesMessage[]>([])
 const selectedMenuItem = ref(-1)
+const contactDialog = ref(false)
 const messageBody = ref<HTMLElement | null>(null)
 const form = ref<{ validate: () => Promise<{ valid: boolean }> } | null>(null)
 
@@ -111,6 +114,10 @@ function currentThreadContactTitle(): string {
   return (
     thread.contact_details?.name?.trim() || formatPhoneNumber(thread.contact)
   )
+}
+
+async function refreshThreadContact() {
+  await threadsStore.loadThreads()
 }
 
 function scrollToElement() {
@@ -277,7 +284,16 @@ onBeforeUnmount(() => {
           <VIcon :icon="mdiArrowLeft" />
         </VBtn>
         <VToolbarTitle v-if="currentThread">
-          {{ currentThreadContactTitle() }}
+          <VTooltip
+            v-if="currentThread.contact_details?.name?.trim()"
+            :text="formatPhoneNumber(currentThread.contact)"
+            location="bottom"
+          >
+            <template #activator="{ props }">
+              <span v-bind="props">{{ currentThreadContactTitle() }}</span>
+            </template>
+          </VTooltip>
+          <template v-else>{{ currentThreadContactTitle() }}</template>
         </VToolbarTitle>
         <VMenu>
           <template #activator="{ props }">
@@ -290,6 +306,24 @@ onBeforeUnmount(() => {
             prepend-gap="24"
             :density="mdAndDown ? 'compact' : 'default'"
           >
+            <VListItem
+              v-if="currentThread?.contact_details"
+              @click="contactDialog = true"
+            >
+              <template #prepend>
+                <VIcon :icon="mdiSquareEditOutline" />
+              </template>
+              <VListItemTitle>Edit Contact</VListItemTitle>
+            </VListItem>
+            <VListItem
+              v-else-if="contactIsPhoneNumber"
+              @click="contactDialog = true"
+            >
+              <template #prepend>
+                <VIcon :icon="mdiAccountPlus" />
+              </template>
+              <VListItemTitle>Add Contact</VListItemTitle>
+            </VListItem>
             <VListItem
               v-if="currentThread && !currentThread.is_archived"
               @click.prevent="archiveThread"
@@ -571,6 +605,13 @@ onBeforeUnmount(() => {
         </VFooter>
       </VContainer>
     </div>
+    <ContactDialog
+      v-model="contactDialog"
+      :contact="currentThread?.contact_details"
+      :initial-phone-number="currentThread?.contact ?? ''"
+      :refresh-contacts="false"
+      @saved="refreshThreadContact"
+    />
   </VContainer>
 </template>
 

--- a/web/app/pages/threads/[id]/index.vue
+++ b/web/app/pages/threads/[id]/index.vue
@@ -18,6 +18,7 @@ import {
 import Pusher from 'pusher-js'
 import type { Channel } from 'pusher-js'
 import { isValidPhoneNumber } from 'libphonenumber-js'
+import { storeToRefs } from 'pinia'
 import type { EntitiesMessage } from '~~/shared/types/api'
 
 definePageMeta({
@@ -31,13 +32,14 @@ useHead({
 const route = useRoute()
 const router = useRouter()
 const config = useRuntimeConfig()
-const { lgAndUp, mdAndDown, mdAndUp } = useDisplay()
+const { lgAndUp, mdAndDown, mdAndUp } = useVDisplay()
 const { formatPhoneNumber, startsWithLetter } = useFilters()
 const notificationsStore = useNotificationsStore()
 const authStore = useAuthStore()
 const phonesStore = usePhonesStore()
 const threadsStore = useThreadsStore()
 const messagesStore = useMessagesStore()
+const { currentThread } = storeToRefs(threadsStore)
 
 const formMessage = ref('')
 const submitting = ref(false)
@@ -58,7 +60,7 @@ const formMessageRules = [
 let webhookChannel: Channel | null = null
 
 const contactIsPhoneNumber = computed(() => {
-  const thread = threadsStore.currentThread
+  const thread = currentThread.value
   if (!thread) return false
   return isValidPhoneNumber(thread.contact) || !isNaN(Number(thread.contact))
 })
@@ -66,7 +68,7 @@ const contactIsPhoneNumber = computed(() => {
 const messageVisibility = computed(() =>
   hideMessages.value ? 'hidden' : 'visible',
 )
-const contact = computed(() => threadsStore.currentThread?.contact ?? '')
+const contact = computed(() => currentThread.value?.contact ?? '')
 
 function isMT(message: EntitiesMessage): boolean {
   return message.type === 'mobile-terminated'
@@ -104,7 +106,7 @@ function formatAttachmentName(url: string): string {
 }
 
 function currentThreadContactTitle(): string {
-  const thread = threadsStore.currentThread
+  const thread = currentThread.value
   if (!thread) return ''
   return (
     thread.contact_details?.name?.trim() || formatPhoneNumber(thread.contact)
@@ -162,7 +164,7 @@ async function loadData() {
 
 async function archiveThread() {
   await threadsStore.updateThread({
-    threadId: threadsStore.currentThread!.id,
+    threadId: currentThread.value!.id,
     isArchived: true,
   })
   await router.push('/threads')
@@ -170,7 +172,7 @@ async function archiveThread() {
 
 async function unArchiveThread() {
   await threadsStore.updateThread({
-    threadId: threadsStore.currentThread!.id,
+    threadId: currentThread.value!.id,
     isArchived: false,
   })
   await router.push('/threads')
@@ -225,7 +227,7 @@ async function sendMessage(event: KeyboardEvent | Event) {
   submitting.value = true
   await messagesStore.sendMessage({
     from: phonesStore.owner!,
-    to: threadsStore.currentThread!.contact,
+    to: currentThread.value!.contact,
     content: formMessage.value,
     sim: 'DEFAULT',
   })
@@ -274,7 +276,7 @@ onBeforeUnmount(() => {
         <VBtn v-if="mdAndDown" icon to="/threads">
           <VIcon :icon="mdiArrowLeft" />
         </VBtn>
-        <VToolbarTitle v-if="threadsStore.currentThread">
+        <VToolbarTitle v-if="currentThread">
           {{ currentThreadContactTitle() }}
         </VToolbarTitle>
         <VMenu>
@@ -289,10 +291,7 @@ onBeforeUnmount(() => {
             :density="mdAndDown ? 'compact' : 'default'"
           >
             <VListItem
-              v-if="
-                threadsStore.currentThread &&
-                !threadsStore.currentThread.is_archived
-              "
+              v-if="currentThread && !currentThread.is_archived"
               @click.prevent="archiveThread"
             >
               <template #prepend>
@@ -301,10 +300,7 @@ onBeforeUnmount(() => {
               <VListItemTitle>Archive</VListItemTitle>
             </VListItem>
             <VListItem
-              v-if="
-                threadsStore.currentThread &&
-                threadsStore.currentThread.is_archived
-              "
+              v-if="currentThread && currentThread.is_archived"
               @click.prevent="unArchiveThread"
             >
               <template #prepend>
@@ -313,8 +309,8 @@ onBeforeUnmount(() => {
               <VListItemTitle>Unarchive</VListItemTitle>
             </VListItem>
             <VListItem
-              v-if="threadsStore.currentThread"
-              @click.prevent="deleteThread(threadsStore.currentThread.id)"
+              v-if="currentThread"
+              @click.prevent="deleteThread(currentThread.id)"
             >
               <template #prepend>
                 <VIcon :icon="mdiDelete" color="error" />
@@ -330,7 +326,7 @@ onBeforeUnmount(() => {
         color="primary"
         indeterminate
       />
-      <VContainer v-if="threadsStore.currentThread" class="pa-0">
+      <VContainer v-if="currentThread" class="pa-0">
         <div
           ref="messageBody"
           class="messages-body no-scrollbar w-100 pl-2"
@@ -357,7 +353,7 @@ onBeforeUnmount(() => {
                   'ml-2': !mdAndUp,
                   'ml-4': mdAndUp,
                 }"
-                :color="threadsStore.currentThread!.color"
+                :color="currentThread.color"
                 size="40"
               >
                 <v-icon

--- a/web/app/pages/threads/index.vue
+++ b/web/app/pages/threads/index.vue
@@ -7,7 +7,7 @@ useHead({
   title: 'Threads - httpSMS',
 })
 
-const { lgAndUp } = useDisplay()
+const { lgAndUp } = useVDisplay()
 const authStore = useAuthStore()
 const phonesStore = usePhonesStore()
 const threadsStore = useThreadsStore()

--- a/web/app/stores/contacts.ts
+++ b/web/app/stores/contacts.ts
@@ -1,0 +1,181 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import type { EntitiesContact } from '~~/shared/types/api'
+import { getApiErrorMessage } from '~/utils/api-error'
+
+export interface ContactInput {
+  name: string
+  emails: string[]
+  phone_numbers: string[]
+  properties?: Record<string, string>
+}
+
+export const useContactsStore = defineStore('contacts', () => {
+  const contacts = ref<EntitiesContact[]>([])
+  const loading = ref(false)
+  const search = ref('')
+  const { apiFetch } = useApi()
+  const notificationsStore = useNotificationsStore()
+
+  const total = computed(() => contacts.value.length)
+
+  const filteredContacts = computed<EntitiesContact[]>(() => {
+    const term = search.value.trim().toLowerCase()
+    if (!term) return contacts.value
+
+    return contacts.value.filter((contact) => {
+      const name = contact.name.toLowerCase()
+      const emails = contact.emails.join(' ').toLowerCase()
+      const phoneNumbers = contact.phone_numbers.join(' ').toLowerCase()
+
+      return (
+        name.includes(term) ||
+        emails.includes(term) ||
+        phoneNumbers.includes(term)
+      )
+    })
+  })
+
+  async function loadContacts(force = false): Promise<void> {
+    if (contacts.value.length > 0 && !force) return
+
+    loading.value = true
+    try {
+      const response = await apiFetch<{ data: EntitiesContact[] }>(
+        '/v1/contacts',
+        {
+          params: { limit: 100 },
+        },
+      )
+      contacts.value = response.data ?? []
+    } catch (error: unknown) {
+      notificationsStore.addNotification({
+        message: getApiErrorMessage(error, 'Error while loading contacts'),
+        type: 'error',
+      })
+      throw error
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function saveContacts(
+    items: ContactInput | ContactInput[],
+  ): Promise<void> {
+    const contactsToSave = Array.isArray(items) ? items : [items]
+
+    loading.value = true
+    try {
+      await apiFetch('/v1/contacts', {
+        method: 'POST',
+        body: contactsToSave,
+      })
+      notificationsStore.addNotification({
+        message:
+          contactsToSave.length > 1 ? 'Contacts created' : 'Contact created',
+        type: 'success',
+      })
+      await loadContacts(true)
+    } catch (error: unknown) {
+      notificationsStore.addNotification({
+        message: getApiErrorMessage(error, 'Error while saving contacts'),
+        type: 'error',
+      })
+      throw error
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function updateContact(
+    id: string,
+    payload: ContactInput,
+  ): Promise<void> {
+    loading.value = true
+    try {
+      await apiFetch(`/v1/contacts/${id}`, {
+        method: 'PUT',
+        body: payload,
+      })
+      notificationsStore.addNotification({
+        message: 'Contact updated',
+        type: 'success',
+      })
+      await loadContacts(true)
+    } catch (error: unknown) {
+      notificationsStore.addNotification({
+        message: getApiErrorMessage(error, 'Error while updating contact'),
+        type: 'error',
+      })
+      throw error
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function deleteContact(id: string): Promise<void> {
+    loading.value = true
+    try {
+      await apiFetch(`/v1/contacts/${id}`, { method: 'DELETE' })
+      contacts.value = contacts.value.filter((contact) => contact.id !== id)
+      notificationsStore.addNotification({
+        message: 'Contact deleted',
+        type: 'success',
+      })
+    } catch (error: unknown) {
+      notificationsStore.addNotification({
+        message: getApiErrorMessage(error, 'Error while deleting contact'),
+        type: 'error',
+      })
+      throw error
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function uploadCsv(file: File): Promise<void> {
+    loading.value = true
+    try {
+      const formData = new FormData()
+      formData.append('document', file)
+
+      await apiFetch('/v1/contacts/upload', {
+        method: 'POST',
+        body: formData,
+      })
+      notificationsStore.addNotification({
+        message: 'Contacts imported successfully',
+        type: 'success',
+      })
+      await loadContacts(true)
+    } catch (error: unknown) {
+      notificationsStore.addNotification({
+        message: getApiErrorMessage(error, 'Error while importing contacts'),
+        type: 'error',
+      })
+      throw error
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function resetState() {
+    contacts.value = []
+    loading.value = false
+    search.value = ''
+  }
+
+  return {
+    contacts,
+    loading,
+    search,
+    total,
+    filteredContacts,
+    loadContacts,
+    saveContacts,
+    updateContact,
+    deleteContact,
+    uploadCsv,
+    resetState,
+  }
+})

--- a/web/app/stores/contacts.ts
+++ b/web/app/stores/contacts.ts
@@ -66,22 +66,25 @@ export const useContactsStore = defineStore('contacts', () => {
 
     loading.value = true
     try {
-      await apiFetch('/v1/contacts', {
-        method: 'POST',
-        body: contactsToSave,
-      })
+      try {
+        await apiFetch('/v1/contacts', {
+          method: 'POST',
+          body: contactsToSave,
+        })
+      } catch (error: unknown) {
+        notificationsStore.addNotification({
+          message: getApiErrorMessage(error, 'Error while saving contacts'),
+          type: 'error',
+        })
+        throw error
+      }
+
       notificationsStore.addNotification({
         message:
           contactsToSave.length > 1 ? 'Contacts created' : 'Contact created',
         type: 'success',
       })
       await loadContacts(true)
-    } catch (error: unknown) {
-      notificationsStore.addNotification({
-        message: getApiErrorMessage(error, 'Error while saving contacts'),
-        type: 'error',
-      })
-      throw error
     } finally {
       loading.value = false
     }
@@ -93,21 +96,24 @@ export const useContactsStore = defineStore('contacts', () => {
   ): Promise<void> {
     loading.value = true
     try {
-      await apiFetch(`/v1/contacts/${id}`, {
-        method: 'PUT',
-        body: payload,
-      })
+      try {
+        await apiFetch(`/v1/contacts/${id}`, {
+          method: 'PUT',
+          body: payload,
+        })
+      } catch (error: unknown) {
+        notificationsStore.addNotification({
+          message: getApiErrorMessage(error, 'Error while updating contact'),
+          type: 'error',
+        })
+        throw error
+      }
+
       notificationsStore.addNotification({
         message: 'Contact updated',
         type: 'success',
       })
       await loadContacts(true)
-    } catch (error: unknown) {
-      notificationsStore.addNotification({
-        message: getApiErrorMessage(error, 'Error while updating contact'),
-        type: 'error',
-      })
-      throw error
     } finally {
       loading.value = false
     }
@@ -136,24 +142,27 @@ export const useContactsStore = defineStore('contacts', () => {
   async function uploadCsv(file: File): Promise<void> {
     loading.value = true
     try {
-      const formData = new FormData()
-      formData.append('document', file)
+      try {
+        const formData = new FormData()
+        formData.append('document', file)
 
-      await apiFetch('/v1/contacts/upload', {
-        method: 'POST',
-        body: formData,
-      })
+        await apiFetch('/v1/contacts/upload', {
+          method: 'POST',
+          body: formData,
+        })
+      } catch (error: unknown) {
+        notificationsStore.addNotification({
+          message: getApiErrorMessage(error, 'Error while importing contacts'),
+          type: 'error',
+        })
+        throw error
+      }
+
       notificationsStore.addNotification({
         message: 'Contacts imported successfully',
         type: 'success',
       })
       await loadContacts(true)
-    } catch (error: unknown) {
-      notificationsStore.addNotification({
-        message: getApiErrorMessage(error, 'Error while importing contacts'),
-        type: 'error',
-      })
-      throw error
     } finally {
       loading.value = false
     }

--- a/web/app/stores/contacts.ts
+++ b/web/app/stores/contacts.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 import type { EntitiesContact } from '~~/shared/types/api'
 import { getApiErrorMessage } from '~/utils/api-error'
 
@@ -10,50 +10,71 @@ export interface ContactInput {
   properties?: Record<string, string>
 }
 
+export interface LoadContactsOptions {
+  force?: boolean
+  skip?: number
+  limit?: number
+}
+
+// DEFAULT_LIMIT mirrors the contacts page's initial items-per-page. It is only
+// used when a caller (e.g. a mutation refresh) does not specify its own limit.
+const DEFAULT_LIMIT = 10
+
 export const useContactsStore = defineStore('contacts', () => {
   const contacts = ref<EntitiesContact[]>([])
+  const total = ref(0)
   const loading = ref(false)
   const search = ref('')
   const { apiFetch } = useApi()
   const notificationsStore = useNotificationsStore()
   let loadContactsGeneration = 0
 
-  const total = computed(() => contacts.value.length)
+  // The pagination window last requested by the page. Mutation-triggered
+  // refreshes reuse it so the user stays on the page they were viewing.
+  let currentSkip = 0
+  let currentLimit = DEFAULT_LIMIT
 
-  const filteredContacts = computed<EntitiesContact[]>(() => {
-    const term = search.value.trim().toLowerCase()
-    if (!term) return contacts.value
+  function normalizeOptions(
+    options: LoadContactsOptions | boolean,
+  ): LoadContactsOptions {
+    if (typeof options === 'boolean') {
+      return { force: options }
+    }
+    return options
+  }
 
-    return contacts.value.filter((contact) => {
-      const name = contact.name.toLowerCase()
-      const emails = contact.emails.join(' ').toLowerCase()
-      const phoneNumbers = contact.phone_numbers.join(' ').toLowerCase()
+  async function loadContacts(
+    options: LoadContactsOptions | boolean = {},
+  ): Promise<void> {
+    const { force = false, skip, limit } = normalizeOptions(options)
 
-      return (
-        name.includes(term) ||
-        emails.includes(term) ||
-        phoneNumbers.includes(term)
-      )
-    })
-  })
+    if (skip !== undefined) {
+      currentSkip = skip
+    }
+    if (limit !== undefined) {
+      currentLimit = limit
+    }
 
-  async function loadContacts(force = false): Promise<void> {
     if (contacts.value.length > 0 && !force) return
 
     const generation = ++loadContactsGeneration
     loading.value = true
     try {
       const term = search.value.trim()
-      const params: Record<string, string | number> = { limit: 100 }
+      const params: Record<string, string | number> = {
+        skip: currentSkip,
+        limit: currentLimit,
+      }
       if (term) {
         params.query = term
       }
-      const response = await apiFetch<{ data: EntitiesContact[] }>(
-        '/v1/contacts',
-        { params },
-      )
+      const response = await apiFetch<{
+        data: EntitiesContact[]
+        total?: number
+      }>('/v1/contacts', { params })
       if (generation === loadContactsGeneration) {
         contacts.value = response.data ?? []
+        total.value = response.total ?? contacts.value.length
       }
     } catch (error: unknown) {
       if (generation !== loadContactsGeneration) {
@@ -135,7 +156,12 @@ export const useContactsStore = defineStore('contacts', () => {
     loading.value = true
     try {
       await apiFetch(`/v1/contacts/${id}`, { method: 'DELETE' })
+      // Invalidate any in-flight load so a stale response cannot resurrect the
+      // just-deleted contact. Bumping the generation makes loadContacts skip
+      // its assignment (and its finally toggling loading) for the older request.
+      loadContactsGeneration++
       contacts.value = contacts.value.filter((contact) => contact.id !== id)
+      total.value = Math.max(0, total.value - 1)
       notificationsStore.addNotification({
         message: 'Contact deleted',
         type: 'success',
@@ -183,16 +209,18 @@ export const useContactsStore = defineStore('contacts', () => {
   function resetState() {
     loadContactsGeneration++
     contacts.value = []
+    total.value = 0
     loading.value = false
     search.value = ''
+    currentSkip = 0
+    currentLimit = DEFAULT_LIMIT
   }
 
   return {
     contacts,
+    total,
     loading,
     search,
-    total,
-    filteredContacts,
     loadContacts,
     saveContacts,
     updateContact,

--- a/web/app/stores/contacts.ts
+++ b/web/app/stores/contacts.ts
@@ -41,11 +41,14 @@ export const useContactsStore = defineStore('contacts', () => {
 
     loading.value = true
     try {
+      const term = search.value.trim()
+      const params: Record<string, string | number> = { limit: 100 }
+      if (term) {
+        params.query = term
+      }
       const response = await apiFetch<{ data: EntitiesContact[] }>(
         '/v1/contacts',
-        {
-          params: { limit: 100 },
-        },
+        { params },
       )
       contacts.value = response.data ?? []
     } catch (error: unknown) {

--- a/web/app/stores/contacts.ts
+++ b/web/app/stores/contacts.ts
@@ -16,6 +16,7 @@ export const useContactsStore = defineStore('contacts', () => {
   const search = ref('')
   const { apiFetch } = useApi()
   const notificationsStore = useNotificationsStore()
+  let loadContactsGeneration = 0
 
   const total = computed(() => contacts.value.length)
 
@@ -39,6 +40,7 @@ export const useContactsStore = defineStore('contacts', () => {
   async function loadContacts(force = false): Promise<void> {
     if (contacts.value.length > 0 && !force) return
 
+    const generation = ++loadContactsGeneration
     loading.value = true
     try {
       const term = search.value.trim()
@@ -50,15 +52,22 @@ export const useContactsStore = defineStore('contacts', () => {
         '/v1/contacts',
         { params },
       )
-      contacts.value = response.data ?? []
+      if (generation === loadContactsGeneration) {
+        contacts.value = response.data ?? []
+      }
     } catch (error: unknown) {
+      if (generation !== loadContactsGeneration) {
+        return
+      }
       notificationsStore.addNotification({
         message: getApiErrorMessage(error, 'Error while loading contacts'),
         type: 'error',
       })
       throw error
     } finally {
-      loading.value = false
+      if (generation === loadContactsGeneration) {
+        loading.value = false
+      }
     }
   }
 
@@ -172,6 +181,7 @@ export const useContactsStore = defineStore('contacts', () => {
   }
 
   function resetState() {
+    loadContactsGeneration++
     contacts.value = []
     loading.value = false
     search.value = ''

--- a/web/app/stores/contacts.ts
+++ b/web/app/stores/contacts.ts
@@ -18,6 +18,10 @@ export interface LoadContactsOptions {
   sortDescending?: boolean
 }
 
+export interface ContactMutationOptions {
+  refresh?: boolean
+}
+
 // DEFAULT_LIMIT mirrors the contacts page's initial items-per-page. It is only
 // used when a caller (e.g. a mutation refresh) does not specify its own limit.
 const DEFAULT_LIMIT = 10
@@ -112,8 +116,10 @@ export const useContactsStore = defineStore('contacts', () => {
 
   async function saveContacts(
     items: ContactInput | ContactInput[],
+    options: ContactMutationOptions = {},
   ): Promise<void> {
     const contactsToSave = Array.isArray(items) ? items : [items]
+    const { refresh = true } = options
 
     loading.value = true
     try {
@@ -137,7 +143,9 @@ export const useContactsStore = defineStore('contacts', () => {
             : 'Contact created successfully',
         type: 'success',
       })
-      await loadContacts(true)
+      if (refresh) {
+        await loadContacts(true)
+      }
     } finally {
       loading.value = false
     }
@@ -146,7 +154,9 @@ export const useContactsStore = defineStore('contacts', () => {
   async function updateContact(
     id: string,
     payload: ContactInput,
+    options: ContactMutationOptions = {},
   ): Promise<void> {
+    const { refresh = true } = options
     loading.value = true
     try {
       try {
@@ -166,7 +176,9 @@ export const useContactsStore = defineStore('contacts', () => {
         message: 'Contact updated',
         type: 'success',
       })
-      await loadContacts(true)
+      if (refresh) {
+        await loadContacts(true)
+      }
     } finally {
       loading.value = false
     }

--- a/web/app/stores/contacts.ts
+++ b/web/app/stores/contacts.ts
@@ -132,7 +132,9 @@ export const useContactsStore = defineStore('contacts', () => {
 
       notificationsStore.addNotification({
         message:
-          contactsToSave.length > 1 ? 'Contacts created' : 'Contact created',
+          contactsToSave.length > 1
+            ? 'Contacts created successfully'
+            : 'Contact created successfully',
         type: 'success',
       })
       await loadContacts(true)
@@ -181,7 +183,7 @@ export const useContactsStore = defineStore('contacts', () => {
       contacts.value = contacts.value.filter((contact) => contact.id !== id)
       total.value = Math.max(0, total.value - 1)
       notificationsStore.addNotification({
-        message: 'Contact deleted',
+        message: 'Contact deleted successfully',
         type: 'success',
       })
     } catch (error: unknown) {

--- a/web/app/stores/contacts.ts
+++ b/web/app/stores/contacts.ts
@@ -14,6 +14,8 @@ export interface LoadContactsOptions {
   force?: boolean
   skip?: number
   limit?: number
+  sortBy?: 'name' | 'updated_at'
+  sortDescending?: boolean
 }
 
 // DEFAULT_LIMIT mirrors the contacts page's initial items-per-page. It is only
@@ -33,6 +35,8 @@ export const useContactsStore = defineStore('contacts', () => {
   // refreshes reuse it so the user stays on the page they were viewing.
   let currentSkip = 0
   let currentLimit = DEFAULT_LIMIT
+  let currentSortBy: 'name' | 'updated_at' = 'updated_at'
+  let currentSortDescending = true
 
   function normalizeOptions(
     options: LoadContactsOptions | boolean,
@@ -46,13 +50,25 @@ export const useContactsStore = defineStore('contacts', () => {
   async function loadContacts(
     options: LoadContactsOptions | boolean = {},
   ): Promise<void> {
-    const { force = false, skip, limit } = normalizeOptions(options)
+    const {
+      force = false,
+      skip,
+      limit,
+      sortBy,
+      sortDescending,
+    } = normalizeOptions(options)
 
     if (skip !== undefined) {
       currentSkip = skip
     }
     if (limit !== undefined) {
       currentLimit = limit
+    }
+    if (sortBy !== undefined) {
+      currentSortBy = sortBy
+    }
+    if (sortDescending !== undefined) {
+      currentSortDescending = sortDescending
     }
 
     if (contacts.value.length > 0 && !force) return
@@ -61,9 +77,11 @@ export const useContactsStore = defineStore('contacts', () => {
     loading.value = true
     try {
       const term = search.value.trim()
-      const params: Record<string, string | number> = {
+      const params: Record<string, string | number | boolean> = {
         skip: currentSkip,
         limit: currentLimit,
+        sort_by: currentSortBy,
+        sort_descending: currentSortDescending,
       }
       if (term) {
         params.query = term

--- a/web/app/stores/threads.ts
+++ b/web/app/stores/threads.ts
@@ -28,7 +28,19 @@ export const useThreadsStore = defineStore('threads', () => {
     const index = threads.value.findIndex(
       (thread) => thread.id === updatedThread.id,
     )
-    if (index !== -1) threads.value[index] = updatedThread
+    if (index !== -1) {
+      const existingThread = threads.value[index]
+      threads.value[index] = {
+        ...updatedThread,
+        // Mark-read PUT responses are not contact-enriched; keep the resolved
+        // contact so display names do not disappear after the thread updates.
+        contact_details:
+          updatedThread.contact_details ??
+          (updatedThread.contact === existingThread.contact
+            ? existingThread.contact_details
+            : undefined),
+      }
+    }
   }
 
   async function loadThreads() {
@@ -45,6 +57,7 @@ export const useThreadsStore = defineStore('threads', () => {
           owner: phonesStore.owner ?? phonesStore.phones[0]?.phone_number,
           limit: 100,
           is_archived: archivedThreads.value,
+          contacts: true,
         },
       },
     )

--- a/web/app/utils/filters.ts
+++ b/web/app/utils/filters.ts
@@ -1,4 +1,11 @@
-import { intervalToDuration, formatDuration } from 'date-fns'
+import {
+  intervalToDuration,
+  formatDuration,
+  differenceInSeconds,
+  differenceInMinutes,
+  differenceInDays,
+  differenceInHours,
+} from 'date-fns'
 import { parsePhoneNumber, isValidPhoneNumber } from 'libphonenumber-js'
 
 export function formatPhoneNumber(value: string): string {
@@ -102,4 +109,17 @@ export function humanizeTime(value: string): string {
 
 export function startsWithLetter(value: string): boolean {
   return /^[a-zA-Z]/.test(value)
+}
+
+export function humanizeTimeShort(date: string) {
+  const now = new Date()
+  const seconds = differenceInSeconds(now, new Date(date))
+  const minutes = differenceInMinutes(now, new Date(date))
+  const hours = differenceInHours(now, new Date(date))
+  const days = differenceInDays(now, new Date(date))
+
+  if (seconds < 60) return 'just now'
+  if (minutes < 60) return `${minutes} minute${minutes !== 1 ? 's' : ''} ago`
+  if (hours < 24) return `${hours} hour${hours !== 1 ? 's' : ''} ago`
+  return `${days} day${days !== 1 ? 's' : ''} ago`
 }

--- a/web/nuxt.config.ts
+++ b/web/nuxt.config.ts
@@ -97,6 +97,9 @@ export default defineNuxtConfig({
   },
 
   vuetify: {
+    moduleOptions: {
+      prefixComposables: true,
+    },
     vuetifyOptions: {
       theme: {
         defaultTheme: 'dark',

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 3.2.0(magicast@0.5.4)
       '@pinia/nuxt':
         specifier: ^0.11.3
-        version: 0.11.3(magicast@0.5.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))
+        version: 0.11.3(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
@@ -25,10 +25,10 @@ importers:
         version: 1.0.1(chart.js@4.5.1)(moment@2.30.1)
       date-fns:
         specifier: ^4.3.0
-        version: 4.3.0
+        version: 4.4.0
       firebase:
         specifier: ^12.13.0
-        version: 12.13.0
+        version: 12.17.1
       flag-icons:
         specifier: ^7.5.0
         version: 7.5.0
@@ -37,98 +37,94 @@ importers:
         version: 11.11.1
       libphonenumber-js:
         specifier: ^1.13.3
-        version: 1.13.3
+        version: 1.13.10
       moment:
         specifier: ^2.30.1
         version: 2.30.1
       nuxt:
         specifier: ^4.5.1
-        version: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.138.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.13.0(typescript@5.9.3))(terser@5.49.2)(tsx@4.22.3)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
+        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.8.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.142.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.102.0)(srvx@0.11.22)(stylelint@17.14.1(typescript@5.9.3))(terser@5.49.2)(tsx@4.23.10)(typescript@5.9.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(yaml@2.9.0)
       pinia:
         specifier: ^3.0.4
-        version: 3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
+        version: 3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3))
       prettier:
         specifier: ^3.8.4
-        version: 3.8.4
+        version: 3.9.6
       pusher-js:
         specifier: ^8.5.0
-        version: 8.5.0
+        version: 8.6.0
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
       sass:
         specifier: ^1.100.0
-        version: 1.100.0
+        version: 1.102.0
       v-phone-input:
         specifier: ^7.0.0
-        version: 7.0.0(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.34(typescript@5.9.3))
+        version: 7.0.0(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@5.9.3))
       vue:
         specifier: ^3.5.34
-        version: 3.5.34(typescript@5.9.3)
+        version: 3.5.41(typescript@5.9.3)
       vue-chartjs:
         specifier: ^5.3.3
-        version: 5.3.3(chart.js@4.5.1)(vue@3.5.34(typescript@5.9.3))
+        version: 5.3.4(chart.js@4.5.1)(vue@3.5.41(typescript@5.9.3))
       vue-router:
         specifier: ^5.0.7
-        version: 5.0.7(@vue/compiler-sfc@3.5.41)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
+        version: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.25.12)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       vuetify:
         specifier: ^4.0.7
-        version: 4.0.7(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.34(typescript@5.9.3))
+        version: 4.1.8(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@5.9.3))
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.0.2
-        version: 21.0.2(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
+        version: 21.2.1(@types/node@26.1.2)(conventional-commits-parser@7.1.2)(typescript@5.9.3)
       '@commitlint/config-conventional':
         specifier: ^21.0.2
-        version: 21.0.2
+        version: 21.2.0
       '@nuxt/eslint':
         specifier: ^1.16.0
-        version: 1.16.0(@typescript-eslint/utils@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+        version: 1.17.0(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(esbuild@0.25.12)(eslint@10.8.0(jiti@2.7.0))(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(srvx@0.11.22)(typescript@5.9.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       '@nuxtjs/seo':
         specifier: ^5.3.2
-        version: 5.3.2(cbbecbeff1ef288b5e7e848ce0fbb97f)
+        version: 5.3.10(d400cf9599512c720fc974c3468a396f)
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
       eslint:
         specifier: ^10.5.0
-        version: 10.5.0(jiti@2.7.0)
+        version: 10.8.0(jiti@2.7.0)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.5.0(jiti@2.7.0))
+        version: 10.1.8(eslint@10.8.0(jiti@2.7.0))
       husky:
         specifier: ^9.1.7
         version: 9.1.7
       lint-staged:
         specifier: ^17.0.8
-        version: 17.0.8
+        version: 17.3.0
       postcss-html:
         specifier: ^1.8.1
         version: 1.8.1
       stylelint:
         specifier: ^17.13.0
-        version: 17.13.0(typescript@5.9.3)
+        version: 17.14.1(typescript@5.9.3)
       stylelint-config-recommended-vue:
         specifier: ^1.6.1
-        version: 1.6.1(postcss-html@1.8.1)(stylelint@17.13.0(typescript@5.9.3))
+        version: 1.6.1(postcss-html@1.8.1)(stylelint@17.14.1(typescript@5.9.3))
       stylelint-config-standard:
         specifier: ^40.0.0
-        version: 40.0.0(stylelint@17.13.0(typescript@5.9.3))
+        version: 40.0.0(stylelint@17.14.1(typescript@5.9.3))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vuetify-nuxt-module:
         specifier: ^0.19.5
-        version: 0.19.5(magicast@0.5.4)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
+        version: 0.19.5(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(typescript@5.9.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
 
 packages:
 
-  '@alloc/quick-lru@5.2.0':
-    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
-    engines: {node: '>=10'}
-
-  '@antfu/install-pkg@1.1.0':
-    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+  '@antfu/install-pkg@2.0.1':
+    resolution: {integrity: sha512-iCKVQcIC0e3oDxEfs3SHQGW+ovhBMZmS1TE+bTk50rVyMCBmCfClv7Qi3HQKlumYwvjb/iIMeWCW2i67q6kFfQ==}
 
   '@antfu/utils@8.1.1':
     resolution: {integrity: sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==}
@@ -157,10 +153,6 @@ packages:
 
   '@babel/generator@8.0.0':
     resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
-  '@babel/generator@8.0.0-rc.6':
-    resolution: {integrity: sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-annotate-as-pure@7.29.7':
@@ -221,17 +213,9 @@ packages:
     resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
-  '@babel/helper-string-parser@8.0.0-rc.6':
-    resolution: {integrity: sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@8.0.0-rc.6':
-    resolution: {integrity: sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-identifier@8.0.4':
     resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
@@ -245,19 +229,9 @@ packages:
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.7':
-    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.8':
     resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@8.0.0-rc.6':
-    resolution: {integrity: sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog==}
-    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/parser@8.0.4':
@@ -291,17 +265,9 @@ packages:
     resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.29.7':
-    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/types@7.29.8':
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/types@8.0.0-rc.6':
-    resolution: {integrity: sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/types@8.0.4':
     resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
@@ -322,26 +288,14 @@ packages:
       commander:
         optional: true
 
-  '@cacheable/memory@2.0.9':
-    resolution: {integrity: sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==}
+  '@cacheable/memory@2.2.0':
+    resolution: {integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==}
 
-  '@cacheable/utils@2.4.1':
-    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
-
-  '@capsizecss/unpack@4.0.1':
-    resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
-    engines: {node: '>=18'}
-
-  '@clack/core@1.4.2':
-    resolution: {integrity: sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==}
-    engines: {node: '>= 20.12.0'}
+  '@cacheable/utils@2.5.0':
+    resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
 
   '@clack/core@1.4.3':
     resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
-    engines: {node: '>= 20.12.0'}
-
-  '@clack/prompts@1.6.0':
-    resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
     engines: {node: '>= 20.12.0'}
 
   '@clack/prompts@1.7.0':
@@ -355,89 +309,93 @@ packages:
   '@colordx/core@5.5.0':
     resolution: {integrity: sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==}
 
-  '@commitlint/cli@21.0.2':
-    resolution: {integrity: sha512-YMmfLbqBg+ZRvvmPhc+cilSQFrh/AgzVgCT1U/OifmUZEwPbvCtA8rN//YNaF9d5eoZphxVMGYtmwA2QgQORgg==}
+  '@commitlint/cli@21.2.1':
+    resolution: {integrity: sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
-  '@commitlint/config-conventional@21.0.2':
-    resolution: {integrity: sha512-P/ZRhryQmkj0Z0dY9FOoRwe3xkwJyyAdtXwt01NT2kuZttcG2CNYp1q5Ci3u+nDT2jcbJRw2kt13Czl1qKNPfg==}
+  '@commitlint/config-conventional@21.2.0':
+    resolution: {integrity: sha512-Qf8WRDVcyVd14if6VTWenebxFbKnVnbzPUJjlzjkyJGeHK2xCGd63Dr1XZzj0plXKQb9P0BfOxoc1HVeCo2BWQ==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/config-validator@21.0.1':
-    resolution: {integrity: sha512-Zd2UFdndeMMaW2O96HK0tdfT4gOImUvidMpAd/pws2zZ4m1nrAZ/9b/v2JYuE8fs86GpXv9F7LNaIuCIWhY+pA==}
+  '@commitlint/config-validator@21.2.0':
+    resolution: {integrity: sha512-t7AzNHAKeIdo/3NRGwzpufKHsKkPHmFs/56N2Fnsh0/r0rGtnQzTxk6vnFgjaGr4hdSQKNB50/KAhR9Yk4LJKA==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/ensure@21.0.1':
-    resolution: {integrity: sha512-jJ1037967wU7YN/xkv+iRlOBlmaOXPhPO5KQSqya6GyXzBlwuLzELBFao16DVg9dZyqmNrhewzwZ3SAibetHBQ==}
+  '@commitlint/ensure@21.2.0':
+    resolution: {integrity: sha512-76IF9vDNS13lAzEEik9eKwzt8f9hYhWiwVXZ2AnyLCz5/f511FsEQ3pw1X3/zSQpdRLQU7i5qDMVKyXi1GWjSg==}
     engines: {node: '>=22.12.0'}
 
   '@commitlint/execute-rule@21.0.1':
     resolution: {integrity: sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/format@21.0.1':
-    resolution: {integrity: sha512-ksmG2+cHGtuDPQQbhBbC4unwm444+6TiPw0d1bKf67hntgZqZ8E0g1MuYKUuyT5IH4IMmXZhKq22/Z3jBvtQIw==}
+  '@commitlint/format@21.2.0':
+    resolution: {integrity: sha512-c4q64xaav2U83t7k7RyzJerBZurPer7FxUOY0RL5L/6CZijZ7K+s6HIBGIghj0ey1P2+seRX0J9XQYtDued6tg==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/is-ignored@21.0.2':
-    resolution: {integrity: sha512-H5z4t8PC9tUsmZ/o+EptM3Nq8sTFtskAShdcqxCoyzklW5eaVT5xbrDAET2uypzir9Vsj4ZZmBtyKjYe2XqgeQ==}
+  '@commitlint/is-ignored@21.2.0':
+    resolution: {integrity: sha512-4/eB0vBN7L88O/oC4ajAEqi7j2ZfNgxl/+11RfAV9YosejZgDXhY2C9VcHnHJhOzPLoSy5P3Mg/46kqeyJfXKw==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/lint@21.0.2':
-    resolution: {integrity: sha512-PnUmLYGeGLfW8oVatR9KpNxSHYAnJOEWlMZzfdeFOUq6WUrFx1fGQaWCWJqMoIll/xPM+GdfJV+tKHZVHhl0Fg==}
+  '@commitlint/lint@21.2.0':
+    resolution: {integrity: sha512-ceO5dp9pLjEZ6y6qbq/uXWXDPykqqlTsyzoQ0NzecpisSJhK3kTy9qzQoPeJuWG/IMNdV1lO0RgmzqoAlSi1uw==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/load@21.0.2':
-    resolution: {integrity: sha512-lwUE70hN0/qE/ZRROhbaX65ly/FF12DrqfReLCESo37M0OQCFAf2jRS+2tSCSORq+bm4Kdju7qNDj46uc1QzTA==}
+  '@commitlint/load@21.2.0':
+    resolution: {integrity: sha512-RjlzWQqruRwIenJEfZtq7kG97co97nKoHpflE5YnF61tDLXxHPrdWImgzw6VL6MlFyaOcVlk74eBV8ZQmc3oIA==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/message@21.0.2':
-    resolution: {integrity: sha512-5n4aqHGD/FNnom/D5L8i7cYtV+xjuXcBL832C3w9VglEsZzIsoHpJsvxzJ7cgiOsOdc/2jU4t5+7qMHh7GBX3g==}
+  '@commitlint/message@21.2.0':
+    resolution: {integrity: sha512-YxGoiXD/HXNXLJPrQwE5poXa+XH0CBEm+mdvbHQP0g6MV/dmJyUFCzPNzZbxL93GvZ70TmtTK0Z0/IBpAqHv8g==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/parse@21.0.2':
-    resolution: {integrity: sha512-QVZJhGHTm+oiuWyEKOCTQ0ZM3mfJ0eGWFeHuj7WzSKEth+UukcCHac9GD8pgdFlg/qGkFWOtyaNd1T8REgagaw==}
+  '@commitlint/parse@21.2.0':
+    resolution: {integrity: sha512-QHWxG4d0PLTF634/AdyZ0MQS+CLn5YOuJlCFhMMlSGKFxzYGUetkHBj18xgBD+6fVzUrA2lrCdi/vlS2f/oYXg==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/read@21.0.2':
-    resolution: {integrity: sha512-BtsrnLVycSSKf4Q0gMch4giCj5NNlmcbhc8ra5vONgGtP2IjRDo33bEFtr5Pm+2N+5fXGWb2MksWPrspPfdhdw==}
+  '@commitlint/read@21.2.1':
+    resolution: {integrity: sha512-hUW7EJQnNTL0vPOmVMNK4CrnrNBN0nN+JJHReFkdHO5y4iyHeEmTBwuC15OCqUTjxWo7idnH1LftfpWVIaPWIA==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/resolve-extends@21.0.1':
-    resolution: {integrity: sha512-0DhjYWL6uYrY16Efa032fYk3woGJDU4AGWiG1XXltT9AMUNYKyb5cIZU2ivbaMZ3+kKFqUjikD2cjh66Sbh/Sg==}
+  '@commitlint/resolve-extends@21.2.0':
+    resolution: {integrity: sha512-4O/1j51+79Wth9s/MGxt/5gs0XYLDgNlYpltQfhAvLE0itusLKs9zruxbiNg1oOkmkb9L9L4USYGjEj7n87NxA==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/rules@21.0.2':
-    resolution: {integrity: sha512-k6tQ69Td7t2qUSIbik8D3TL1q3ZJpkEbV+yLogDzCRAdOxJm4ndhtBNREsLA1/puRfWvzS9eioF2w43WT+hHgQ==}
+  '@commitlint/rules@21.2.0':
+    resolution: {integrity: sha512-C2yXMNpiB8ETZKfx5JD8+ExgF8vTU1VQMKPSUUYwqKpw9oJWQBrlXBpdU038mj2WPjof7o9UzFpmTyBeGMZwZg==}
     engines: {node: '>=22.12.0'}
 
   '@commitlint/to-lines@21.0.1':
     resolution: {integrity: sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/top-level@21.0.2':
-    resolution: {integrity: sha512-s9KKM+e+mXgFeIh4n7KmOGAVT3mkJ3Fp1bBYHIK5pjeUwlEMzp/tZfb5u0Poa680AsQTXMEMRxZi1vQ9m2X5ug==}
+  '@commitlint/top-level@21.2.0':
+    resolution: {integrity: sha512-Y5gmQ+KxzqCrBFJfLvFEPvvwD3LDiNZoTT2yeFBm96M8qhmqSzQc5DvX3rheAaAMjyIvMXOCLS/mWfdpONsjyQ==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/types@21.0.1':
-    resolution: {integrity: sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==}
+  '@commitlint/types@21.2.0':
+    resolution: {integrity: sha512-7zVFCDB2reMvJH5dmbKnOQPjZEvjdJTH8jc0U/PIPU1r3/+vf5pD1HlfitV2MWsWXrvu7u39iY1lyLUPOaN0Gw==}
     engines: {node: '>=22.12.0'}
 
-  '@conventional-changelog/git-client@2.7.0':
-    resolution: {integrity: sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==}
-    engines: {node: '>=18'}
+  '@conventional-changelog/git-client@3.1.1':
+    resolution: {integrity: sha512-w/q+UIVdWQMgXlziPIYfPlyDud+H8kcvSCzDQQoc/gid7yZzb6eNfAkNN4UlEcS2cVVh924jevsOIb36d0In2g==}
+    engines: {node: '>=22'}
     peerDependencies:
-      conventional-commits-filter: ^5.0.0
-      conventional-commits-parser: ^6.4.0
+      conventional-commits-filter: ^6.0.1
+      conventional-commits-parser: ^7.1.2
     peerDependenciesMeta:
       conventional-commits-filter:
         optional: true
       conventional-commits-parser:
         optional: true
 
-  '@csstools/css-calc@3.2.1':
-    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+  '@conventional-changelog/template@1.2.1':
+    resolution: {integrity: sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==}
+    engines: {node: '>=22'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -449,8 +407,8 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.5':
-    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
     peerDependencies:
       css-tree: ^3.2.1
     peerDependenciesMeta:
@@ -468,8 +426,8 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/selector-resolve-nested@4.0.0':
-    resolution: {integrity: sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==}
+  '@csstools/selector-resolve-nested@4.0.1':
+    resolution: {integrity: sha512-j3vdQu0XwLME5qOTWxm8cnmvsf423R2YL6DbKklCHZwkDm7UdKNu6RPlw4REIJhSlKBICY3B70/7QZdicLqZgg==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       postcss-selector-parser: ^7.1.1
@@ -480,11 +438,6 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^7.1.1
 
-  '@devframes/hub@0.5.4':
-    resolution: {integrity: sha512-NZs5RFuNb6tjQd2JBsRYQT+OqE+z16Kg9/72HG4k+uJdzK90sAGtAjOwK8bsvav/9l85KGx4agfkgxnfbl313w==}
-    peerDependencies:
-      devframe: 0.5.4
-
   '@dxup/nuxt@0.5.6':
     resolution: {integrity: sha512-uZjAFoocWtWHr7YP9jm6FqwI8kjX2QN9bjcncoZt0GS+zExIAP3Ewv6EqEUvVP7w9pjZE+T19QxLHeoacN/MNg==}
 
@@ -494,17 +447,17 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/core@1.11.1':
-    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/runtime@1.11.1':
-    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
-
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -512,8 +465,8 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
-  '@es-joy/jsdoccomment@0.87.0':
-    resolution: {integrity: sha512-mFXZloZMzuJZXSHUmAFu/pXTk0ZJTJBluuAkrvbzidpTN8W6F2bpRFuedSH+85kbdlRLJqc+gfN+kD3JOLJK5g==}
+  '@es-joy/jsdoccomment@0.91.0':
+    resolution: {integrity: sha512-vgqlMGNNhZxwDYbUNIHj3Hskb4R28iqdXx90ufHyt/NeuTQkeqjTDslAs9I0/GCAfbxP5BpH5WsL1R1fht5Lxg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@es-joy/resolve.exports@1.2.0':
@@ -522,12 +475,6 @@ packages:
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -544,12 +491,6 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
@@ -558,12 +499,6 @@ packages:
 
   '@esbuild/android-arm@0.25.12':
     resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -580,12 +515,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
@@ -594,12 +523,6 @@ packages:
 
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -616,12 +539,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
   '@esbuild/darwin-x64@0.28.1':
     resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
@@ -630,12 +547,6 @@ packages:
 
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -652,12 +563,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
   '@esbuild/freebsd-x64@0.28.1':
     resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
@@ -666,12 +571,6 @@ packages:
 
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -688,12 +587,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
   '@esbuild/linux-arm@0.28.1':
     resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
@@ -702,12 +595,6 @@ packages:
 
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -724,12 +611,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
   '@esbuild/linux-loong64@0.28.1':
     resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
@@ -738,12 +619,6 @@ packages:
 
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -760,12 +635,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
   '@esbuild/linux-ppc64@0.28.1':
     resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
@@ -774,12 +643,6 @@ packages:
 
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -796,12 +659,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.28.1':
     resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
@@ -810,12 +667,6 @@ packages:
 
   '@esbuild/linux-x64@0.25.12':
     resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -832,12 +683,6 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.28.1':
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
@@ -846,12 +691,6 @@ packages:
 
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -868,12 +707,6 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.28.1':
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
@@ -882,12 +715,6 @@ packages:
 
   '@esbuild/openbsd-x64@0.25.12':
     resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -904,12 +731,6 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/openharmony-arm64@0.28.1':
     resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
@@ -918,12 +739,6 @@ packages:
 
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -940,12 +755,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
@@ -954,12 +763,6 @@ packages:
 
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -976,20 +779,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
   '@esbuild/win32-x64@0.28.1':
     resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.9.1':
-    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+  '@eslint-community/eslint-utils@4.10.1':
+    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
@@ -1015,12 +812,12 @@ packages:
     resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.6.0':
-    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-inspector@3.0.4':
-    resolution: {integrity: sha512-qyb1cjiiwD2mlg5GJC4JiO/EOO/rvEtm+GgLtgJ054bu8ZPj6hK1PLCRzxOnBghlPKWVqSjs4i+fXoPkt488Yw==}
+  '@eslint/config-inspector@3.2.0':
+    resolution: {integrity: sha512-kylJhcii8eDOiRFPANNUHOyDebBIOt+nqYXt8q6W9FbhYzFJAXjLzJz6KFNzY0WvIyOBKdbSQdwdPNrkMh05tg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1028,6 +825,10 @@ packages:
 
   '@eslint/core@1.2.1':
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/css-tree@4.0.5':
+    resolution: {integrity: sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/js@10.0.1':
@@ -1050,30 +851,32 @@ packages:
   '@fingerprintjs/botd@2.0.0':
     resolution: {integrity: sha512-yhuz23NKEcBDTHmGz/ULrXlGnbHenO+xZmVwuBkuqHUkqvaZ5TAA0kAgcRy4Wyo5dIBdkIf57UXX8/c9UlMLJg==}
 
-  '@firebase/ai@2.12.0':
-    resolution: {integrity: sha512-b+OL4vdyiSLZL/7dLd67V55CjKJvU9MpNmwnday7eA6GG2+J4iwUEsEHgw0/jKY3A41FfkF0SrnYFvtKbQZ65A==}
+  '@firebase/ai@2.14.0':
+    resolution: {integrity: sha512-TYEQqCQUTyVHuG/HVi9vau6F9kvEaS49o/hmdn/yUuN6ZXQkwIml2nNJTIBfjNl/r9LOxwUNILgcOY16nxObug==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@firebase/app': 0.x
       '@firebase/app-types': 0.x
 
-  '@firebase/analytics-compat@0.2.28':
-    resolution: {integrity: sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==}
+  '@firebase/analytics-compat@0.2.29':
+    resolution: {integrity: sha512-allztvCvCUlItZzD97TiRAtGoFJzR1FQFmLxbaLc6PvgscqD9cl5NdKPTtka6keShVYXvCZJpzWcRoH4TME8rw==}
     peerDependencies:
+      '@firebase/app': 0.x
       '@firebase/app-compat': 0.x
 
   '@firebase/analytics-types@0.8.4':
     resolution: {integrity: sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==}
 
-  '@firebase/analytics@0.10.22':
-    resolution: {integrity: sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==}
+  '@firebase/analytics@0.10.23':
+    resolution: {integrity: sha512-34ALWXzWA6PTRUA5hipZmsm1RKzeecw5J1+qTCXsiMzwLqONC+GuTIQSdmm91MmTAEA+wG1Q5t0IFahcYQOqAA==}
     peerDependencies:
       '@firebase/app': 0.x
 
-  '@firebase/app-check-compat@0.4.3':
-    resolution: {integrity: sha512-L3AKIRTJxT9b7cDUH3OyV8gWTnmW3vYkwdzRsukWt4kbPBTct12xalnyvHDkm1lKkr+cQq/4uzBx1bOWsQ2ciw==}
+  '@firebase/app-check-compat@0.4.6':
+    resolution: {integrity: sha512-2pzNEZEkX84jSqy6TH6FI1HSLA1lc7kakRUybBbKjg9YhIttPlW/XX3N9CDtChji2PTTPWVPZiWhB10exHfA+A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
+      '@firebase/app': 0.x
       '@firebase/app-compat': 0.x
 
   '@firebase/app-check-interop-types@0.3.4':
@@ -1082,27 +885,28 @@ packages:
   '@firebase/app-check-types@0.5.4':
     resolution: {integrity: sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==}
 
-  '@firebase/app-check@0.11.3':
-    resolution: {integrity: sha512-aJ4DfubWfTO8/2vhEhIAizOoOmiycESTU32e+OUgbWcS/G3PA4Vxlr/9zaiN2wfUG2AptQ7DTvj00tyuFZP5Bg==}
+  '@firebase/app-check@0.13.0':
+    resolution: {integrity: sha512-AbMttBKazQvGVXBZhQdVAdPzRhwHyJAY3Ghu5y2C7IZKIDIppzNYz0shTZ1mP4FBJa+28BuC4t+5h1Q6pT3Asg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@firebase/app': 0.x
 
-  '@firebase/app-compat@0.5.12':
-    resolution: {integrity: sha512-Pe513OBerK/CIBxz4/za9atd5MsZtd6DzHz4cmqkvkrcDWhQChAoHBpZ3McuZNuSP8YZiKwfX/J1frR07l15/w==}
+  '@firebase/app-compat@0.5.16':
+    resolution: {integrity: sha512-shQq37O8qELDzvsVwYPlDXwD1zlcrZ0m2bpBF5ov2HSbY8x+AHsnL5TtJ2e1JAfkQN05qHao1AfabS69PN6GiA==}
     engines: {node: '>=20.0.0'}
 
   '@firebase/app-types@0.9.5':
     resolution: {integrity: sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==}
 
-  '@firebase/app@0.14.12':
-    resolution: {integrity: sha512-FT+HoNp1NdaZ/N26hCwV3WbxS1m6gTn3p2QRBQ3KH7YqyCQqJx0iT7126RgVk68/Rq+9DeL/zCFnHZ0C4u1nLQ==}
+  '@firebase/app@0.16.0':
+    resolution: {integrity: sha512-G+ZGEyVP8YTb3ay6A+XpcYgFH3sTESHcnHU/EyTktodqhz2BHkLq+QEP7IVwjiMX0cxYwpVKip0/wC0KZcn9vQ==}
     engines: {node: '>=20.0.0'}
 
-  '@firebase/auth-compat@0.6.6':
-    resolution: {integrity: sha512-KDJ/GAf/rt7galOpn3DRb2buFfGkZCsHTryKjXDG0eeRnok4+2B4nnkMOMdjRnPkElmcJv2Ao0vEA6kp5m98PQ==}
+  '@firebase/auth-compat@0.6.9':
+    resolution: {integrity: sha512-/hHeTBmQ61+N5J1RECls+WfskZTY78JXr7aO5EMOfUpqJvDqvoS+568k0rp6Ss/4UWwBjadILs+H+SGy1zCS3A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
+      '@firebase/app': 0.x
       '@firebase/app-compat': 0.x
 
   '@firebase/auth-interop-types@0.2.5':
@@ -1114,8 +918,8 @@ packages:
       '@firebase/app-types': 0.x
       '@firebase/util': 1.x
 
-  '@firebase/auth@1.13.1':
-    resolution: {integrity: sha512-/1nkKY/MicI+I9WWcx6R4NKs77AaW9NQ0IwsFdUBomWrW0/cXEmopfM2dtLm2oI1qG6z6vom3CXZDHJIJXoMuw==}
+  '@firebase/auth@1.13.4':
+    resolution: {integrity: sha512-s+NS1aV0DDyyfoIMeSz53HXnVTv7ufJjJfrP63XyaWHweJ5vOoxKWrTm5tO7S7PDqvyOa/Wi3oP0dgAo6JTMMA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@firebase/app': 0.x
@@ -1124,30 +928,39 @@ packages:
       '@react-native-async-storage/async-storage':
         optional: true
 
-  '@firebase/component@0.7.3':
-    resolution: {integrity: sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==}
+  '@firebase/component@0.7.4':
+    resolution: {integrity: sha512-tLpOaaCol9ugUIYp2R3CbWPPA8Ajg/papX/XHEy8U52b/QXH3BbX8tTJX9aShDCjp+9sMAxMLD94i7lresdugQ==}
     engines: {node: '>=20.0.0'}
 
-  '@firebase/data-connect@0.7.0':
-    resolution: {integrity: sha512-ar9sNOJh5poQCSMSVlnVE8eo8+usTD1POWDCv65omkKUvnFMcdXaQ7J/e7WGKqJzcEMgiezSX/TZiKHZkItMbQ==}
+  '@firebase/data-connect@0.7.3':
+    resolution: {integrity: sha512-nHBFk3Ntl+NZCRIUG2d5j7I69P0otjyQ/duhVKLbw4+5cNke/F6RK1pdE5Jnf831/QOTs2Bd00LlxlZ+jNsb9w==}
     peerDependencies:
       '@firebase/app': 0.x
 
-  '@firebase/database-compat@2.1.4':
-    resolution: {integrity: sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==}
-    engines: {node: '>=20.0.0'}
-
-  '@firebase/database-types@1.0.20':
-    resolution: {integrity: sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==}
-
-  '@firebase/database@1.1.3':
-    resolution: {integrity: sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==}
-    engines: {node: '>=20.0.0'}
-
-  '@firebase/firestore-compat@0.4.9':
-    resolution: {integrity: sha512-NPtBuFr79BbIQJXFWhW4xFC6rBksK8/ewqCTYbbAYfZBDDx0/iHTUj4WpKi5D4d0Pn2Md/3T/e5V9379G5N/Zg==}
+  '@firebase/database-compat@2.1.6':
+    resolution: {integrity: sha512-mu7S/75UIajB1A5M9Vfojk69LttW55uABp9nHEtWrV/mIaSEwvoaIe9GySsEzS2EKFK5/3f5okcAuUbihhYeJg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-compat': 0.x
+    peerDependenciesMeta:
+      '@firebase/app':
+        optional: true
+      '@firebase/app-compat':
+        optional: true
+
+  '@firebase/database-types@1.0.21':
+    resolution: {integrity: sha512-SX1jUqhttKgg/m9dYRTvqU9QvucBooziWfA986r4cpsbi4zlsvewe424j3Vpduwd6DG1MSAMfBVT2VqA61FnkA==}
+
+  '@firebase/database@1.1.4':
+    resolution: {integrity: sha512-D+j4+8uhGtNd1tVD+X+c8JrC4ppStGJKyujSQt2NPwdN26QcCk0BeIxue+UqspHkHiFHyQOimwlzjLewGq6S+A==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/firestore-compat@0.4.12':
+    resolution: {integrity: sha512-k2uX81Ao/S0jnFcWGPOQpKK1cPlJHvD9WIqh/RE1XBDP2yg5zhE4rHhSg1rtB11k39q3nKon9XLNDDrPjGclag==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
       '@firebase/app-compat': 0.x
 
   '@firebase/firestore-types@3.0.4':
@@ -1156,30 +969,32 @@ packages:
       '@firebase/app-types': 0.x
       '@firebase/util': 1.x
 
-  '@firebase/firestore@4.14.1':
-    resolution: {integrity: sha512-PouS0NJZ3NYOZE/tPDvXa8VUeJ10Ll//7jIdFvMYdhQkd/P3O7nlqhyoTmY0h8Xa9hxg+H0j6gxUytJcoZ9YOg==}
+  '@firebase/firestore@4.17.0':
+    resolution: {integrity: sha512-P9tof6pyO1bnLlMWbux+5O7WFJqlb7OTPMKxxOiXKYiQl7mxykAvxr1BFCgWeEXUU7DZxQncyJ040B0IhFVZCg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@firebase/app': 0.x
 
-  '@firebase/functions-compat@0.4.4':
-    resolution: {integrity: sha512-Be+MwhseVf/eFAZwGrFJGok6S7cmsLrAPK8MgyM8LjM0MewTsx2n01WOOca9jio1UsCZOJ0aVyQobnINcdNuIQ==}
+  '@firebase/functions-compat@0.4.6':
+    resolution: {integrity: sha512-dj9sOet+FIU91jeU4A3vGJoXHty7NqkSfjRLCwLgJXPDk1m72KFuxD3nlFgw/yXx/Fr7UjqzbxZ0LrIOdpx7+w==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
+      '@firebase/app': 0.x
       '@firebase/app-compat': 0.x
 
   '@firebase/functions-types@0.6.4':
     resolution: {integrity: sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==}
 
-  '@firebase/functions@0.13.4':
-    resolution: {integrity: sha512-oB5rpm2Emxn2+IS1gRelAeT/5tSZMwM/KhqC5LnJsmTNnS1ZDhD7ZMZNgCI8vchTW6PbaXIwEnpUryGuIQsNbg==}
+  '@firebase/functions@0.13.6':
+    resolution: {integrity: sha512-9obLnzeQUivK5lmtGFOU2ucQ38BjTp+jpPtbfFp/mDsdVCvEpRqdWNvMMQ6aQwR4vcVc/utsvngm5BRkXbc7ZA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@firebase/app': 0.x
 
-  '@firebase/installations-compat@0.2.22':
-    resolution: {integrity: sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==}
+  '@firebase/installations-compat@0.2.23':
+    resolution: {integrity: sha512-isaXmjb9roM83eVeXAe+ZRNKYNsSo2s0aNM+cy04AAGEyVL/d8Aa11GwEXovRFeYjl9+1yRAOxRDTOukZRwTxA==}
     peerDependencies:
+      '@firebase/app': 0.x
       '@firebase/app-compat': 0.x
 
   '@firebase/installations-types@0.5.4':
@@ -1187,8 +1002,8 @@ packages:
     peerDependencies:
       '@firebase/app-types': 0.x
 
-  '@firebase/installations@0.6.22':
-    resolution: {integrity: sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==}
+  '@firebase/installations@0.6.23':
+    resolution: {integrity: sha512-MBkbcQfd+3qHjW+slsH4s7jH5qTdGlYpwqmxEZ7QcIpgDxu1SKyU0f+mCZhCt1BCacLNiOWF5L0R06N0LtlfMg==}
     peerDependencies:
       '@firebase/app': 0.x
 
@@ -1196,49 +1011,53 @@ packages:
     resolution: {integrity: sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==}
     engines: {node: '>=20.0.0'}
 
-  '@firebase/messaging-compat@0.2.26':
-    resolution: {integrity: sha512-fn0XvWOfK4tsDLSipwJUW9Cp6ahWA6z+iJHxZ0pHp9MzMSUNQx85yuxZAuI7gkGXfqs7+DqEDHyyS7jDGswrmQ==}
+  '@firebase/messaging-compat@0.2.28':
+    resolution: {integrity: sha512-/AmMqHRnSQhPsdeED3ocs+s30/tpFvZDiiwIYY2uXFRvLujo1fnbPOeCFoe4Y+dRy1LCSjpvJf+dy5ZTsxi1yg==}
     peerDependencies:
+      '@firebase/app': 0.x
       '@firebase/app-compat': 0.x
 
-  '@firebase/messaging-interop-types@0.2.4':
-    resolution: {integrity: sha512-wrzITQq+xw5LtygX7O0fu43/k9ABQ4x5H9/sR5m1SbNnhIRI5xd3+raSNJaJkYC4BUhM9A4ZNSnyR2sjhxnb2Q==}
+  '@firebase/messaging-interop-types@0.2.5':
+    resolution: {integrity: sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw==}
 
-  '@firebase/messaging@0.12.26':
-    resolution: {integrity: sha512-lHVTO9uLofymHVWkYeUtMddIPcmJvSzVbHRB88W6XKfxbcKF+p3QrfqKhDxremSB4NQjUla1Gwn7d9umSMmt/w==}
+  '@firebase/messaging@0.13.1':
+    resolution: {integrity: sha512-kL8fdjbNBI7hprlXJrUjktDWosrpT4JtfwXtVVevImPF/rBRAsC+LS/jIs+kgQVuotnvMhaBCgAFipBoY9YU9g==}
     peerDependencies:
       '@firebase/app': 0.x
 
-  '@firebase/performance-compat@0.2.25':
-    resolution: {integrity: sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==}
+  '@firebase/performance-compat@0.2.26':
+    resolution: {integrity: sha512-jgoocXLN6ao26xWQ8pzosmzQ33uLzGBJQPNK0NTbVy1XvIHr5pfgBf9hWLOxsWe+R7sJq5bjD+8ybXprmt61mA==}
     peerDependencies:
+      '@firebase/app': 0.x
       '@firebase/app-compat': 0.x
 
   '@firebase/performance-types@0.2.4':
     resolution: {integrity: sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==}
 
-  '@firebase/performance@0.7.12':
-    resolution: {integrity: sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==}
+  '@firebase/performance@0.7.13':
+    resolution: {integrity: sha512-1u6fuXP9cj0s+lkTFAspr/ttfPebPbEdpx+5Wdr4mPZbp8qH2KCMxOddEAR1ZMRa5GI0E7hDYSnolEmbqOFOAg==}
     peerDependencies:
       '@firebase/app': 0.x
 
-  '@firebase/remote-config-compat@0.2.24':
-    resolution: {integrity: sha512-EWZTt6fJ7YmPHodQNsSxAIDZY2x8P5kRPvXAc5CmzzBm+NyPFhODbfDsNllDXDL8jlzp50bVWjDY+BXepZS9Mg==}
+  '@firebase/remote-config-compat@0.2.28':
+    resolution: {integrity: sha512-kEO9Gn6fbmVj7eNUtZ6d59mLgUDUD0qo7aCicGOWNfuRWTaUv3CF9DMYychO61zaEQ3cfA+CEny4V1E8A1gRGA==}
     peerDependencies:
+      '@firebase/app': 0.x
       '@firebase/app-compat': 0.x
 
   '@firebase/remote-config-types@0.5.1':
     resolution: {integrity: sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==}
 
-  '@firebase/remote-config@0.8.3':
-    resolution: {integrity: sha512-ggGKAaLy9YNOvpFoQZgm5p5SiFw3ZFtwti08dojnBQmQicpThTxvG5xZMSpCTYMj2o3gM/yK9CVd2w+kZub8YA==}
+  '@firebase/remote-config@0.9.1':
+    resolution: {integrity: sha512-nzQUSJnk1zAZEl2Q5O3I7Z61cYLK5JI4H6wyyOiHkVZ+bmgy1YXNNMptNbVjixMQ/eCzgA6nZRaC+1eBcJGUFA==}
     peerDependencies:
       '@firebase/app': 0.x
 
-  '@firebase/storage-compat@0.4.3':
-    resolution: {integrity: sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==}
+  '@firebase/storage-compat@0.4.4':
+    resolution: {integrity: sha512-qSRgCB9f2R/nCp8t/8OC101cIFBFeUazlRInOMdzbnLzvrQBzEfx19SrR4pvdj/0+M+P/y8AK/a2s+3EB+B1Pw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
+      '@firebase/app': 0.x
       '@firebase/app-compat': 0.x
 
   '@firebase/storage-types@0.8.4':
@@ -1247,39 +1066,18 @@ packages:
       '@firebase/app-types': 0.x
       '@firebase/util': 1.x
 
-  '@firebase/storage@0.14.3':
-    resolution: {integrity: sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==}
+  '@firebase/storage@0.14.4':
+    resolution: {integrity: sha512-jfzEWZb3Fpsq3FwAB2ifoc8mcSh935qXdDou3TpyjDWa45hhNcZUv8/w28/10njByhfK7snbakKN30nwnzQ3/w==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@firebase/app': 0.x
 
-  '@firebase/util@1.15.1':
-    resolution: {integrity: sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==}
+  '@firebase/util@1.15.2':
+    resolution: {integrity: sha512-974pWIZVLDMc5GW5YAsj8y0XxULxIy/sPUy7tsxmWbF93KRIyh9xpuHlh0zDL+shUcf5nHDjFOg9YLiQ763eiA==}
     engines: {node: '>=20.0.0'}
 
   '@firebase/webchannel-wrapper@1.0.6':
     resolution: {integrity: sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==}
-
-  '@floating-ui/core@1.7.5':
-    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
-
-  '@floating-ui/core@1.8.0':
-    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
-
-  '@floating-ui/dom@1.7.6':
-    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
-
-  '@floating-ui/dom@1.8.0':
-    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
-
-  '@floating-ui/utils@0.2.11':
-    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
-
-  '@floating-ui/utils@0.2.12':
-    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
-
-  '@floating-ui/vue@1.1.11':
-    resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
 
   '@grpc/grpc-js@1.9.16':
     resolution: {integrity: sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==}
@@ -1309,23 +1107,6 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
-
-  '@iconify-json/carbon@1.2.24':
-    resolution: {integrity: sha512-b7u/eTWE3xFa7UXlRJBSEm6At1y6+F0P3imBEip5/8QeRzouxVjBf80Y2xnu1GYsFo9MYlHA0bZfxxMd5givfw==}
-
-  '@iconify/collections@1.0.705':
-    resolution: {integrity: sha512-JyUTM5/vqZfnUwtM18kh3nUB82A8QYHDLQj5zEZAvgR3hFdZvDhlH0LEdqOYKHWMTNW5l16EiiY2kstuw/EiTQ==}
-
-  '@iconify/types@2.0.0':
-    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
-
-  '@iconify/utils@3.1.3':
-    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
-
-  '@iconify/vue@5.0.1':
-    resolution: {integrity: sha512-aumwwooJlFJ5H5qYWB6ZTAyM0C8hpfcSVLB9/a3qnH1GGvIJ+FEbpEs4s/HfErYe/M5qZeLjwmESR5fFm3lXEw==}
-    peerDependencies:
-      vue: '>=3.0.0'
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1489,12 +1270,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@internationalized/date@3.12.2':
-    resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
-
-  '@internationalized/number@3.6.7':
-    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
-
   '@ioredis/commands@1.10.0':
     resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
 
@@ -1558,20 +1333,15 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+  '@napi-rs/wasm-runtime@1.2.2':
+    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
     peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
-  '@napi-rs/wasm-runtime@1.1.6':
-    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
-  '@nodable/entities@2.2.0':
-    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1598,18 +1368,13 @@ packages:
   '@nuxt/devalue@2.0.2':
     resolution: {integrity: sha512-GBzP8zOc7CGWyFQS6dv1lQz8VVpz5C2yRszbXufwG/9zhStTIH50EtD87NmWbTMwXDvZLNg8GIpb1UFdH93JCA==}
 
-  '@nuxt/devtools-kit@3.2.4':
-    resolution: {integrity: sha512-Yxy2Xgmq5hf3dQy983V0xh0OJV2mYwRZz9eVIGc3EaribdFGPDNGMMbYqX9qCty3Pbxn/bCF3J0UyPaNlHVayQ==}
-    peerDependencies:
-      vite: '>=6.0'
-
   '@nuxt/devtools-kit@3.4.1':
     resolution: {integrity: sha512-6ltPm2yUW8GvDdf3VJna7+flLi+ej7xRfSr+S4ovevKt/CuPf9EqYOn1jW7Kw/U1MXt/71zkn+/O2vu3G6O9Hg==}
     peerDependencies:
       vite: '>=6.0'
 
-  '@nuxt/devtools-kit@4.0.0-alpha.3':
-    resolution: {integrity: sha512-ymp4jqS3hFfwRw8uDkv8cpu4kWvhQrX+S4jnA/oOc76s4AXf2HCZZJgrncKxh+txqi1NJj8nsQNBbaqRAo3g4w==}
+  '@nuxt/devtools-kit@4.0.0-alpha.7':
+    resolution: {integrity: sha512-Tgh+tSejh1GnZjdjgWyc4qCxskeX08XuSQBYMn/4SIV5AubeqYeAOMBD2qSmHOXjMCUpgyzpEhODcP3sgdgGRA==}
     peerDependencies:
       vite: '>=6.0'
 
@@ -1627,8 +1392,8 @@ packages:
       '@vitejs/devtools':
         optional: true
 
-  '@nuxt/eslint-config@1.16.0':
-    resolution: {integrity: sha512-YWEqctFWoKOUTaHWXe6TaUgZ1ewN7jeKz/ni4JopxDGIQ8AIMMST6VMWryybHqbPzEfpx8sEcAAFGM4W4quYhQ==}
+  '@nuxt/eslint-config@1.17.0':
+    resolution: {integrity: sha512-5lHecnGvi7RxGsR3Amvnl47bxb3F4wFD9KQgbbmhd6prz3OAAbgQio9EK88tPyNHt7+dxIFFOnCH6TJNl/QbqQ==}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
       eslint-plugin-format: '*'
@@ -1636,13 +1401,13 @@ packages:
       eslint-plugin-format:
         optional: true
 
-  '@nuxt/eslint-plugin@1.16.0':
-    resolution: {integrity: sha512-vbX9EsJqTqIRwf3+sv9mJ/OtFKhH8o8NIbNF9Q6weQZY1MRf8jGEvLnjsyJa5VEEHl5TXSXsPcyrmIK58jsRpw==}
+  '@nuxt/eslint-plugin@1.17.0':
+    resolution: {integrity: sha512-h/fn4K09tA5tvdLj9Zlu5mb3TOVO2zLAetCsfJ1/LLVm2XWtgDVhfSB+Sm93cF1rCGxahmHZd4RJz2nAsWTDvg==}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
 
-  '@nuxt/eslint@1.16.0':
-    resolution: {integrity: sha512-VlZBHG86xUY72pZMcZ98cDtsUj972vZ23Pd4wqpxMLgLJ3RtHxQke0vgD/6PZ6uJsRjh7CAUGpsp2+d26ZdaSA==}
+  '@nuxt/eslint@1.17.0':
+    resolution: {integrity: sha512-54aD2xJvI2QJnHvQwN22hEgE/izF5ez+diPE7yLCJskKQ0tqPrNJCcRjBtuFQmQMQjTfHESsfuFdLfwMGUz8bw==}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
       eslint-webpack-plugin: ^4.1.0
@@ -1653,36 +1418,22 @@ packages:
       vite-plugin-eslint2:
         optional: true
 
-  '@nuxt/fonts@0.14.0':
-    resolution: {integrity: sha512-4uXQl9fa5F4ibdgU8zomoOcyMdnwgdem+Pi8JEqeDYI5yPR32Kam6HnuRr47dTb97CstaepAvXPWQUUHMtjsFQ==}
-
-  '@nuxt/icon@2.3.1':
-    resolution: {integrity: sha512-ebx7Zp08eR0Mw3zFAh3aT+t5zC4RoI0Xf0wLEfbv23LIPUQ9fvxYpofNiNZdG9m96Fvc3pQu6v+NaCRbRYRRog==}
-
-  '@nuxt/kit@3.21.6':
-    resolution: {integrity: sha512-5VOwxUcoM/z6w4c75hQrikHpY+TzjTLZQ+QnuO7KajyGx0IJBLVy1lw25oy79leF+GgyjJJO1cHfUfWeuEDCzA==}
+  '@nuxt/kit@3.21.11':
+    resolution: {integrity: sha512-0Xi3tgwN77w43Q8GCPIrvWmF1J7Peehkts44E0uKNIml9lB8WoUn8YxyUjxBv47XtVR86NWoWALAT+/IEMHJEA==}
     engines: {node: '>=18.12.0'}
 
-  '@nuxt/kit@4.4.6':
-    resolution: {integrity: sha512-AzsqBJeG7b3whIciyzkz4nBossEotM314KzKAptc8kH07ORBIR8Qh3QYKepo2YZwtxiDP2Y9aqzAztwpSEDHtw==}
+  '@nuxt/kit@4.5.2':
+    resolution: {integrity: sha512-l66LU9DcJYjmNwqwAj2I5UGRrUbnG2DOKGChnN70zIGtn0eq/z87gi/FRgha6eMb9/FmB1PFHgtx6PWVml1C2Q==}
     engines: {node: '>=18.12.0'}
 
-  '@nuxt/kit@4.4.8':
-    resolution: {integrity: sha512-ZUlZ5iYfyfJFDPluhn6ZxFWcsuxWbLnZBc8w3MAROcQ4lYfZ+qFpALBLSNlpc0zhOa++33EE+5PEbOAdVIY+dw==}
-    engines: {node: '>=18.12.0'}
-
-  '@nuxt/kit@4.5.1':
-    resolution: {integrity: sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==}
-    engines: {node: '>=18.12.0'}
-
-  '@nuxt/nitro-server@4.5.1':
-    resolution: {integrity: sha512-bYg+Rri9qLNiNnK70mvdghwwWtOEvlvBn3BnnEZWEFM8A51zM803Ltg+TwR6B6/1jdYOdZ6cnso4pvpCJuPlww==}
+  '@nuxt/nitro-server@4.5.2':
+    resolution: {integrity: sha512-sx/vtT8D1WIRUOMuKQz/9z8nZb7jgVWc6HWwlkXKDjYZ84otPFtYCozKqhXWv6xf3JxJvge/RUAOwh9Z7P4nQQ==}
     engines: {node: ^22.19.0 || ^24.11.0 || >=26.0.0}
     peerDependencies:
       '@babel/plugin-proposal-decorators': ^7.25.0 || ^8.0.0
       '@babel/plugin-syntax-typescript': ^7.25.0 || ^8.0.0
       '@rollup/plugin-babel': ^6.0.0 || ^7.0.0
-      nuxt: ^4.5.1
+      nuxt: ^4.5.2
     peerDependenciesMeta:
       '@babel/plugin-proposal-decorators':
         optional: true
@@ -1690,10 +1441,6 @@ packages:
         optional: true
       '@rollup/plugin-babel':
         optional: true
-
-  '@nuxt/schema@4.5.1':
-    resolution: {integrity: sha512-RDdu0BBg9y+Eiyu95LUDJ57YrejJ5v1/VA2r5oBLYiiSiLrlVt33HN9ut4qSyUN8gRTOXnFADery8AyJpTjdWA==}
-    engines: {node: ^14.18.0 || >=16.10.0}
 
   '@nuxt/schema@4.5.2':
     resolution: {integrity: sha512-h9g1kt9O2iU9nX6HDFu9gvwtpn+8oSJX0RSTWRBnEx/Pkz+WlOHtjuS0SbkTAXw5aT1+H1GysWVwNTjJfBY/0w==}
@@ -1706,69 +1453,13 @@ packages:
     peerDependencies:
       '@nuxt/kit': '>=3.0.0'
 
-  '@nuxt/ui@4.9.0':
-    resolution: {integrity: sha512-ufcG2UsX6/SMqh/oa4pIKM5AHDDK1ZWRTe6f4+Y5/xFUh1TBD25o4eb35BGFap16Uy/iIow1ih8g8h8wcw1Wcg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@inertiajs/vue3': ^2.0.7 || ^3.0.0
-      '@internationalized/date': ^3.0.0
-      '@internationalized/number': ^3.0.0
-      '@nuxt/content': ^3.0.0
-      '@tiptap/core': ^3
-      '@tiptap/extension-bubble-menu': ^3
-      '@tiptap/extension-code': ^3
-      '@tiptap/extension-collaboration': ^3
-      '@tiptap/extension-drag-handle': ^3
-      '@tiptap/extension-drag-handle-vue-3': ^3
-      '@tiptap/extension-floating-menu': ^3
-      '@tiptap/extension-horizontal-rule': ^3
-      '@tiptap/extension-image': ^3
-      '@tiptap/extension-mention': ^3
-      '@tiptap/extension-node-range': ^3
-      '@tiptap/extension-placeholder': ^3
-      '@tiptap/markdown': ^3
-      '@tiptap/pm': ^3
-      '@tiptap/starter-kit': ^3
-      '@tiptap/suggestion': ^3
-      '@tiptap/vue-3': ^3
-      joi: ^18.0.0
-      superstruct: ^2.0.0
-      tailwindcss: ^4.0.0
-      typescript: ^5.6.3 || ^6.0.0
-      valibot: ^1.0.0
-      vue-router: ^4.5.0 || ^5.0.0
-      yup: ^1.7.0
-      zod: ^3.24.0 || ^4.0.0
-    peerDependenciesMeta:
-      '@inertiajs/vue3':
-        optional: true
-      '@internationalized/date':
-        optional: true
-      '@internationalized/number':
-        optional: true
-      '@nuxt/content':
-        optional: true
-      joi:
-        optional: true
-      superstruct:
-        optional: true
-      valibot:
-        optional: true
-      vue-router:
-        optional: true
-      yup:
-        optional: true
-      zod:
-        optional: true
-
-  '@nuxt/vite-builder@4.5.1':
-    resolution: {integrity: sha512-gHMqCZ4Fd9lvJ6FUh9qyzD5Sdx0UyM1pxV+wzjlQvBbX4NxvB16spMcNGUUnnV6nX2so3JJROXxghlKf7Uj6nw==}
+  '@nuxt/vite-builder@4.5.2':
+    resolution: {integrity: sha512-fC8KUs5F1VpSEjTIjmx5pdflciMlp3FDCubx3AXElvRPLtBAPmyB69kmqVFjRnVQ8+vRHNyI7iBHUg9Se8srLA==}
     engines: {node: ^22.18.0 || ^24.11.0 || >=26.0.0}
     peerDependencies:
       '@babel/plugin-proposal-decorators': ^7.25.0 || ^8.0.0
       '@babel/plugin-syntax-jsx': ^7.25.0 || ^8.0.0
-      nuxt: 4.5.1
+      nuxt: 4.5.2
       rolldown: ^1.0.0
       rollup-plugin-visualizer: ^6.0.0 || ^7.0.1
       vue: ^3.3.4
@@ -1782,27 +1473,24 @@ packages:
       rollup-plugin-visualizer:
         optional: true
 
-  '@nuxtjs/color-mode@4.0.1':
-    resolution: {integrity: sha512-eiA7hWXi5zNHaYKyJFCGF6i0wFZtuvR7KDXZ6jiSvwxjCpRFwphrw0MOSmNfArTSSsT1wpW+/2H92cejeVfUlg==}
-
   '@nuxtjs/google-fonts@3.2.0':
     resolution: {integrity: sha512-cGAjDJoeQ2jm6VJCo4AtSmKO6KjsbO9RSLj8q261fD0lMVNMZCxkCxBkg8L0/2Vfgp+5QBHWVXL71p1tiybJFw==}
 
-  '@nuxtjs/robots@6.1.2':
-    resolution: {integrity: sha512-1jEoIfhxl2goQ7hHyG4SGLnypK+N3N4oNEL7eTE7vO21+2yXcYqNUCUtm9E3CVFHz3X5wKzv7O83XV4daH9Ygg==}
+  '@nuxtjs/robots@6.1.3':
+    resolution: {integrity: sha512-t1EAXgJ5A3QfwVOzWrHCuojHhirKDtUMOuoUPBVvfxyDGKIsHwnif5+4vR9HQK2fdOZqiSE/TfBsWiZhjJleOw==}
     peerDependencies:
       zod: '>=3'
     peerDependenciesMeta:
       zod:
         optional: true
 
-  '@nuxtjs/seo@5.3.2':
-    resolution: {integrity: sha512-oRHLfEBCHS6C0resx71ffAAE7XZWYEMvOzuCiXVZfP0cahIl0AIQdgrrvmFso1bxITHmrVXz5Gr++K5kpyuZXw==}
+  '@nuxtjs/seo@5.3.10':
+    resolution: {integrity: sha512-+bvq98L3vS4RLj0hyX+buJazxjmRM/IikoVrlED8U4gaCxXH5yUJBM63DPALSGlO+P6IirhRYAKdzLsD05LSGg==}
     peerDependencies:
-      nuxt: ^3.16.0 || ^4.0.0
+      nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
 
-  '@nuxtjs/sitemap@8.2.2':
-    resolution: {integrity: sha512-5tnNu0yHsh7J++epvQt7SLIfmFYqmr3tGuIgsI3yooXBtlDNhXt1+0hp6FZ2b+PocFOsxU22c98zzeucwW0Ydw==}
+  '@nuxtjs/sitemap@8.3.3':
+    resolution: {integrity: sha512-voYdRe4n4TDQ17aRXBbpAszSD8O2AEM9759piG3PHBmBG6Jtc2nEH7zUClCjeSLjKmAkaeDhLMxSzrZBMjuAfw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: '>=3'
@@ -1810,460 +1498,200 @@ packages:
       zod:
         optional: true
 
-  '@oxc-parser/binding-android-arm-eabi@0.132.0':
-    resolution: {integrity: sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==}
+  '@oxc-parser/binding-android-arm-eabi@0.142.0':
+    resolution: {integrity: sha512-ZiRGDutGsv1G6bL/ozy/koC0Sv39T1DqyoC4KD1DOy9ZoACm1O5UWhEK2c02Qdk+4lfLVkvFa/mQ0fm/4h1BtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxc-parser/binding-android-arm-eabi@0.137.0':
-    resolution: {integrity: sha512-KDs+0VPdEmasOkpuJHW9V5WCF+cvYdMQv2Jd+aJXt+cxIx12NToRQRbXaRwUEDsZw+/jMk81Ve8ZFbjUkJTOwA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
-  '@oxc-parser/binding-android-arm-eabi@0.138.0':
-    resolution: {integrity: sha512-hSYAD+F9W2Qh8SETMqBsQRx6YHvB4z+i/i36shlC7tfdZQauMs4vf3G/EQwKOkNlN7rkTiKINvsNmQb9q2MWcQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
-  '@oxc-parser/binding-android-arm64@0.132.0':
-    resolution: {integrity: sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==}
+  '@oxc-parser/binding-android-arm64@0.142.0':
+    resolution: {integrity: sha512-WZkvGRLNQTz8lR9zP5nLjUdlroRCopBu3g9zF1p/laE6DzT1UbQo8Rdz5MWhaJUPYg/6gp+jo7HUgsyKaN1FtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxc-parser/binding-android-arm64@0.137.0':
-    resolution: {integrity: sha512-WhALNzfy3x/RfC6bsqX+csavuUY0yHHE7XfgPE5M542uhoBZUUoGTPG+nkMbGoG4+gcfss5s7urMyn5QBHu0sw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxc-parser/binding-android-arm64@0.138.0':
-    resolution: {integrity: sha512-Ns5LLTp8cVyP8DsYqD482h0HE84xiGYRgtm7g4LtTinq209NAiMF768e/8r2NHaa0UMirS5mrT1m1VwiVmBi4Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxc-parser/binding-darwin-arm64@0.132.0':
-    resolution: {integrity: sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==}
+  '@oxc-parser/binding-darwin-arm64@0.142.0':
+    resolution: {integrity: sha512-l4khS8LQOOVYsGRVARo1gSaCT/aBSceUVXgtovWc2+drnxVuDr082WA3OCHVdVzIz5JIrP/y9CWsSKxBDNmYGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-arm64@0.137.0':
-    resolution: {integrity: sha512-bFPr5hgmNMOMoyPTGtdsK4Ug21RovIPojRMgDDhSp1LtCnc/DkLwGONKjgRjszg677RlGnkYSviQ8hHaUPOVYA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxc-parser/binding-darwin-arm64@0.138.0':
-    resolution: {integrity: sha512-Yka0m4YhKUHBIZufafSLAeO+DUrfHPtNXBlZSj7DxshquIl41x/a+i/MbRnbOy8heuLiYU1STa6h0FAAzT7Pbw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxc-parser/binding-darwin-x64@0.132.0':
-    resolution: {integrity: sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==}
+  '@oxc-parser/binding-darwin-x64@0.142.0':
+    resolution: {integrity: sha512-QBsNF3nqlXmcH2B1YOPqQYmCJoy4HuIjUxGbBO/k5JAJUl68ghU2psRY2zPk+RyBaWqKP/qfL4oaFgEMCdwskA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-x64@0.137.0':
-    resolution: {integrity: sha512-CL5dMm1asqXIDZHg14FLxj3Mc36w8PI7xCWh1uA4is6z8g2XrIILoTcQYOxDbwzuk34RDPX5IAGUxZr6LA9KAg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxc-parser/binding-darwin-x64@0.138.0':
-    resolution: {integrity: sha512-MWLUZZzmNRUqTWueZF27ncreaZ1wZ0gboWL2QMPxRQA2xgOmBPlGg2H9pAKJSPBlwEHcWa9TdWRiehAS+yls8w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxc-parser/binding-freebsd-x64@0.132.0':
-    resolution: {integrity: sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==}
+  '@oxc-parser/binding-freebsd-x64@0.142.0':
+    resolution: {integrity: sha512-b7Q7m4Cqc6XqNhri3R+QhU+GVy646Pn+bkdhrDdWym/Fdi0ZUa+d73H9dm5H91JtbtAQ/z1d8XKMW3oOV8a4tQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-parser/binding-freebsd-x64@0.137.0':
-    resolution: {integrity: sha512-79h8rYGnSlKPGWo7mHr2ixO6ea7aW8B0CT965SZ8SLbNnCOH5aOYBTeVXUY6eMvEaiLyWr8Skuiugr5pDYgLGw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxc-parser/binding-freebsd-x64@0.138.0':
-    resolution: {integrity: sha512-Vae5tzsrzZ/lCDVCZUMi/vzSiiHEgcOEfsyIfWOHmjZ2ji+gT+n96T757yX5/f7/7JIJuiannAHJKV5ARaF6ng==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
-    resolution: {integrity: sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==}
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
+    resolution: {integrity: sha512-3riVS5IhdH3uCZj1Y9ftDQlR0dvLsIlw/edrRqk8JhgNd5K0XSs+UBtgh50N13CAlW9/TXj6sVGXaKNBocd0Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.137.0':
-    resolution: {integrity: sha512-ASgmlSimhGyr0lksgVIo6hibz1obnDq4qJbiMX/AzltfgPnanRrzG1Q+23g8ljOHOjv6dsznkUuCYL3gg0sY1Q==}
+  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
+    resolution: {integrity: sha512-NmXUOpgpTSkhl795TiXmWppTwmSJ92RC1qvD6e4XOF+slgmo3e6Ah+kEu+6AN8s7NAOEwqGmir58MgSQSWmBSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.138.0':
-    resolution: {integrity: sha512-qkU8wv5mYexrCw0X4DHFgxGbRScwGLIIKUkHXU7xXEiLoMnQzELak2gujxfa9GFrlEgPjbyLUDFHWm67Zs38ng==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
-    resolution: {integrity: sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.137.0':
-    resolution: {integrity: sha512-AU2J9aa22Sx32wRGnDjybOU9TQXXQUud5sdUi+ZB0XxwM8aToWLweV+yA0wlQm0yIUVqljquqoHCYEq9II8gJQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.138.0':
-    resolution: {integrity: sha512-3HgULIvoDV7h2ZfVYzxQwOSOJnAjMwYmyUBzndNuLRGgBNI549ED0P6AGmN9y2TnSvrwJ+Q8zqdxqssMnGXitA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
-    resolution: {integrity: sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==}
+  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
+    resolution: {integrity: sha512-gc0EXsKtXgerujmU2Bql3u1L1HsSQ2774R83idq/FoNMPVV/RY/1ErFsvnit7KoiP/sLvzQixeUo4Ut0ic0wmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.137.0':
-    resolution: {integrity: sha512-GdEtiG89yMr7XkUGxifgodXEEm2f+xW2f9CpDjlgAnBOwhTmrpQMvhOGobLVKUyzf/qHBXW16smk5zbF3nZU6w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.138.0':
-    resolution: {integrity: sha512-pIonbH2p0KLCwz4CNPCi0xGqci4numpMQDCLJwLfsrEky7NUuByKDFhCjzE0E7vR3aj/lBjyMoTskHBo/qSg8g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
-    resolution: {integrity: sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==}
+  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
+    resolution: {integrity: sha512-F2XvmWSE0uWpie+jHKKIFgdVOe9ypGhkEZxKx5DuW215K6cbAC274yYaPkcM7EqY4Df3Weyhpcz3lsURyH2LVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-arm64-musl@0.137.0':
-    resolution: {integrity: sha512-EGJ+Bs8iXx8KBH8DQ5BLoEm5lnHaYjlh4/8j8vFhrr/6z4tqONy5BZDzLpKmmNWlN6Hlc5r8YOuBVHqZ9vRFEQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-arm64-musl@0.138.0':
-    resolution: {integrity: sha512-cT5L1Xz/5m6Ga1hD3922gLc+fePOauJZJdApPTI/2Vu0EmYo62uHG9V5Dq65hhgU9TW10oDi2840y9cGdd7BIg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
-    resolution: {integrity: sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==}
+  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
+    resolution: {integrity: sha512-wLMbT21U/QxknQsk+VvNF0b9D2/aGWhcaQQQ+VYlE8FwD5+GoWZIPPXNzyHmkYyhm0KB3itL+TBavjMatqNnYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-ppc64-gnu@0.137.0':
-    resolution: {integrity: sha512-vzFUQENy/fnbSe5DZWovq6tIBc1uhuMztanSW6rz1e9WdQE4gHwYuD7ZII6JnrJifd1R3RSoqiZbgRFlVL2tYQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.138.0':
-    resolution: {integrity: sha512-hKy/vvejKk3LNE/FsRbekWejLa046//TnLWtSo7ur29NIsNbSIvnOVYIirSVC7fsd6NO8UFzwDdcoZfCyBvSBA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
-    resolution: {integrity: sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==}
+  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
+    resolution: {integrity: sha512-+G8F/4ckwT7FCJV4H2bt09xEzJbjNCfuL4Sp1AYNaFtFMVtgIGMuJlteT82U+K0UIZ/DzAR/LDlMFnEuajG7Kw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.137.0':
-    resolution: {integrity: sha512-SfVI14HBQs9gtLcUD5hTt5hsNbdrqSUNg9S8muN+LhVQ5nf1WwH3hAoK6B9NKgdYgWAQSXFXGiiBedQ4r/BKuw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.138.0':
-    resolution: {integrity: sha512-bh6tjNGq0v0b9GAMu0pTv/YpTqepCFy0TIOtQHm8+41fZwLXTaB6xiEWVUSarNCXqc5kyzYcH6EOfwW1sJxJOw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
-    resolution: {integrity: sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==}
+  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
+    resolution: {integrity: sha512-hTsHtTLxMAfCo+rpF5K3qZJKW2NpPN/CHd4mYB3y7XlSdspHkd2gehDIofP64AacA9nWQw2tY3O7wR6UY8IVOA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-riscv64-musl@0.137.0':
-    resolution: {integrity: sha512-e7Ppy4FCIFNQxT/ikSeIWFoQ0l+N9vgtRBtLcyZXeolTzApyVoPqEXsYPrcdM/9i0Bwk8knvYd37vaEMxHyi6g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.138.0':
-    resolution: {integrity: sha512-HhOkddcClSTtTxY10f/mACblKcQdxWy4lYYwX12G23j+S5eiJ5y1kpo1r7kKng+2bdnCBO+lCDWOVVc9kVl9+g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
-    resolution: {integrity: sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==}
+  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
+    resolution: {integrity: sha512-6y7qYY3TCUDYjqswImdTGl92y+KA/80twALegQPN27kfY+bG7Ib1+L3jbmrCZQx6wrVnai9IPsEZp07I0hx7JQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.137.0':
-    resolution: {integrity: sha512-Bho5qFwdhqsIFR7gipYEUlqvi3SRrY8sugxXig380MIaakBB1PyU9+7dBiBVScfImTNWhijUxdBwqrprGdq5WA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.138.0':
-    resolution: {integrity: sha512-5mi+wtbeJiEa4waGG88EcEGgJBBNJdDeIcayPPcrLNMXbCrgdtbb80q0Nrat7A8NglLUVzhuTAAp7K6PjmUO8Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
-    resolution: {integrity: sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==}
+  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
+    resolution: {integrity: sha512-i69kAWU+2LgoH5bR+zWiiu+UzAw7Oxkwv7COeJTeY19pn4e70nKQcr9Pm6cL2Z0Z54d+gl9qADlK/0yyuCPiBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-x64-gnu@0.137.0':
-    resolution: {integrity: sha512-36mGWtg7PyFzjJwGDkH6/F4o2nIDEoKXLPr/X/lwqklkomQwJJt1I5GJVmGhovUEmgPK5WAeAZMqlFCehwiy9Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-x64-gnu@0.138.0':
-    resolution: {integrity: sha512-ckbq3AMI7lI8AhQtE8KdqYRmzmzwKfCU12QN/PBKXO72PfWdvvZQN0hFShDX/XRNsPqjddLmvXaQMT3zfYtNlw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxc-parser/binding-linux-x64-musl@0.132.0':
-    resolution: {integrity: sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==}
+  '@oxc-parser/binding-linux-x64-musl@0.142.0':
+    resolution: {integrity: sha512-4SQs678MmjYVrmhAgCWD4o0vpaFszXw9xLX5p2Z9MMFcltxiLkA88wQjh80YHjPrXtpyZ2CWI5m+1yNKM0m2Pw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-x64-musl@0.137.0':
-    resolution: {integrity: sha512-/Jqx6+N7A44n2BdvUr7pXhVr2vFjs6WGH3unZRczwrfiH0H1zY0QwKQMG/dtRiTlKGDKGukznPT8lx84/oEsZg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-x64-musl@0.138.0':
-    resolution: {integrity: sha512-JrCOzHO9BYEs5Xz5JHYBxSc/hYKxfXUj5QQb64sERSbkQot6+KEgMTOR2C9hLrhaqOui65OYcFyTTS+YxXDtnA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-openharmony-arm64@0.132.0':
-    resolution: {integrity: sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==}
+  '@oxc-parser/binding-openharmony-arm64@0.142.0':
+    resolution: {integrity: sha512-YHpx9N7Ln3a++Tc8rv+H7mrK1zyJQOAwCFg8LZ3lTs1T5afGWeZrLPhPT9HLnIwSjCyJqPWVMIrMxbjcmBr2oQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxc-parser/binding-openharmony-arm64@0.137.0':
-    resolution: {integrity: sha512-9Uj0qHNNl+OgT1UTGwF7ixIXU6T1u2SbMidmgPy/h1h/fl2gRS6YpAxxY1gwHofcWjoTwkoMFd8xs5Vuj6GOFA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxc-parser/binding-openharmony-arm64@0.138.0':
-    resolution: {integrity: sha512-eASMMfOOIfLHkWJRPSu8llByvVRM+c1M/lh18KjsjELM3y10+7B5iBbbrht9LdtsJXQ+mRuP/lJ7UWe3Ok3ehw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxc-parser/binding-wasm32-wasi@0.132.0':
-    resolution: {integrity: sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==}
+  '@oxc-parser/binding-wasm32-wasi@0.142.0':
+    resolution: {integrity: sha512-3pLDyY3+oogW73RM5uehNgAiR/Xfb7fvO2Q1Z1gIqZ2+50XDVQmBVlRkHXZTU4gKnQHpwETNsYQVsJ3joVB2iA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@oxc-parser/binding-wasm32-wasi@0.137.0':
-    resolution: {integrity: sha512-gW2vfkytNGgMVADiuzdvOfw0mWG9za20F/1fCJsif5aBMAvWJTSbpIXbIe0XkOe0VENk+PadpQ7cZgUy2sUJcA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
-  '@oxc-parser/binding-wasm32-wasi@0.138.0':
-    resolution: {integrity: sha512-BnTCO87Iwc57NufXS7vcrkrmpN+daeCeYr1+/xgPT6HjwNs0lBmJYeFrcOs4WkNN8yscdd6Rc4FxWh3+59hAFw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
-    resolution: {integrity: sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==}
+  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
+    resolution: {integrity: sha512-Had/VeVY28Oyb0K+Q4FV8KCzoBycIh93oDK6pCbya9lkzdq+ikMHMgBubsdqqlybjJmQRawCQRrnBRHyQwYvcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.137.0':
-    resolution: {integrity: sha512-x+pFANF0yL5uK/6T7lu6SlR5qid6sp//eZXKLq5iNsIE+EQg6EaS8/wsW7E91nXXjpnPhSoMOHXShSVhGRdn8w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.138.0':
-    resolution: {integrity: sha512-+Zi47boD2wKNL0hOA47Vkwk6njMZ8sOsr4Geu/56EUtlooDh9crNOU41U6bXGS0UjC4Y72HtRA1iuB6qx1ARUw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
-    resolution: {integrity: sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==}
+  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
+    resolution: {integrity: sha512-GGi3+YphVHavvgs6gum2UXoNCqzHAmPt/nXkn8ZQZstV2Q1qZD1Mn8fz/nWrDkefHQtrG/+1/XrbMxsBTo6Svw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.137.0':
-    resolution: {integrity: sha512-sQUqym80PFi6McRsIqfJrSu2JrSClEZIXXD+/FjAFoULEKzOPsldIdFBG96xdX8aVMzCNQ9792FPx3MfkEIrFA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.138.0':
-    resolution: {integrity: sha512-SYcV674Wi2WuoBefUFgf0PBMNlZe5IF0YZ0TnP7DK+EusMVpEWq6iz+7r64svjAb7vjthzlas0FUCSlz8YkqYg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
-    resolution: {integrity: sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==}
+  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
+    resolution: {integrity: sha512-Ny/Wv4Us1LGC/ljwNTp+Hx3r/pH15EFfeDF0p+n898gt+TtRd6C9SccHcuUhDiNTb8s5tt7jdeAMDRQZ4Vq6hg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-x64-msvc@0.137.0':
-    resolution: {integrity: sha512-2AsevxlvNN4WKxpEn3RtqD5zbqMaXF+T7JXblsP4gVuY+vC9dXS4ED/PwfRCliFqoeisYS3Iro4DHzxr0TEvVA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-x64-msvc@0.138.0':
-    resolution: {integrity: sha512-QZplnCxS4vPe4StAVBtvD2bW3pELlidf0Ek6iQ/HHiCjbEtrs5pFZZfLAoPhKLJyDzyxoGAdic9bSIYrJYTZcg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@oxc-project/types@0.132.0':
-    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
-
-  '@oxc-project/types@0.137.0':
-    resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
-
-  '@oxc-project/types@0.138.0':
-    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
   '@oxc-project/types@0.143.0':
     resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
 
-  '@parcel/watcher-android-arm64@2.5.6':
-    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
+  '@parcel/watcher-android-arm64@2.6.0':
+    resolution: {integrity: sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [android]
 
-  '@parcel/watcher-darwin-arm64@2.5.6':
-    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
+  '@parcel/watcher-darwin-arm64@2.6.0':
+    resolution: {integrity: sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@parcel/watcher-darwin-x64@2.5.6':
-    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
+  '@parcel/watcher-darwin-x64@2.6.0':
+    resolution: {integrity: sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@parcel/watcher-freebsd-x64@2.5.6':
-    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
+  '@parcel/watcher-freebsd-x64@2.6.0':
+    resolution: {integrity: sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  '@parcel/watcher-linux-arm-glibc@2.5.6':
-    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
+  '@parcel/watcher-linux-arm-glibc@2.6.0':
+    resolution: {integrity: sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@parcel/watcher-linux-arm-musl@2.5.6':
-    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
+  '@parcel/watcher-linux-arm-musl@2.6.0':
+    resolution: {integrity: sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@parcel/watcher-linux-arm64-glibc@2.5.6':
-    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
+  '@parcel/watcher-linux-arm64-glibc@2.6.0':
+    resolution: {integrity: sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@parcel/watcher-linux-arm64-musl@2.5.6':
-    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
+  '@parcel/watcher-linux-arm64-musl@2.6.0':
+    resolution: {integrity: sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@parcel/watcher-linux-x64-glibc@2.5.6':
-    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
+  '@parcel/watcher-linux-x64-glibc@2.6.0':
+    resolution: {integrity: sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@parcel/watcher-linux-x64-musl@2.5.6':
-    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
+  '@parcel/watcher-linux-x64-musl@2.6.0':
+    resolution: {integrity: sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
@@ -2275,26 +1703,20 @@ packages:
     bundledDependencies:
       - napi-wasm
 
-  '@parcel/watcher-win32-arm64@2.5.6':
-    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
+  '@parcel/watcher-win32-arm64@2.6.0':
+    resolution: {integrity: sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@parcel/watcher-win32-ia32@2.5.6':
-    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@parcel/watcher-win32-x64@2.5.6':
-    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
+  '@parcel/watcher-win32-x64@2.6.0':
+    resolution: {integrity: sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [win32]
 
-  '@parcel/watcher@2.5.6':
-    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
+  '@parcel/watcher@2.6.0':
+    resolution: {integrity: sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==}
     engines: {node: '>= 10.0.0'}
 
   '@pinia/nuxt@0.11.3':
@@ -2336,20 +1758,14 @@ packages:
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.2':
-    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
-
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
 
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.1':
-    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
-
-  '@quansync/fs@1.0.0':
-    resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@rolldown/binding-android-arm64@1.2.3':
     resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
@@ -2654,50 +2070,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@shikijs/core@4.3.1':
-    resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
-    engines: {node: '>=20'}
-
-  '@shikijs/engine-javascript@4.3.1':
-    resolution: {integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==}
-    engines: {node: '>=20'}
-
-  '@shikijs/engine-oniguruma@4.3.1':
-    resolution: {integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==}
-    engines: {node: '>=20'}
-
-  '@shikijs/langs@4.3.1':
-    resolution: {integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==}
-    engines: {node: '>=20'}
-
-  '@shikijs/primitive@4.3.1':
-    resolution: {integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==}
-    engines: {node: '>=20'}
-
-  '@shikijs/themes@4.3.1':
-    resolution: {integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==}
-    engines: {node: '>=20'}
-
-  '@shikijs/types@4.3.1':
-    resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
-    engines: {node: '>=20'}
-
-  '@shikijs/vscode-textmate@10.0.2':
-    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
-
   '@simple-git/args-pathspec@1.0.3':
     resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
 
   '@simple-git/argv-parser@1.1.1':
     resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
 
-  '@simple-libs/child-process-utils@1.0.2':
-    resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
-    engines: {node: '>=18'}
+  '@simple-libs/child-process-utils@2.0.0':
+    resolution: {integrity: sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A==}
+    engines: {node: '>=22'}
 
-  '@simple-libs/stream-utils@1.2.0':
-    resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
-    engines: {node: '>=18'}
+  '@simple-libs/stream-utils@2.0.0':
+    resolution: {integrity: sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==}
+    engines: {node: '>=22'}
 
   '@sindresorhus/base62@1.0.0':
     resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
@@ -2723,352 +2108,6 @@ packages:
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
 
-  '@swc/helpers@0.5.23':
-    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
-
-  '@tailwindcss/node@4.3.2':
-    resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
-
-  '@tailwindcss/oxide-android-arm64@4.3.2':
-    resolution: {integrity: sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==}
-    engines: {node: '>= 20'}
-    cpu: [arm64]
-    os: [android]
-
-  '@tailwindcss/oxide-darwin-arm64@4.3.2':
-    resolution: {integrity: sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==}
-    engines: {node: '>= 20'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@tailwindcss/oxide-darwin-x64@4.3.2':
-    resolution: {integrity: sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==}
-    engines: {node: '>= 20'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@tailwindcss/oxide-freebsd-x64@4.3.2':
-    resolution: {integrity: sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==}
-    engines: {node: '>= 20'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
-    resolution: {integrity: sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==}
-    engines: {node: '>= 20'}
-    cpu: [arm]
-    os: [linux]
-
-  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
-    resolution: {integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==}
-    engines: {node: '>= 20'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
-    resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
-    engines: {node: '>= 20'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
-    resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
-    engines: {node: '>= 20'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
-    resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
-    engines: {node: '>= 20'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
-    resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-    bundledDependencies:
-      - '@napi-rs/wasm-runtime'
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@tybys/wasm-util'
-      - '@emnapi/wasi-threads'
-      - tslib
-
-  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
-    resolution: {integrity: sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==}
-    engines: {node: '>= 20'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
-    resolution: {integrity: sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==}
-    engines: {node: '>= 20'}
-    cpu: [x64]
-    os: [win32]
-
-  '@tailwindcss/oxide@4.3.2':
-    resolution: {integrity: sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==}
-    engines: {node: '>= 20'}
-
-  '@tailwindcss/postcss@4.3.2':
-    resolution: {integrity: sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==}
-
-  '@tailwindcss/vite@4.3.2':
-    resolution: {integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==}
-    peerDependencies:
-      vite: ^5.2.0 || ^6 || ^7 || ^8
-
-  '@tanstack/table-core@8.21.3':
-    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
-    engines: {node: '>=12'}
-
-  '@tanstack/virtual-core@3.17.3':
-    resolution: {integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==}
-
-  '@tanstack/vue-table@8.21.3':
-    resolution: {integrity: sha512-rusRyd77c5tDPloPskctMyPLFEQUeBzxdQ+2Eow4F7gDPlPOB1UnnhzfpdvqZ8ZyX2rRNGmqNnQWm87OI2OQPw==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      vue: '>=3.2'
-
-  '@tanstack/vue-virtual@3.13.31':
-    resolution: {integrity: sha512-wZMEoSf852jQqaf3Ika1J7PiBae6341LNy/2CxmIyn0XKDQXMuK41wVX+xp6G0yx8jyR95Ef+Tdr13DK7mbJtQ==}
-    peerDependencies:
-      vue: ^2.7.0 || ^3.0.0
-
-  '@tiptap/core@3.27.1':
-    resolution: {integrity: sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ==}
-    peerDependencies:
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extension-blockquote@3.29.2':
-    resolution: {integrity: sha512-ca4OzKDh0yaxg2+Z56bC2QnWsNsFp2YMRfVig1PDXyMVFMNJpLcnhxgq/9btn+xYAlYrj8RymOeCTYREOR6Zjg==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-      '@tiptap/pm': 3.29.2
-
-  '@tiptap/extension-bold@3.29.2':
-    resolution: {integrity: sha512-elYbGxJsYnBb4leqrcjdIJuiG380BcOgN+UUzvOv+qEjfGVzHodFOMBl3qnmD6urYHNu5/qQK2S0qSSRXKCLNQ==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-
-  '@tiptap/extension-bubble-menu@3.27.1':
-    resolution: {integrity: sha512-j/j8Qp9Z5nViade2m7zjrO/CYH/Ca80Qj7aqo0eUaei6FZQ5izlF9o4XQU5EFMAutV6mwynsPUp8FVo5sCuYfw==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extension-bullet-list@3.29.2':
-    resolution: {integrity: sha512-3bWcCUPbCHv0XttlMdnAtXLNYWx2pblByMgxmGsaP9FU0QnslGXty6A6gHCqI33ygRg1vrA6U5Wtpwbi5aKu5g==}
-    peerDependencies:
-      '@tiptap/extension-list': 3.29.2
-
-  '@tiptap/extension-code-block@3.29.2':
-    resolution: {integrity: sha512-w153ct8g6dLiPTdXQ6SOIMxX4SEo5Q50AmjdEEEcJ7ZcYUcde/ScSskLHfOYmyt5ZFAiyEwr121+pux+p3/oAQ==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-      '@tiptap/pm': 3.29.2
-
-  '@tiptap/extension-code@3.27.1':
-    resolution: {integrity: sha512-epOUpFfEmBzjvnqvjv2qHX7NAuLo5dlOGV690lWu+sAYMjibuJBeVvAiKPyFCfRCCTUxdbDB3jbaOA1yEcEJ7w==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-
-  '@tiptap/extension-collaboration@3.27.1':
-    resolution: {integrity: sha512-Da7WeKNIaLsbcHBWlgexMgm5ygoA1mhRroFND1vweLNsWIPxvyjci7jrq/uDN1tSnpqMlJsdyW0tXzbVGYTpMw==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-      '@tiptap/pm': 3.27.1
-      '@tiptap/y-tiptap': ^3.0.5
-      yjs: ^13
-
-  '@tiptap/extension-document@3.29.2':
-    resolution: {integrity: sha512-YUamvefLnsqu6124GavVTI7nqcFlQJ12ROB0oSwG69eSBZYNjg1tIs05LFrBxkwf4Xgqd6YzfJ9+FeG428RvzQ==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-
-  '@tiptap/extension-drag-handle-vue-3@3.27.1':
-    resolution: {integrity: sha512-ccVg6gsv1Tsf2Vio8t3xRSLBigr7INO11cF2VEI8K4A4JCE8ZrhOr5bMA76XHHwxejb/e5NE/tFhdLUjPnLS2g==}
-    peerDependencies:
-      '@tiptap/extension-drag-handle': 3.27.1
-      '@tiptap/pm': 3.27.1
-      '@tiptap/vue-3': 3.27.1
-      vue: ^3.0.0
-
-  '@tiptap/extension-drag-handle@3.27.1':
-    resolution: {integrity: sha512-DGzthoQEgPPbbwy/tY314AF1SV/1gIGQYlU/R6GWxegc7h/5/Qp1SopjguyuZwoO5BPwyBZXa9J/f58MeHQOWw==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-      '@tiptap/extension-collaboration': 3.27.1
-      '@tiptap/extension-node-range': 3.27.1
-      '@tiptap/pm': 3.27.1
-      '@tiptap/y-tiptap': ^3.0.5
-
-  '@tiptap/extension-dropcursor@3.29.2':
-    resolution: {integrity: sha512-KKno7cU9r1HdR48CRrsDu69/1UjZdoslq/UcE+Kx+tdhAv/aljXMkRSNzGMrBNOBDmHRgS1+58zm21WQWdQzwA==}
-    peerDependencies:
-      '@tiptap/extensions': 3.29.2
-
-  '@tiptap/extension-floating-menu@3.27.1':
-    resolution: {integrity: sha512-BmJF1VqB7dSJkgAalrpVFj88WLhxKjcWPuWHOqf2ITrUU2832BhKLXKmxjWUy1gqV8PfNNVWtGfIERy7I0y0+Q==}
-    peerDependencies:
-      '@floating-ui/dom': ^1.0.0
-      '@tiptap/core': 3.27.1
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extension-gapcursor@3.29.2':
-    resolution: {integrity: sha512-8Q39UR4/Tit759IeW9xZIe3NMwN11GsuA3FLheDyyGn7RrW02HD3HhUDlazE54Ki4HoosjFmChPlN4Ik2ubdRQ==}
-    peerDependencies:
-      '@tiptap/extensions': 3.29.2
-
-  '@tiptap/extension-hard-break@3.29.2':
-    resolution: {integrity: sha512-eUW3LN3fq8rXnjEUeI3D2QONYdLsU3yYQm4jxlErs2h4cfwrFjgf19VSUFVmm6LrFbbQ0OnDVPeVLL6iOwDw2w==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-
-  '@tiptap/extension-heading@3.29.2':
-    resolution: {integrity: sha512-6W4aIy70Mh7BNlbG9zZ5FBLhJhU2UUEzgZJ/jwYSCcB30o8McLxJSEjhtoHiX8R78Ah2/JzBGvIe5olZlbeE4A==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-
-  '@tiptap/extension-horizontal-rule@3.27.1':
-    resolution: {integrity: sha512-QlKE7qn5qMnIGVGhXQlvYedvLtNJ9z0dmit5w8vPb8tKzW4Spk6M7N2kruprrDA8GBwHfeR5wmF+njfUm34qxg==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extension-image@3.27.1':
-    resolution: {integrity: sha512-+JTahgQT+NxiGjduaB3qJVyhU/wh4m3pVkht1Earioku2bm/apj5Lb8rSowa/NJYP3B+oQgV/V4YLw5dtDgBoA==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-
-  '@tiptap/extension-italic@3.29.2':
-    resolution: {integrity: sha512-iH63V/5wsaMnY4Jz0+meaAGhaec4AiOzOduzl6ZZr5IyGhZ1kthyW84ELt0dyLI3hNceAUhaNWc+I7+vX0aoXA==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-
-  '@tiptap/extension-link@3.29.2':
-    resolution: {integrity: sha512-DcVer5SqrexKCEP6Ip1UPxJUMvcRCCItSv0wxoGytanrimBh2smvcg6X0DWnjlsi5H0updhyl+atYCmmQXUIXA==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-      '@tiptap/pm': 3.29.2
-
-  '@tiptap/extension-list-item@3.29.2':
-    resolution: {integrity: sha512-s8vBVHHFT0Qpu7CzAZ7S1kYmSiVaDvUNvMNcZUWnxj6VPfiwmx0eXd9FsjePrRCMoM5tFmPnhFTHDxY3D/eZeQ==}
-    peerDependencies:
-      '@tiptap/extension-list': 3.29.2
-
-  '@tiptap/extension-list-keymap@3.29.2':
-    resolution: {integrity: sha512-R+3k8OLnxdCH7Xy9ieOwUt5m2Je74u8mikothGmsYVO2Zyq48fIbmZ+X6RBPCu7DBOI2FIUhHEFbKQeDWvDNmA==}
-    peerDependencies:
-      '@tiptap/extension-list': 3.29.2
-
-  '@tiptap/extension-list@3.29.2':
-    resolution: {integrity: sha512-WPZ9BHAPT6QeIm1vdVkuoOWvy9a8/EZeJwV2VhU8LXyTAttvzyj4rsbbHyJWvYWlUSTt/QF2AZ2zhKo7u1w3/A==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-      '@tiptap/pm': 3.29.2
-
-  '@tiptap/extension-mention@3.27.1':
-    resolution: {integrity: sha512-QfaKdl8PET01JvEFrIjMcOC1iYrBm2tsZEn07J1AaCqClW9iWcg/nCAdkdFhVir1fC54SLuaui43xslBawQRFg==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-      '@tiptap/pm': 3.27.1
-      '@tiptap/suggestion': 3.27.1
-
-  '@tiptap/extension-node-range@3.27.1':
-    resolution: {integrity: sha512-30OkvZA2+mtupOSihSyRyRAgoVP+RHXs0AT/2DCWc3NHwg+SHo/OrB/S5zsOW9p74Q+6V3hd1K3Nw6Qp9F9M0Q==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extension-ordered-list@3.29.2':
-    resolution: {integrity: sha512-ndCunC+UsYOpkOtL7vGnDz21UNa45WUlcO9wMT1fbuYow2QnRhsuMlCWENXI52YPPARWuQ0RDgN7q6TaxPERBg==}
-    peerDependencies:
-      '@tiptap/extension-list': 3.29.2
-
-  '@tiptap/extension-paragraph@3.29.2':
-    resolution: {integrity: sha512-7qJj5YTr11vvjNgjDN1ypOfwTovc0QOCYcit/rskeuVgnmQZOZQzC/BbyKLLG7UGnpRLemU/mEGbW9pAqjAXkQ==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-
-  '@tiptap/extension-placeholder@3.27.1':
-    resolution: {integrity: sha512-lhcNDcczQ75yJOSywCHb58Hmtg1aPL/2TdYmeLPxVrP048D7rRs133sfONcgyyw0AvhnfmPOkHLTv3QtKSowhw==}
-    peerDependencies:
-      '@tiptap/extensions': 3.27.1
-
-  '@tiptap/extension-strike@3.29.2':
-    resolution: {integrity: sha512-aEvLAbddUQZ+FukCreV3q4G2HfNI+odE7E9U+wbq6XsSWKyo8/pDu1muz+TFKNre4blSMOQ3JQmw5UeHDKy+fg==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-
-  '@tiptap/extension-text@3.29.2':
-    resolution: {integrity: sha512-Ubko45JWWHe8glBt2PiGNF8hcbys/JNalFhiR7Y1X4iOOtAxAKJJxh3+eq+//NTlGuBPdWGp7zw8EEUp7anjKA==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-
-  '@tiptap/extension-underline@3.29.2':
-    resolution: {integrity: sha512-K7XwH/xS/5AIREWQ00VTEf/W5U0olp7j6wwit7cdd/8nHv6h6AGr1+iEApHKoLXWQZLfGQKzJlT9W61LAl+fHA==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-
-  '@tiptap/extensions@3.27.1':
-    resolution: {integrity: sha512-1Tdx9faw8k0/83V6X+xCDVhV8yElGt95JxeW3YMkKQJI56QdlPz0xOdJPlMiSGJKinPyVier+x9LJD/YZUZIaw==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extensions@3.29.2':
-    resolution: {integrity: sha512-BCz+FCAChSYtUe4BFj97HEO+nSK+J7GxbJgZG4Hg7DT/gI+hRyeNndU8efiQAx3WGdzsFi3UxRpcF1tTQM7iMQ==}
-    peerDependencies:
-      '@tiptap/core': 3.29.2
-      '@tiptap/pm': 3.29.2
-
-  '@tiptap/markdown@3.27.1':
-    resolution: {integrity: sha512-4m2LZcj/uN0uLlGnXr3i7sfdxbQNNmeMn4wFyFrP2xpshcKPL5WujUAcqT2rgKfaDjKQ8gIK/GpgSQKuRENFwg==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/pm@3.27.1':
-    resolution: {integrity: sha512-Ffjx+vimmBU7zH/KrpXzJid3+pziCe/VL2aexSTP63cyQwKQ65LkFkCKaIsSpFdQQuakVZBGWjCA5RoBV852pw==}
-
-  '@tiptap/starter-kit@3.27.1':
-    resolution: {integrity: sha512-vfxRsqW8rCc0k4pzo0ilU3wobVi2wqVj88VZI2SlgZlNnUAkrDGDIAph7CTa9k9fshV+O1ivpEgPC5yC046jow==}
-
-  '@tiptap/suggestion@3.27.1':
-    resolution: {integrity: sha512-GNBPRav+lAfXzqmmUAS6ylRAn3G8JfsP6XosjoORxJIQJLx1ktDqwp6tm1Vgz9aGIM2TrBxLS1uBbI1Gb2/1VA==}
-    peerDependencies:
-      '@floating-ui/dom': ^1.0.0
-      '@tiptap/core': 3.27.1
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/vue-3@3.27.1':
-    resolution: {integrity: sha512-o5GB6hfUnyf9sCB306rHWmaIYRL+02ROX657EkuY8tEWKHMTuMjHWl2AqHMP47wz0W9DaMOJLvcPpYdAEKq3Mw==}
-    peerDependencies:
-      '@floating-ui/dom': ^1.0.0
-      '@tiptap/core': 3.27.1
-      '@tiptap/pm': 3.27.1
-      vue: ^3.0.0
-
-  '@tiptap/y-tiptap@3.0.6':
-    resolution: {integrity: sha512-kcGeVGKtq/cPGVseNKjtmtcY2WXUAEm1SqS5x0Smubj4nOCRyPiHg6kY4QuuZhmXjTK7hdo8chokkPUKWXPE9Q==}
-    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
-    peerDependencies:
-      prosemirror-model: ^1.7.1
-      prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
-      y-protocols: ^1.0.1
-      yjs: ^13.5.38
-
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
-
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -3078,20 +2117,14 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/hast@3.0.4':
-    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
-
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/mdast@4.0.4':
-    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
-
-  '@types/node@25.9.1':
-    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
   '@types/qrcode@1.5.6':
     resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
@@ -3099,100 +2132,67 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
-  '@types/unist@3.0.3':
-    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/web-bluetooth@0.0.20':
-    resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
-
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
-  '@typescript-eslint/eslint-plugin@8.62.0':
-    resolution: {integrity: sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==}
+  '@typescript-eslint/eslint-plugin@8.66.0':
+    resolution: {integrity: sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.62.0
+      '@typescript-eslint/parser': ^8.66.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.62.0':
-    resolution: {integrity: sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.62.0':
-    resolution: {integrity: sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.62.0':
-    resolution: {integrity: sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.62.0':
-    resolution: {integrity: sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.62.0':
-    resolution: {integrity: sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==}
+  '@typescript-eslint/parser@8.66.0':
+    resolution: {integrity: sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.62.0':
-    resolution: {integrity: sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.62.0':
-    resolution: {integrity: sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==}
+  '@typescript-eslint/project-service@8.66.0':
+    resolution: {integrity: sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.62.0':
-    resolution: {integrity: sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==}
+  '@typescript-eslint/scope-manager@8.66.0':
+    resolution: {integrity: sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.66.0':
+    resolution: {integrity: sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.66.0':
+    resolution: {integrity: sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.62.0':
-    resolution: {integrity: sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==}
+  '@typescript-eslint/types@8.66.0':
+    resolution: {integrity: sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@ungap/structured-clone@1.3.2':
-    resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
-
-  '@unhead/bundler@3.1.7':
-    resolution: {integrity: sha512-yJPDwKZ3NOSmzB1a4ea5MEbeaXBq9EvOcGnav46SsPnslE7jq7QKkx42UQzxJk0q6yFPGdCZbFae2IO1HTtLPA==}
+  '@typescript-eslint/typescript-estree@8.66.0':
+    resolution: {integrity: sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@unhead/cli': ^3.1.7
-      esbuild: '>=0.17.0'
-      lightningcss: '>=1.20.0'
-      rolldown: '>=1.0.0-beta.0'
-      unhead: ^3.1.7
-      vite: '>=6.4.2'
-      webpack: '>=5.0.0'
-    peerDependenciesMeta:
-      '@unhead/cli':
-        optional: true
-      esbuild:
-        optional: true
-      lightningcss:
-        optional: true
-      rolldown:
-        optional: true
-      vite:
-        optional: true
-      webpack:
-        optional: true
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.66.0':
+    resolution: {integrity: sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.66.0':
+    resolution: {integrity: sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@unhead/bundler@3.3.1':
     resolution: {integrity: sha512-F9gEgqpUKqHFzOv+7Pgm3TbmXhUdLX+WjZiPAK/huLDzblzZmvAUE9vRDymWaOST7jqGT/tPKkwl2kqbgb3nPw==}
@@ -3224,11 +2224,6 @@ packages:
       webpack:
         optional: true
 
-  '@unhead/vue@2.1.17':
-    resolution: {integrity: sha512-pnC8x9HLV3qQXdvWfylUEU25uhfCAy3ly9nmpQz84j9py818DRfU8jOsQ5wjdWtxyU1vX/fW2udfm4jtxUK8Bg==}
-    peerDependencies:
-      vue: '>=3.5.18'
-
   '@unhead/vue@3.3.1':
     resolution: {integrity: sha512-iS+eiE1NehbV/eF7wzR7UUuUVTv8fIphFOCekQvEMuPqfKPCB8f3wf7sgPgUngYX6mdgM6PmkGmaOQgTBxqwbw==}
     peerDependencies:
@@ -3240,12 +2235,6 @@ packages:
         optional: true
       webpack:
         optional: true
-
-  '@unocss/config@66.7.4':
-    resolution: {integrity: sha512-xdIpeZv2l69GlvO2GjAMXXMnJ4LPI0J9OXIEsON6kSHJzZqL9Gbztqvt9L+3OXQsNCeduJF/Dm9JrNPSbpDqHw==}
-
-  '@unocss/core@66.7.4':
-    resolution: {integrity: sha512-OGXh+RRsAgOrecTKRjUd4SepHR7W4v6zIf6pGtKyIIAIMnzcW/tU+afR1cDbhtb4efZMQhzaoAh3ncvkL8eEYA==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.12.2':
     resolution: {integrity: sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==}
@@ -3367,20 +2356,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@valibot/to-json-schema@1.7.1':
-    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
-    peerDependencies:
-      valibot: ^1.4.0
-
   '@vercel/nft@1.10.2':
     resolution: {integrity: sha512-w+WyX5Ulmj4dtTZrxaulqrjaLZHSbnPzx75SJsTNYmotKsqn1JlLnDJa+lz5hn90HJofhl/2MAtw0mCrgM3qYw==}
     engines: {node: '>=20'}
     hasBin: true
-
-  '@vitejs/devtools-kit@0.3.4':
-    resolution: {integrity: sha512-QHvb3wF0KZxvbfEplzzdGenB/dWoPBQlUnw3VVBm5qUYTdoud8rOoem9QI6h/+7a+iwy88LmLigxbSXbbv2Uyg==}
-    peerDependencies:
-      vite: '*'
 
   '@vitejs/plugin-vue-jsx@5.1.6':
     resolution: {integrity: sha512-YXvi4as2clxt6DFw5+a0tTA97ntiQXm/raR8ofNj3aNwwdlVGTiG2gp7EvfZW17P50acL/9bP0ccF4XnqNmlgA==}
@@ -3395,15 +2374,6 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
-
-  '@vue-macros/common@3.1.2':
-    resolution: {integrity: sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==}
-    engines: {node: '>=20.19.0'}
-    peerDependencies:
-      vue: ^2.7.0 || ^3.2.25
-    peerDependenciesMeta:
-      vue:
-        optional: true
 
   '@vue-macros/common@3.1.4':
     resolution: {integrity: sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==}
@@ -3430,47 +2400,20 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@vue/compiler-core@3.5.34':
-    resolution: {integrity: sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==}
-
-  '@vue/compiler-core@3.5.39':
-    resolution: {integrity: sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==}
-
   '@vue/compiler-core@3.5.41':
     resolution: {integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==}
-
-  '@vue/compiler-dom@3.5.34':
-    resolution: {integrity: sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==}
-
-  '@vue/compiler-dom@3.5.39':
-    resolution: {integrity: sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==}
 
   '@vue/compiler-dom@3.5.41':
     resolution: {integrity: sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==}
 
-  '@vue/compiler-sfc@3.5.34':
-    resolution: {integrity: sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==}
-
-  '@vue/compiler-sfc@3.5.39':
-    resolution: {integrity: sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==}
-
   '@vue/compiler-sfc@3.5.41':
     resolution: {integrity: sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==}
-
-  '@vue/compiler-ssr@3.5.34':
-    resolution: {integrity: sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==}
-
-  '@vue/compiler-ssr@3.5.39':
-    resolution: {integrity: sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==}
 
   '@vue/compiler-ssr@3.5.41':
     resolution: {integrity: sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==}
 
-  '@vue/devtools-api@7.7.9':
-    resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
-
-  '@vue/devtools-api@8.1.2':
-    resolution: {integrity: sha512-vA0O112YqyDuNA1s7Yb2gCgToQ/OxOWiFDO5ThLCcDy0ldHnSd1dUTaSYhOldbqoNgumE4dxtGAoAaSUKUD1Zg==}
+  '@vue/devtools-api@7.7.10':
+    resolution: {integrity: sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==}
 
   '@vue/devtools-api@8.2.1':
     resolution: {integrity: sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==}
@@ -3480,55 +2423,29 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@vue/devtools-kit@7.7.9':
-    resolution: {integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==}
-
-  '@vue/devtools-kit@8.1.2':
-    resolution: {integrity: sha512-f75/upc+GCyjXErpgPGz4582ujS0L/adAltGy+tqXMGUJpgAcfGr6CxnnhpZY8BHuMYt6KpbF8uaFrrQG66rGQ==}
+  '@vue/devtools-kit@7.7.10':
+    resolution: {integrity: sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==}
 
   '@vue/devtools-kit@8.2.1':
     resolution: {integrity: sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==}
 
-  '@vue/devtools-shared@7.7.9':
-    resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
-
-  '@vue/devtools-shared@8.1.2':
-    resolution: {integrity: sha512-X9RyVFYAdkBe4IUf5v48TxBF/6QPmF8CmWrDAjXzfUHrgQ/HGfTC1A6TqgXqZ03ye66l3AD51BAGD69IvKM9sw==}
+  '@vue/devtools-shared@7.7.10':
+    resolution: {integrity: sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==}
 
   '@vue/devtools-shared@8.2.1':
     resolution: {integrity: sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==}
 
-  '@vue/reactivity@3.5.34':
-    resolution: {integrity: sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==}
-
   '@vue/reactivity@3.5.41':
     resolution: {integrity: sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==}
-
-  '@vue/runtime-core@3.5.34':
-    resolution: {integrity: sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==}
 
   '@vue/runtime-core@3.5.41':
     resolution: {integrity: sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==}
 
-  '@vue/runtime-dom@3.5.34':
-    resolution: {integrity: sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==}
-
   '@vue/runtime-dom@3.5.41':
     resolution: {integrity: sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==}
 
-  '@vue/server-renderer@3.5.34':
-    resolution: {integrity: sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==}
-    peerDependencies:
-      vue: 3.5.34
-
   '@vue/server-renderer@3.5.41':
     resolution: {integrity: sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==}
-
-  '@vue/shared@3.5.34':
-    resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
-
-  '@vue/shared@3.5.39':
-    resolution: {integrity: sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==}
 
   '@vue/shared@3.5.41':
     resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
@@ -3539,73 +2456,16 @@ packages:
       vue: ^3.0.0
       vuetify: '>=3'
 
-  '@vueuse/core@10.11.1':
-    resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
-
-  '@vueuse/core@14.3.0':
-    resolution: {integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==}
+  '@vueuse/core@14.4.0':
+    resolution: {integrity: sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==}
     peerDependencies:
       vue: ^3.5.0
 
-  '@vueuse/integrations@14.3.0':
-    resolution: {integrity: sha512-76I5FT2ESvCmCaSwapI+a/u/CFtNXmzl9f9lNp1hRtx8vKB8hfiokJr8IvQqcQG5ckGXElyXK516b54ozV3MvA==}
-    peerDependencies:
-      async-validator: ^4
-      axios: ^1
-      change-case: ^5
-      drauu: ^0.4
-      focus-trap: ^7 || ^8
-      fuse.js: ^7
-      idb-keyval: ^6
-      jwt-decode: ^4
-      nprogress: ^0.2
-      qrcode: ^1.5
-      sortablejs: ^1
-      universal-cookie: ^7 || ^8
-      vue: ^3.5.0
-    peerDependenciesMeta:
-      async-validator:
-        optional: true
-      axios:
-        optional: true
-      change-case:
-        optional: true
-      drauu:
-        optional: true
-      focus-trap:
-        optional: true
-      fuse.js:
-        optional: true
-      idb-keyval:
-        optional: true
-      jwt-decode:
-        optional: true
-      nprogress:
-        optional: true
-      qrcode:
-        optional: true
-      sortablejs:
-        optional: true
-      universal-cookie:
-        optional: true
+  '@vueuse/metadata@14.4.0':
+    resolution: {integrity: sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==}
 
-  '@vueuse/metadata@10.11.1':
-    resolution: {integrity: sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==}
-
-  '@vueuse/metadata@14.3.0':
-    resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
-
-  '@vueuse/nuxt@14.3.0':
-    resolution: {integrity: sha512-Uxaz/DsNa3i7vHTSjZin5R17R5pt+MtpAifsfqhV1qiBZti1wYv+/S3xysCMHuuiWyLIbbignKxIsgG9ul5kEA==}
-    peerDependencies:
-      nuxt: ^3.0.0 || ^4.0.0-0
-      vue: ^3.5.0
-
-  '@vueuse/shared@10.11.1':
-    resolution: {integrity: sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==}
-
-  '@vueuse/shared@14.3.0':
-    resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
+  '@vueuse/shared@14.4.0':
+    resolution: {integrity: sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==}
     peerDependencies:
       vue: ^3.5.0
 
@@ -3627,11 +2487,6 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   acorn@8.18.0:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
@@ -3646,10 +2501,6 @@ packages:
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
-
-  ansi-escapes@7.3.0:
-    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
-    engines: {node: '>=18'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -3666,10 +2517,6 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
-
-  ansis@4.3.0:
-    resolution: {integrity: sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==}
-    engines: {node: '>=14'}
 
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
@@ -3697,19 +2544,12 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  aria-hidden@1.2.6:
-    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
-    engines: {node: '>=10'}
-
-  array-ify@1.0.0:
-    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+  argue-cli@3.1.0:
+    resolution: {integrity: sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==}
+    engines: {node: '>=22'}
 
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
-    engines: {node: '>=20.19.0'}
-
-  ast-walker-scope@0.8.3:
-    resolution: {integrity: sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==}
     engines: {node: '>=20.19.0'}
 
   ast-walker-scope@0.9.0:
@@ -3786,8 +2626,8 @@ packages:
       bare-events:
         optional: true
 
-  bare-url@2.5.1:
-    resolution: {integrity: sha512-cD5ciQuKlx+eumTCfqbfiL+fhQm+dHbVNB/cX4+d+I/nx4JsVop9VoFEPAs5RJ6I84QR6bZIBjpd2kjDOYeWcg==}
+  bare-url@2.4.7:
+    resolution: {integrity: sha512-o8CRCiJtib+ycO3mE4A5UChtGX4dDP2XxsWVu9P+Zc3H8tcmKwNVEDoDTXmwN+uuMhfKeT7/i7Y26xS8W7ohoA==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -3812,10 +2652,6 @@ packages:
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
-
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
@@ -3839,8 +2675,8 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
-  builtin-modules@5.2.0:
-    resolution: {integrity: sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ==}
+  builtin-modules@5.3.0:
+    resolution: {integrity: sha512-hMQUl2bUFG339QygPM97E+mc8OY1IAchORZxm4a/frcYwKzozMzRVDBwHW0NjOqGElLm2O37AVQE8ikxlZHrMQ==}
     engines: {node: '>=18.20'}
 
   bundle-name@4.1.0:
@@ -3861,16 +2697,12 @@ packages:
       magicast:
         optional: true
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
 
-  cacheable@2.3.5:
-    resolution: {integrity: sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==}
+  cacheable@2.5.0:
+    resolution: {integrity: sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -3886,17 +2718,8 @@ packages:
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
-  ccount@2.0.1:
-    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
-
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
-
-  character-entities-html4@2.1.0:
-    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
-
-  character-entities-legacy@3.0.0:
-    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   chart.js@4.5.1:
     resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
@@ -3931,14 +2754,6 @@ packages:
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
-  cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
-
-  cli-truncate@5.2.0:
-    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
-    engines: {node: '>=20'}
-
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -3964,15 +2779,6 @@ packages:
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
 
-  colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
-  colortranslator@5.0.0:
-    resolution: {integrity: sha512-Z3UPUKasUVDFCDYAjP2fmlVRf1jFHJv1izAmPjiOa0OCIw1W7iC8PZ2GsoDa8uZv+mKyWopxxStT9q05+27h7w==}
-
-  comma-separated-tokens@2.0.3:
-    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
-
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
@@ -3986,9 +2792,6 @@ packages:
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-
-  compare-func@2.0.0:
-    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
   compatx@0.2.0:
     resolution: {integrity: sha512-6gLRNt4ygsi5NyMVhceOCFv14CIdDFN7fQjX1U4+47qVE/+kjPoXMK65KWK+dWxmFzMTuKazoQ9sch6pM0p5oA==}
@@ -4007,18 +2810,22 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
-  conventional-changelog-angular@8.3.1:
-    resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
-    engines: {node: '>=18'}
+  conventional-changelog-angular@9.2.1:
+    resolution: {integrity: sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==}
+    engines: {node: '>=22'}
 
-  conventional-changelog-conventionalcommits@9.3.1:
-    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
-    engines: {node: '>=18'}
+  conventional-changelog-conventionalcommits@10.2.1:
+    resolution: {integrity: sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==}
+    engines: {node: '>=22'}
 
-  conventional-commits-parser@6.4.0:
-    resolution: {integrity: sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==}
-    engines: {node: '>=18'}
+  conventional-commits-parser@7.1.2:
+    resolution: {integrity: sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==}
+    engines: {node: '>=22'}
     hasBin: true
+
+  convert-hrtime@5.0.0:
+    resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
+    engines: {node: '>=12'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -4036,8 +2843,9 @@ packages:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
 
-  core-js-compat@3.49.0:
-    resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
+  core-js-compat@3.50.0:
+    resolution: {integrity: sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==}
+    engines: {node: '>=6.4.0'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -4059,8 +2867,8 @@ packages:
       typescript:
         optional: true
 
-  countries-list@3.3.0:
-    resolution: {integrity: sha512-XRUjS+dcZuNh/fg3+mka3bXgcg4TbQZ1gaK5IJqO6qulerBANl1bmrd20P2dgmPkBpP+5FnejiSF1gd7bgAg+g==}
+  countries-list@3.4.1:
+    resolution: {integrity: sha512-sKLGAZD5EAdzQwQ19vOp/9u33MTjmZ0CkdXPYtp/An6cyIlJ/E8TwGf2FcPe1AnzHO+h7nbTfoHyXIi58Hpa+Q==}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -4139,12 +2947,8 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  culori@4.0.2:
-    resolution: {integrity: sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  date-fns@4.3.0:
-    resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   db0@0.3.4:
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
@@ -4212,10 +3016,6 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
-
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -4230,16 +3030,20 @@ packages:
   devalue@5.9.0:
     resolution: {integrity: sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==}
 
-  devframe@0.5.4:
-    resolution: {integrity: sha512-dbHU/LuptR1aMXcizjHUeY3gu7qVaRQoFYqbbyyGuO6Y+avFA4uQtwinHtG1qa7lRel/7b8JrBDm0nbnxU3vqg==}
+  devframe@0.8.2:
+    resolution: {integrity: sha512-oodQXEQnrvufA1so/E058Z3SG3bk9AlUE5+NIAsyx5ZJH9P/oX6WMxjC0bs5PPwtKbS7pBHjxja2AD8EwGE8/Q==}
+    hasBin: true
     peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.0.0
+      '@modelcontextprotocol/client': ^2.0.0
+      '@modelcontextprotocol/server': ^2.0.0
+      cac: ^7.0.0
     peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
+      '@modelcontextprotocol/client':
         optional: true
-
-  devlop@1.1.0:
-    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+      '@modelcontextprotocol/server':
+        optional: true
+      cac:
+        optional: true
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -4269,10 +3073,6 @@ packages:
     resolution: {integrity: sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==}
     engines: {node: '>=20'}
 
-  dot-prop@5.3.0:
-    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
-    engines: {node: '>=8'}
-
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
@@ -4289,50 +3089,6 @@ packages:
   electron-to-chromium@1.5.402:
     resolution: {integrity: sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==}
 
-  embla-carousel-auto-height@8.6.0:
-    resolution: {integrity: sha512-/HrJQOEM6aol/oF33gd2QlINcXy3e19fJWvHDuHWp2bpyTa+2dm9tVVJak30m2Qy6QyQ6Fc8DkImtv7pxWOJUQ==}
-    peerDependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel-auto-scroll@8.6.0:
-    resolution: {integrity: sha512-WT9fWhNXFpbQ6kP+aS07oF5IHYLZ1Dx4DkwgCY8Hv2ZyYd2KMCPfMV1q/cA3wFGuLO7GMgKiySLX90/pQkcOdQ==}
-    peerDependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel-autoplay@8.6.0:
-    resolution: {integrity: sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==}
-    peerDependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel-class-names@8.6.0:
-    resolution: {integrity: sha512-l1hm1+7GxQ+zwdU2sea/LhD946on7XO2qk3Xq2XWSwBaWfdgchXdK567yzLtYSHn4sWYdiX+x4nnaj+saKnJkw==}
-    peerDependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel-fade@8.6.0:
-    resolution: {integrity: sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==}
-    peerDependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel-reactive-utils@8.6.0:
-    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
-    peerDependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel-vue@8.6.0:
-    resolution: {integrity: sha512-v8UO5UsyLocZnu/LbfQA7Dn2QHuZKurJY93VUmZYP//QRWoCWOsionmvLLAlibkET3pGPs7++03VhJKbWD7vhQ==}
-    peerDependencies:
-      vue: ^3.2.37
-
-  embla-carousel-wheel-gestures@8.1.0:
-    resolution: {integrity: sha512-J68jkYrxbWDmXOm2n2YHl+uMEXzkGSKjWmjaEgL9xVvPb3HqVmg6rJSKfI3sqIDVvm7mkeTy87wtG/5263XqHQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      embla-carousel: ^8.0.0 || ~8.0.0-rc03
-
-  embla-carousel@8.6.0:
-    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
-
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -4346,10 +3102,6 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
-  enhanced-resolve@5.21.6:
-    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
-    engines: {node: '>=10.13.0'}
-
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -4361,10 +3113,6 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
-
-  environment@1.1.0:
-    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
-    engines: {node: '>=18'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -4385,16 +3133,11 @@ packages:
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
-  es-toolkit@1.48.1:
-    resolution: {integrity: sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==}
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4452,8 +3195,8 @@ packages:
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
 
-  eslint-plugin-import-x@4.17.0:
-    resolution: {integrity: sha512-aM7V25Bg6YuYxtEhwjafzfS0NTMds1D2PMQI0K4KqJxQJRtkP4CO+MQTWRdBq2qAnmPxTxLevhXUBtByxJqS1w==}
+  eslint-plugin-import-x@4.17.1:
+    resolution: {integrity: sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/utils': ^8.56.0
@@ -4465,26 +3208,26 @@ packages:
       eslint-import-resolver-node:
         optional: true
 
-  eslint-plugin-jsdoc@63.0.7:
-    resolution: {integrity: sha512-pxrqGO733F7xmVYB5vQOiciiT9uddxqehawnbPjZmW2YaJR6fT5cP3UQd2BNoE85ATspCMtNL8w/a5WDGX3Qwg==}
+  eslint-plugin-jsdoc@63.3.3:
+    resolution: {integrity: sha512-xI4IeVRzRFA2DGHrPLIxF3U+oJHU3FE+P9Zb27fVs5dPHgfcpoAs0PyCbznVhK7pwR+9BPUztFeXSgpw/CL4Yg==}
     engines: {node: ^22.13.0 || >=24}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
 
-  eslint-plugin-regexp@3.1.0:
-    resolution: {integrity: sha512-qGXIC3DIKZHcK1H9A9+Byz9gmndY6TTSRkSMTZpNXdyCw2ObSehRgccJv35n9AdUakEjQp5VFNLas6BMXizCZg==}
+  eslint-plugin-regexp@3.1.1:
+    resolution: {integrity: sha512-MxR5nqoQCtVWmJwia0D2+NlXX1xzdpkslsVOZLEYQ4PQWEaL65PCZXURxaBc3lPnkNFpNxzMIRmYVxdl8giXRA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     peerDependencies:
       eslint: '>=9.38.0'
 
-  eslint-plugin-unicorn@65.0.1:
-    resolution: {integrity: sha512-daCrQrgxOoOz2uMPWB3Y3vvv/5q+ncwICI8IjoebiwtW87CaY4tAN5EEiRXTYVnf7qi1v1BGBdHOSnZLV0rx6A==}
-    engines: {node: ^20.10.0 || >=21.0.0}
+  eslint-plugin-unicorn@73.0.0:
+    resolution: {integrity: sha512-V0YatLe9nkGhXEXKe2Qljb1EY0sJHwDV0HUF1NKFwtsHh/fU7qGHDgv+6fchzZcgU2/7noHo2gdjnmo0P2uDPw==}
+    engines: {node: '>=22'}
     peerDependencies:
-      eslint: '>=9.38.0'
+      eslint: '>=10.4'
 
-  eslint-plugin-vue@10.9.2:
-    resolution: {integrity: sha512-4g7ZP3pYcuqd7Zp0pzUKcos0W+RkjBz4EGdhJ92FcYk6v03Ti/GK5NwjgsjxHK+98eXDbHeK7VtX1az7/8doZA==}
+  eslint-plugin-vue@10.10.0:
+    resolution: {integrity: sha512-dL9x9rBHqqNcByWiLOHK6L0SB97V82/NC0cZRn9cXPjM7pCuWlpQQP9bFH4vjBv80ej1ZpzAkuD8zWH1o9bZbA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@stylistic/eslint-plugin': ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
@@ -4524,8 +3267,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.5.0:
-    resolution: {integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==}
+  eslint@10.8.0:
+    resolution: {integrity: sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -4572,9 +3315,6 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
-  eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
-
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
@@ -4615,17 +3355,17 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
-  fast-xml-builder@1.2.1:
-    resolution: {integrity: sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==}
+  fast-xml-builder@1.3.0:
+    resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
 
-  fast-xml-parser@5.9.3:
-    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==}
+  fast-xml-parser@5.10.1:
+    resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
     hasBin: true
 
   fastest-levenshtein@1.0.16:
@@ -4648,8 +3388,8 @@ packages:
       picomatch:
         optional: true
 
-  file-entry-cache@11.1.3:
-    resolution: {integrity: sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==}
+  file-entry-cache@11.1.5:
+    resolution: {integrity: sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -4678,8 +3418,8 @@ packages:
     resolution: {integrity: sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==}
     engines: {node: '>=20'}
 
-  firebase@12.13.0:
-    resolution: {integrity: sha512-iutR8ejvAqk6qUClnsPz3U3VIjTWp243AX4cD3iifak5t56to1J29xUIQgSDDzaAqKvhshZerzSahwMQj2TlvA==}
+  firebase@12.17.1:
+    resolution: {integrity: sha512-dhp41ye9jMQvhx5FwjMkf/hjDHJApl7gXmvzOZGvP0M7c/GZGUnQ4qvsvlOBkF0Pa7wAwHMdcpL0ON2pXCQ4Sw==}
 
   flag-icons@7.5.0:
     resolution: {integrity: sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg==}
@@ -4688,31 +3428,14 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flat-cache@6.1.22:
-    resolution: {integrity: sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==}
+  flat-cache@6.1.23:
+    resolution: {integrity: sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==}
 
-  flatted@3.4.2:
-    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
   fnv1a-64@0.1.2:
     resolution: {integrity: sha512-mJbcILTPybAR1jdOwt/lVv8N2cffeJFFP+gVbSAwLEx1ujXH27RpPd8Rokec/KX9c76UYIB6Co+H4lQzxPnJfA==}
-
-  fontaine@0.8.0:
-    resolution: {integrity: sha512-eek1GbzOdWIj9FyQH/emqW1aEdfC3lYRCHepzwlFCm5T77fBSRSyNRKE6/antF1/B1M+SfJXVRQTY9GAr7lnDg==}
-    engines: {node: '>=18.12.0'}
-
-  fontkitten@1.0.3:
-    resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
-    engines: {node: '>=20'}
-
-  fontless@0.2.1:
-    resolution: {integrity: sha512-mUWZ8w91/mw2KEcZ6gHNoNNmsAq9Wiw2IypIux5lM03nhXm+WSloXGUNuRETNTLqZexMgpt7Aj/v63qqrsWraQ==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -4720,20 +3443,6 @@ packages:
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
-
-  framer-motion@12.42.2:
-    resolution: {integrity: sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -4747,9 +3456,9 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  fuse.js@7.4.2:
-    resolution: {integrity: sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==}
-    engines: {node: '>=10'}
+  function-timeout@1.0.2:
+    resolution: {integrity: sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==}
+    engines: {node: '>=18'}
 
   fuse.js@7.5.0:
     resolution: {integrity: sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==}
@@ -4780,17 +3489,11 @@ packages:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
 
-  get-tsconfig@4.14.0:
-    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+  get-tsconfig@4.14.1:
+    resolution: {integrity: sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==}
 
   giget@3.3.1:
     resolution: {integrity: sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==}
-    hasBin: true
-
-  git-raw-commits@5.0.1:
-    resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
-    engines: {node: '>=18'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -4826,16 +3529,12 @@ packages:
     resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
     engines: {node: '>=6'}
 
-  globals@17.7.0:
-    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
+  globals@17.9.0:
+    resolution: {integrity: sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==}
     engines: {node: '>=18'}
 
-  globby@16.2.0:
-    resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==}
-    engines: {node: '>=20'}
-
-  globby@16.2.3:
-    resolution: {integrity: sha512-VZX7TV7jmd/pn71vdnLKtgwy1IWqc3KjI9x1/UtPkwoKk5fKrNLY30ltDe3cAM5xruIN7YuuaulFt133jRrKZg==}
+  globby@16.2.2:
+    resolution: {integrity: sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==}
     engines: {node: '>=20'}
 
   globjoin@0.1.4:
@@ -4854,12 +3553,12 @@ packages:
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
-  h3@2.0.1-rc.22:
-    resolution: {integrity: sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==}
+  h3@2.0.1-rc.26:
+    resolution: {integrity: sha512-GDxlvDsKxgjRvG5UBRJYyGJTMWLV30CJ4cV+e7QCTgftDHihrvio1fVPbNembhEr6J4WNm8IWy3fookgyTweLw==}
     engines: {node: '>=20.11.1'}
     hasBin: true
     peerDependencies:
-      crossws: ^0.4.1
+      crossws: ^0.4.9
     peerDependenciesMeta:
       crossws:
         optional: true
@@ -4875,15 +3574,6 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
-
-  hast-util-to-html@9.0.5:
-    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
-
-  hast-util-whitespace@3.0.0:
-    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
-
-  hey-listen@1.0.8:
-    resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
 
   highlight.js@11.11.1:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
@@ -4907,9 +3597,6 @@ packages:
   html-tags@5.1.0:
     resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
     engines: {node: '>=20.10'}
-
-  html-void-elements@3.0.0:
-    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
@@ -4944,15 +3631,15 @@ packages:
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
 
+  identifier-regex@1.1.0:
+    resolution: {integrity: sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==}
+    engines: {node: '>=18'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
-
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   ignore@7.0.6:
@@ -4967,8 +3654,8 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
-  immutable@5.1.5:
-    resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
+  immutable@5.1.9:
+    resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -5041,13 +3728,13 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
-    engines: {node: '>=18'}
-
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-identifier@1.1.0:
+    resolution: {integrity: sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==}
+    engines: {node: '>=18'}
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -5069,10 +3756,6 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  is-obj@2.0.0:
-    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
-    engines: {node: '>=8'}
-
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
@@ -5092,8 +3775,8 @@ packages:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  is-unsafe@1.0.1:
-    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
+  is-unsafe@2.0.0:
+    resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
 
   is-what@5.5.0:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
@@ -5117,9 +3800,6 @@ packages:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
 
-  isomorphic.js@0.2.5:
-    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
-
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -5140,12 +3820,16 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
-  jsdoc-type-pratt-parser@7.2.0:
-    resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
+  jsdoc-type-pratt-parser@7.3.0:
+    resolution: {integrity: sha512-DoyJXo7x/n48M3NsGOs9QnEws0ft0tV3YsSgvWMNxz2hZtz+Q6fpqUD96lVYX4a+jcEkzHeFNDJOn68TzXfbdA==}
+    engines: {node: '>=20.0.0'}
+
+  jsdoc-type-pratt-parser@8.0.0:
+    resolution: {integrity: sha512-uQu/fXVqVaMg6gM8/E5G5+eygVcZ1NV0Z51CvqhNa2bDWxvHMl484ETr6vph4oPyC+KUcbP/w2W2pewfCiR9aQ==}
     engines: {node: '>=20.0.0'}
 
   jsesc@3.1.0:
@@ -5208,22 +3892,11 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  lib0@0.2.117:
-    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
-    engines: {node: '>=16'}
-    hasBin: true
-
-  libphonenumber-js@1.13.3:
-    resolution: {integrity: sha512-xMkdAMqcyG7iN2WZZmGIfWbYxW4orRkny+0/AXIbwL0xll2zkDX0Vzo/BXFa6+7mh2UvJl9MbcTtHk0YXkFtBA==}
+  libphonenumber-js@1.13.10:
+    resolution: {integrity: sha512-xJxrdqvbl2rtn2MaUJrUejz8J7/uZNC0V77oks2LxYrO/+ZtVpRmz+fEQMuu6VusnEB1fmpByiLS1WXecOnAnw==}
 
   lighthouse-logger@2.0.2:
     resolution: {integrity: sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==}
-
-  lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [android]
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -5231,22 +3904,10 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
   lightningcss-darwin-arm64@1.33.0:
     resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.33.0:
@@ -5255,36 +3916,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
   lightningcss-freebsd-x64@1.33.0:
     resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
-
   lightningcss-linux-arm-gnueabihf@1.33.0:
     resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
-
-  lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.33.0:
     resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
@@ -5293,26 +3935,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
-
-  lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
@@ -5321,13 +3949,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
@@ -5335,22 +3956,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [win32]
-
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [win32]
-
-  lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.33.0:
@@ -5358,10 +3967,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
-
-  lightningcss@1.32.0:
-    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
-    engines: {node: '>= 12.0.0'}
 
   lightningcss@1.33.0:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
@@ -5374,11 +3979,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkifyjs@4.3.3:
-    resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
-
-  lint-staged@17.0.8:
-    resolution: {integrity: sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==}
+  lint-staged@17.3.0:
+    resolution: {integrity: sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==}
     engines: {node: '>=22.22.1'}
     hasBin: true
 
@@ -5390,10 +3992,6 @@ packages:
     peerDependenciesMeta:
       '@parcel/watcher':
         optional: true
-
-  listr2@10.2.1:
-    resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
-    engines: {node: '>=22.13.0'}
 
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
@@ -5428,10 +4026,6 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
-  log-update@6.1.0:
-    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
-    engines: {node: '>=18'}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -5445,9 +4039,6 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  magic-regexp@0.10.0:
-    resolution: {integrity: sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==}
-
   magic-string-ast@1.0.3:
     resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
     engines: {node: '>=20.19.0'}
@@ -5458,16 +4049,12 @@ packages:
   magic-string@1.1.0:
     resolution: {integrity: sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==}
 
-  magicast@0.5.3:
-    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
-
   magicast@0.5.4:
     resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
 
-  marked@17.0.6:
-    resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
-    engines: {node: '>= 20'}
-    hasBin: true
+  make-asynchronous@1.1.0:
+    resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
+    engines: {node: '>=18'}
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
@@ -5475,18 +4062,14 @@ packages:
   mathml-tag-names@4.0.0:
     resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
 
-  mdast-util-to-hast@13.2.1:
-    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
-
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
-  meow@13.2.0:
-    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
-    engines: {node: '>=18'}
+  mdn-data@2.29.0:
+    resolution: {integrity: sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==}
 
   meow@14.1.0:
     resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
@@ -5498,21 +4081,6 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-
-  micromark-util-character@2.1.1:
-    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
-
-  micromark-util-encode@2.0.1:
-    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
-
-  micromark-util-sanitize-uri@2.0.1:
-    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
-
-  micromark-util-symbol@2.0.1:
-    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
-
-  micromark-util-types@2.0.2:
-    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -5534,14 +4102,6 @@ packages:
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
-
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
-
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
-    engines: {node: 18 || 20 || >=22}
 
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
@@ -5575,18 +4135,6 @@ packages:
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
-  motion-dom@12.42.2:
-    resolution: {integrity: sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==}
-
-  motion-utils@12.39.0:
-    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
-
-  motion-v@2.3.0:
-    resolution: {integrity: sha512-J0CCfXtICCni9RjotDUBOs57xNpYI9yyBSohEOxaRHrmjwOtlw291fhRu/mdgEdSasys96R028YDDOAtWBbRaA==}
-    peerDependencies:
-      '@vueuse/core': '>=10.0.0'
-      vue: '>=3.0.0'
-
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -5596,11 +4144,6 @@ packages:
 
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
-
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.17:
     resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
@@ -5667,9 +4210,6 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
-  nostics@0.2.0:
-    resolution: {integrity: sha512-/WQpI46UMbqvy1okYb+V+9wW3J8/m6GJ33wm691n/tyi6YtJiZ6ssJjENAU7y4evfYrrgYN9HllKDzPvffil1w==}
-
   nostics@1.2.0:
     resolution: {integrity: sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==}
 
@@ -5684,21 +4224,23 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  nuxt-link-checker@5.1.2:
-    resolution: {integrity: sha512-qnRRT0suYq3xTf4EGQbo0Dx0LShVOMTa3WTULJhhvn/WkpbC95uvDKQAX+/JCME3EPob4ADiy8PPTqsc74Z/ig==}
+  nuxt-link-checker@5.1.3:
+    resolution: {integrity: sha512-tGNgRzJli+vwlfxHRDViLGRjAgrha1weXeuId9PuG5IJRM1juQqQa7hkilOphUwKgh5MzNejYBcnzad8wip5JQ==}
     peerDependencies:
       nuxt: ^3.9.0 || ^4.0.0
 
-  nuxt-og-image@6.7.2:
-    resolution: {integrity: sha512-+TdTqdimQvMrTxWrvci3hHLxsgP/RhkQQ+4XawLgis9tWpGCxmbdSfrelBr9C0LeQ/vhc7ztSIOzsewcGbLpXw==}
+  nuxt-og-image@6.7.6:
+    resolution: {integrity: sha512-XjqbFnfgQzZQB0rKWxOHhaFJk9RUJrLRK70WuHXVRv556Y9D44LVFb9oFMrgIHy88gB7icySaoAA3rKlYbEJCQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
       '@resvg/resvg-js': ^2.6.0
       '@resvg/resvg-wasm': ^2.6.0
-      '@takumi-rs/core': ^1.0.0-beta.3 || ^2.0.0-rc.5
-      '@takumi-rs/wasm': ^1.0.0-beta.3 || ^2.0.0-rc.5
+      '@takumi-rs/core': ^1.0.0-beta.3 || ^2.0.0
+      '@takumi-rs/wasm': ^1.0.0-beta.3 || ^2.0.0
       '@unhead/vue': ^2.0.5 || ^3.0.0
+      '@unocss/config': ^66.7.5
+      '@unocss/core': ^66.7.5
       fontless: ^0.2.0
       nitropack: ^2.13.4
       playwright-core: ^1.50.0
@@ -5717,6 +4259,10 @@ packages:
         optional: true
       '@takumi-rs/wasm':
         optional: true
+      '@unocss/config':
+        optional: true
+      '@unocss/core':
+        optional: true
       fontless:
         optional: true
       nitropack:
@@ -5734,8 +4280,8 @@ packages:
       zod:
         optional: true
 
-  nuxt-schema-org@6.2.3:
-    resolution: {integrity: sha512-EkiLjx967+ckgSTxDRb1lDLL+AQgsmn1QhW+NRH23r9VtU3MI80hY69/XE5bEnYs0QPRYHRgppF/v9IUZ0XwEQ==}
+  nuxt-schema-org@6.2.8:
+    resolution: {integrity: sha512-gjOnLZLBt6WMXYbW1UmbVG72z7RCLFBk3EsKZP1mfePhgeDtXwgtceTgPntXDcNB3qEHeeeG9H7qlI3yNzv1nw==}
     peerDependencies:
       '@unhead/vue': ^2.0.7 || ^3.0.0
       unhead: ^2.0.7 || ^3.0.0
@@ -5748,10 +4294,11 @@ packages:
       zod:
         optional: true
 
-  nuxt-seo-utils@8.3.1:
-    resolution: {integrity: sha512-IChfSk6HYHeeZwTDQB2n/1Yj7jDflCWdeI6ZlElfdanZL673wE56CvAW9B1xrfGRkPalLy49OoLfp8YOzlzR7A==}
+  nuxt-seo-utils@8.3.3:
+    resolution: {integrity: sha512-uj7TQh9evOQzskyZwgUXxUghGRBf5DiRAi8xL0EiaGADIvY8sAuJGYaZJPpDkGCb+hm8GKtjglkNUd+K3CSiHA==}
     hasBin: true
     peerDependencies:
+      '@unhead/bundler': ^3.2.1
       '@unhead/vue': ^2.0.7 || ^3.0.0
       esbuild: '>=0.17.0'
       lightningcss: '>=1.20.0'
@@ -5759,6 +4306,8 @@ packages:
       rolldown: '>=1.0.0-beta.0'
       unhead: ^2.0.7 || ^3.0.0
     peerDependenciesMeta:
+      '@unhead/bundler':
+        optional: true
       '@unhead/vue':
         optional: true
       esbuild:
@@ -5770,33 +4319,33 @@ packages:
       unhead:
         optional: true
 
-  nuxt-site-config-kit@4.1.1:
-    resolution: {integrity: sha512-xa341q3+RbpfNNKTwQ2Nsn980WZqF3zZPIR4PlF0xsm2M8Qfxtuaa1I7wMq6/fg/E2J9IyUm0DQ+B4mnKtMs4Q==}
+  nuxt-site-config-kit@4.2.0:
+    resolution: {integrity: sha512-5vcDTXMwvFquFf8jesB2CuZOEZtOx7ZrP9RqqF9ZvZgMyCWVYLDSDdbE+/onTXb42AjfaYTb+gwHF3sZ2ZLuGw==}
 
-  nuxt-site-config@4.1.1:
-    resolution: {integrity: sha512-hYf7YtYng5fsuxeAH5hE11sC/Q18pPa8MOULYS2GKb9KjIMiK+d57mDIU/8i4AabVyxrYKJkNuqIg/c4dWrYAw==}
+  nuxt-site-config@4.2.0:
+    resolution: {integrity: sha512-Vyb8/ylP1KYuH/IlMTaY0PQgQfqEQZYAi8AQXq0ymTTboexMlLIrF1s17BFIx8jbtI5rrKWCa5xPbHGNtJ34FQ==}
+    peerDependencies:
+      vue: ^3.5.30
 
-  nuxt@4.5.1:
-    resolution: {integrity: sha512-bDfkB3VKenF7diLS+r6hBGjW/5hyH35q2xHZ355jEYuD1/dVC/3DW8yW8P+8p+Qk8MX+J0TmD66+jxnCandEpA==}
+  nuxt@4.5.2:
+    resolution: {integrity: sha512-tR3fcqeHlHmmkLMpIg3V7Y+1ltr302lW8djMw/iy+myfo7QSSz+BVJDuQhg5j73b9oteSyBfOKTDYTgvMtj6TA==}
     engines: {node: ^22.19.0 || ^24.11.0 || >=26.0.0}
     hasBin: true
     peerDependencies:
       '@parcel/watcher': ^2.1.0
       '@types/node': '>=18.12.0'
+      rolldown: ~1.2.1
     peerDependenciesMeta:
       '@parcel/watcher':
         optional: true
       '@types/node':
         optional: true
 
-  nuxtseo-layer-devtools@5.3.2:
-    resolution: {integrity: sha512-fXWMKHJqmRxOyissWW10Jgc4dSD4Z8BrjJ/rDjF68esn62fotXwaW9aLpBSrm28NVb0SpLdJlJ2IgmF4jc2sdw==}
-
-  nuxtseo-shared@5.3.2:
-    resolution: {integrity: sha512-0A+oVQJUvcNKFqB/lzhG5+YhthZmrpzRv2os0LRsPbGNXwj1w3qUbmd0d7SRIP80cto1lKhZfSNZ/HxoCsbI4A==}
+  nuxtseo-shared@5.3.10:
+    resolution: {integrity: sha512-6TduAGz7Kx2ytOpHU6DMXr5voAolq4104D7KZ9EK6I5ABCV+PDrIxB1xeu8OLLYpD/Yf+REFvM+HIIVCqSRCoQ==}
     peerDependencies:
-      '@nuxt/schema': ^3.16.0 || ^4.0.0
-      nuxt: ^3.16.0 || ^4.0.0
+      '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
+      nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
       nuxt-site-config: ^3.2.0 || ^4.0.0
       vue: ^3.5.0
       zod: ^3.23.0 || ^4.0.0
@@ -5842,16 +4391,6 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
-  onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
-
-  oniguruma-parser@0.12.2:
-    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
-
-  oniguruma-to-es@4.3.6:
-    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
-
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
@@ -5860,19 +4399,8 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
-  orderedmap@2.1.1:
-    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
-
-  oxc-parser@0.132.0:
-    resolution: {integrity: sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
-  oxc-parser@0.137.0:
-    resolution: {integrity: sha512-yFImD+WLElJpLKy8llG1qe4DCmMsL18peRp8XP1JKfig/gISbJkglnpDtX2aTmAn10kZF7164HbN2H8QPsXxGg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
-  oxc-parser@0.138.0:
-    resolution: {integrity: sha512-c25lvfpZ2+WY1yk6NkP0X0RTQg0ZxgSVaZHDa7lt6fEe1jwZjPWkRWvTyZ1xyaM7roVJMdtRCfbhUj/d4ims3Q==}
+  oxc-parser@0.142.0:
+    resolution: {integrity: sha512-kKR+jPiRJYJDexVoziIg/FVGvr1fT1FZSSJOk6tVoMKKSlsf1Cso+cgGCJkOEDWOP174vRntCPFKg+AS7InWvw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-walker@1.1.1:
@@ -5888,6 +4416,10 @@ packages:
         optional: true
       rolldown:
         optional: true
+
+  p-event@6.0.1:
+    resolution: {integrity: sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==}
+    engines: {node: '>=16.17'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -5913,6 +4445,10 @@ packages:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  p-timeout@6.1.4:
+    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
+    engines: {node: '>=14.16'}
+
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
@@ -5920,8 +4456,8 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
-  package-manager-detector@1.6.0:
-    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -5945,8 +4481,8 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-expression-matcher@1.6.1:
-    resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==}
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
     engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
@@ -5986,10 +4522,6 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -6184,10 +4716,6 @@ packages:
     peerDependencies:
       postcss: ^8.4.31
 
-  postcss-selector-parser@7.1.1:
-    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
-    engines: {node: '>=4'}
-
   postcss-selector-parser@7.1.5:
     resolution: {integrity: sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==}
     engines: {node: '>=4'}
@@ -6207,10 +4735,6 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -6223,8 +4747,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6242,58 +4766,16 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
-  property-information@7.2.0:
-    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
-
-  prosemirror-changeset@2.4.1:
-    resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
-
-  prosemirror-commands@1.7.2:
-    resolution: {integrity: sha512-q6Q6szxqdu9Xd6EcdKsqXghu5nQdZTpB4Q9yd04WRc7/jt763e/rT60Owh0L1GYY+T46o5rD+9lEN36dZS43tw==}
-
-  prosemirror-dropcursor@1.8.3:
-    resolution: {integrity: sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==}
-
-  prosemirror-gapcursor@1.4.1:
-    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
-
-  prosemirror-history@1.5.0:
-    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
-
-  prosemirror-inputrules@1.5.1:
-    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
-
-  prosemirror-keymap@1.2.3:
-    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
-
-  prosemirror-model@1.25.11:
-    resolution: {integrity: sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==}
-
-  prosemirror-schema-list@1.5.1:
-    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
-
-  prosemirror-state@1.4.4:
-    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
-
-  prosemirror-tables@1.8.5:
-    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
-
-  prosemirror-transform@1.12.0:
-    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
-
-  prosemirror-view@1.42.2:
-    resolution: {integrity: sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==}
-
-  protobufjs@7.6.1:
-    resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  pusher-js@8.5.0:
-    resolution: {integrity: sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw==}
+  pusher-js@8.6.0:
+    resolution: {integrity: sha512-wShJPfCS/kYkCBVzVW67wa9cnQIgHTszEK2XHNrFkOgGruuGw081aERAxfRjfdFU+WcIt8x6dvbwkTW4iZuQ8Q==}
 
   qified@0.10.1:
     resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
@@ -6307,11 +4789,12 @@ packages:
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
-  quansync@1.0.0:
-    resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
-
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quote-js-string@0.1.0:
+    resolution: {integrity: sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA==}
+    engines: {node: '>=22'}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -6322,6 +4805,10 @@ packages:
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
+
+  re2js@2.8.6:
+    resolution: {integrity: sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==}
+    engines: {node: '>=18.0.0'}
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -6349,31 +4836,13 @@ packages:
     resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  regex-recursion@6.0.2:
-    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
-
-  regex-utilities@2.3.0:
-    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
-
-  regex@6.1.0:
-    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
-
   regexp-ast-analysis@0.7.1:
     resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  regexp-tree@0.1.27:
-    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
-    hasBin: true
-
   regjsparser@0.13.2:
     resolution: {integrity: sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==}
     hasBin: true
-
-  reka-ui@2.9.10:
-    resolution: {integrity: sha512-yuvZVTp4fWH2G3qk+ze/x6YYlyc2Xl1d+eMUlIYrKqzTowBKteoDoN17fitURmqSUck3mc7JbcYgp49DnGu2EQ==}
-    peerDependencies:
-      vue: '>= 3.4.0'
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -6405,10 +4874,6 @@ packages:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
-
-  restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
@@ -6453,12 +4918,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rope-sequence@1.3.4:
-    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
-
-  rou3@0.8.1:
-    resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
-
   rou3@0.9.1:
     resolution: {integrity: sha512-z/sSmzvtwMDDnxsPVhfWMuG6F6mbmhFDXoVqLmMfbpDD9qfV3GDmSQpf0+W296/ZDIpW2wcMmBfpVFzcnOi/nA==}
 
@@ -6475,8 +4934,8 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  sass@1.100.0:
-    resolution: {integrity: sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==}
+  sass@1.102.0:
+    resolution: {integrity: sha512-NSOyTnaQF7rTAEOtI2fwb386vL+akyiQLBZu8Na7hXCb+umJy0GAqlcMIaqACZ6Z1VgTBS4K9PG6B3IdjHGJsw==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -6493,11 +4952,6 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
-    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.8.5:
@@ -6551,10 +5005,6 @@ packages:
     resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
-  shiki@4.3.1:
-    resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
-    engines: {node: '>=20'}
-
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -6572,10 +5022,14 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  site-config-stack@4.1.1:
-    resolution: {integrity: sha512-sJoqaL3ihMkAGgOXBfg28zL55qZdzgNj0BQBQf3QSw2ilCYSGRNYWgg6kucxmmcyFtRC89WlOXAqG0OR422Xng==}
+  site-config-stack@4.2.0:
+    resolution: {integrity: sha512-clV6zAwnsl/xQJCYE+Z/QHciPZ5DP5B3L0s7plOJ92ro8kIe6D/UZlX8JGZC1E18CUeyeJTKBcFWNIRZxSdUJw==}
     peerDependencies:
       vue: ^3.5.30
+
+  sitemapd@0.2.1:
+    resolution: {integrity: sha512-ei/QCl/cxTPEC8b/KtibUalvORO4q1ZIN8h22gq6DaSUuHO9jolYViHSojEDPll/AmH4CQnFDkKNuiyMOs83ig==}
+    engines: {node: '>=18.0.0'}
 
   slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
@@ -6584,14 +5038,6 @@ packages:
   slice-ansi@4.0.0:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
-
-  slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
-
-  slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
 
   smob@1.6.2:
     resolution: {integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==}
@@ -6612,14 +5058,11 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
-  space-separated-tokens@2.0.2:
-    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
-
   spdx-exceptions@2.5.0:
     resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
 
-  spdx-expression-parse@4.0.0:
-    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+  spdx-expression-parse@5.0.0:
+    resolution: {integrity: sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==}
 
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
@@ -6630,6 +5073,11 @@ packages:
 
   srvx@0.11.22:
     resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
+  srvx@0.12.5:
+    resolution: {integrity: sha512-IuvtDNQg5EIwv3c6dleyau7u8hCyGQ7D6+V/QM799Aud07z0wCUcurKLTRfyG33C8oUY+UWcVBFkfHMcbtmRLA==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -6666,10 +5114,6 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
-  string-width@8.2.1:
-    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
-    engines: {node: '>=20'}
-
   string-width@8.2.2:
     resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
     engines: {node: '>=20'}
@@ -6679,9 +5123,6 @@ packages:
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
-  stringify-entities@4.0.4:
-    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -6699,9 +5140,6 @@ packages:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
     engines: {node: '>=12'}
 
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
-
   strip-literal@4.0.0:
     resolution: {integrity: sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==}
 
@@ -6717,12 +5155,12 @@ packages:
     peerDependencies:
       postcss: ^8.5.25
 
-  stylelint-config-html@1.1.0:
-    resolution: {integrity: sha512-IZv4IVESjKLumUGi+HWeb7skgO6/g4VMuAYrJdlqQFndgbj6WJAXPhaysvBiXefX79upBdQVumgYcdd17gCpjQ==}
-    engines: {node: ^12 || >=14}
+  stylelint-config-html@2.0.0:
+    resolution: {integrity: sha512-Lk1NPEdUxzHkPv3ehktjpiOk4MPaqQ3H8fkvhxdWlQpaZCm9ze0SoMbRQLqkUxEMfPE1G9/x968uxm/+d2njoA==}
+    engines: {node: ^22.12 || >=24}
     peerDependencies:
-      postcss-html: ^1.0.0
-      stylelint: '>=14.0.0'
+      postcss-html: ^2.0.0
+      stylelint: '>=16.0.0'
 
   stylelint-config-recommended-vue@1.6.1:
     resolution: {integrity: sha512-lLW7hTIMBiTfjenGuDq2kyHA6fBWd/+Df7MO4/AWOxiFeXP9clbpKgg27kHfwA3H7UNMGC7aeP3mNlZB5LMmEQ==}
@@ -6743,10 +5181,14 @@ packages:
     peerDependencies:
       stylelint: ^17.0.0
 
-  stylelint@17.13.0:
-    resolution: {integrity: sha512-G1WYzMerp7ihOaIe9VJCHLt12MoAD2QLf1AFerYP37+BCRBUK5UCpq8e/mN+zCIaJPKQcaxhE4WlPmqdiOx/gw==}
+  stylelint@17.14.1:
+    resolution: {integrity: sha512-xVQwyiuxALUBNB2fBe0tmNemg9KqLtdj3T64mioFDar79B2cU8LIyz+3KL6LdiHs9NkeNfwxpKSaIVOY8f112g==}
     engines: {node: '>=20.19.0'}
     hasBin: true
+
+  super-regex@1.1.0:
+    resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
+    engines: {node: '>=18'}
 
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
@@ -6780,26 +5222,6 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tailwind-merge@3.6.0:
-    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
-
-  tailwind-variants@3.2.2:
-    resolution: {integrity: sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg==}
-    engines: {node: '>=16.x', pnpm: '>=7.x'}
-    peerDependencies:
-      tailwind-merge: '>=3.0.0'
-      tailwindcss: '*'
-    peerDependenciesMeta:
-      tailwind-merge:
-        optional: true
-
-  tailwindcss@4.3.2:
-    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
-
-  tapable@2.3.3:
-    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
-    engines: {node: '>=6'}
-
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
@@ -6818,8 +5240,9 @@ packages:
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
-  tiny-inflate@1.0.3:
-    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+  time-span@5.1.0:
+    resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
+    engines: {node: '>=12'}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -6828,21 +5251,9 @@ packages:
     resolution: {integrity: sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==}
     engines: {node: ^16.14.0 || >= 17.3.0}
 
-  tinyexec@1.2.2:
-    resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
-    engines: {node: '>=18'}
-
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -6867,9 +5278,6 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
-  trim-lines@3.0.1:
-    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
-
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -6879,8 +5287,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.22.3:
-    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+  tsx@4.23.10:
+    resolution: {integrity: sha512-0Vb9eKU47njkxv/6B8CRZRDsxNDT/Pz+BIU+M5jw7xL3TdzAjSxlZUxu0xFL/kLpaG3sHZ0LH2wbK1T1yo7CUQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -6891,12 +5299,13 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   type-fest@5.8.0:
     resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
     engines: {node: '>=20'}
-
-  type-level-regexp@0.1.17:
-    resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -6909,14 +5318,8 @@ packages:
   ultrahtml@1.7.0:
     resolution: {integrity: sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==}
 
-  unconfig-core@7.5.0:
-    resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
-
   unconfig@0.6.1:
     resolution: {integrity: sha512-cVU+/sPloZqOyJEAfNwnQSFCzFrZm85vcVkryH7lnlB/PiTycUkAjt5Ds79cfIshGOZ+M5v3PBDnKgpmlE5DtA==}
-
-  unconfig@7.5.0:
-    resolution: {integrity: sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==}
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
@@ -6941,8 +5344,8 @@ packages:
       unplugin:
         optional: true
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   undici@8.10.0:
     resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
@@ -6950,9 +5353,6 @@ packages:
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
-
-  unhead@2.1.17:
-    resolution: {integrity: sha512-HLMKXOszRhAPBrr6VlqCeVeJq2kbC4kXwzGLEZvvojPLWNYTJw22xG7Bfwhsvs31+IBet3Wl8ADg9dwYdyphfQ==}
 
   unhead@3.3.1:
     resolution: {integrity: sha512-eqHlbLyuvIXw898WopQmosTml4PdYW5ZhXDom/sf7ysAqQB9uvYrw2/dNvbrmkJTufSkmNmgGCjoQcvoT2mS/A==}
@@ -6970,25 +5370,6 @@ packages:
     resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
     engines: {node: '>=20'}
 
-  unifont@0.7.4:
-    resolution: {integrity: sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==}
-
-  unimport@5.7.0:
-    resolution: {integrity: sha512-njnL6sp8lEA8QQbZrt+52p/g4X0rw3bnGGmUcJnt1jeG8+iiqO779aGz0PirCtydAIVcuTBRlJ52F0u46z309Q==}
-    engines: {node: '>=18.12.0'}
-
-  unimport@6.3.0:
-    resolution: {integrity: sha512-M+Dxk5W9WRd+8j56W9tp8lGW/dmMc7g5zj7BWQnEjKQhryBstqsi1V0izb0zHwSkEN8cSYV7K75/bykairV2tA==}
-    engines: {node: '>=18.12.0'}
-    peerDependencies:
-      oxc-parser: '*'
-      rolldown: ^1.0.0
-    peerDependenciesMeta:
-      oxc-parser:
-        optional: true
-      rolldown:
-        optional: true
-
   unimport@6.4.0:
     resolution: {integrity: sha512-JJOOuNMFq8b4ZPBKwQUxEcba4MplskDzYI1Lvrf8rJfWphZTWvPNXWa493qsPngHUmub89w6C7j+SeLWTE/UIQ==}
     engines: {node: '>=18.12.0'}
@@ -7001,58 +5382,13 @@ packages:
       rolldown:
         optional: true
 
-  unist-util-is@6.0.1:
-    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
-
-  unist-util-position@5.0.0:
-    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
-
-  unist-util-stringify-position@4.0.0:
-    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
-
-  unist-util-visit-parents@6.0.2:
-    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
-
-  unist-util-visit@5.1.0:
-    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
-
-  unplugin-auto-import@21.0.0:
-    resolution: {integrity: sha512-vWuC8SwqJmxZFYwPojhOhOXDb5xFhNNcEVb9K/RFkyk/3VnfaOjzitWN7v+8DEKpMjSsY2AEGXNgt6I0yQrhRQ==}
-    engines: {node: '>=20.19.0'}
-    peerDependencies:
-      '@nuxt/kit': ^4.0.0
-      '@vueuse/core': '*'
-    peerDependenciesMeta:
-      '@nuxt/kit':
-        optional: true
-      '@vueuse/core':
-        optional: true
-
-  unplugin-utils@0.3.1:
-    resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
-    engines: {node: '>=20.19.0'}
-
   unplugin-utils@0.3.2:
     resolution: {integrity: sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==}
     engines: {node: '>=20.19.0'}
 
-  unplugin-vue-components@32.1.0:
-    resolution: {integrity: sha512-YiUkSxuRjab18XFOrX5VsIxXzccrfmHVGsGeJgSgklb829DQmCy9E4vvDUE4tuvZZdxyFJZX0Oc4TPnnxiiMyg==}
-    engines: {node: '>=20.19.0'}
-    peerDependencies:
-      '@nuxt/kit': ^3.2.2 || ^4.0.0
-      vue: ^3.0.0
-    peerDependenciesMeta:
-      '@nuxt/kit':
-        optional: true
-
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
-
-  unplugin@3.0.0:
-    resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   unplugin@3.3.0:
     resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
@@ -7191,29 +5527,9 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
-  valibot@1.4.1:
-    resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
-    peerDependencies:
-      typescript: '>=5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  vaul-vue@0.4.1:
-    resolution: {integrity: sha512-A6jOWOZX5yvyo1qMn7IveoWN91mJI5L3BUKsIwkg6qrTGgHs1Sb1JF/vyLJgnbN1rH4OOOxFbtqL9A46bOyGUQ==}
-    peerDependencies:
-      reka-ui: ^2.0.0
-      vue: ^3.3.0
-
-  verkit@0.2.0:
-    resolution: {integrity: sha512-6M8R2xSKplkQ+0mAm07IMh548GLLPUnRQZJCCe/W4rfk/SXW2bs8ZJSWa5kjdIdsx3hLG5oLWROJ4+N5hpX08g==}
+  verkit@0.3.2:
+    resolution: {integrity: sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==}
     engines: {node: '>=18.12.0'}
-
-  vfile-message@4.0.3:
-    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
-
-  vfile@6.0.3:
-    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-dev-rpc@2.0.0:
     resolution: {integrity: sha512-yKwbTwdHKSD2k/aGqyWpPHepo45OQc8lH3/6IfT4ZqeKE26ooKvi4WIEKzqWav8v+9Is8u1k8q54hvOmqASazA==}
@@ -7331,25 +5647,14 @@ packages:
   vue-bundle-renderer@2.3.1:
     resolution: {integrity: sha512-7F4LNMopUw5RgYWo4zCmVUHCc6aQRC6dCKHUYkM/n+fux4AUGdL1x6m5A515WWyFysRRN7cx3hBzVqoisfRfzw==}
 
-  vue-chartjs@5.3.3:
-    resolution: {integrity: sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==}
+  vue-chartjs@5.3.4:
+    resolution: {integrity: sha512-x3Fqob8RQvrTdssfi9ecsCzEkFOd8JPmNwSkSQzdfKj/uBsRJs/Y88cZcZIEcPsTVfMGwMo4MOoihoDG2DoE/g==}
     peerDependencies:
       chart.js: ^4.1.1
       vue: ^3.0.0-0 || ^2.7.0
 
-  vue-component-type-helpers@3.3.6:
-    resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
-
-  vue-demi@0.14.10:
-    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
-    engines: {node: '>=12'}
-    hasBin: true
-    peerDependencies:
-      '@vue/composition-api': ^1.0.0-rc.1
-      vue: ^3.0.0-0 || ^2.6.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
+  vue-component-type-helpers@3.3.9:
+    resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
 
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
@@ -7359,21 +5664,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-
-  vue-router@5.0.7:
-    resolution: {integrity: sha512-dqfk8kvRbCutmCOCj/XLDqDEYxc1wBdAOGLuVy5M93ifYMsBd5fIjfaPN4tQAbxr5IprdBDIox1gr4wYyOx/SA==}
-    peerDependencies:
-      '@pinia/colada': '>=0.21.2'
-      '@vue/compiler-sfc': ^3.5.34
-      pinia: ^3.0.4
-      vue: ^3.5.34
-    peerDependenciesMeta:
-      '@pinia/colada':
-        optional: true
-      '@vue/compiler-sfc':
-        optional: true
-      pinia:
-        optional: true
 
   vue-router@5.2.0:
     resolution: {integrity: sha512-QAC5i0LEb1GLG0LXDQmHu8L7FX12j0KwU/JTKmLQUJMrn04gQdKP6Du+p0QwpHb3iy71vBlqnHQ8WAfOSAWhqw==}
@@ -7393,14 +5683,6 @@ packages:
       vite:
         optional: true
 
-  vue@3.5.34:
-    resolution: {integrity: sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   vue@3.5.41:
     resolution: {integrity: sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==}
     peerDependencies:
@@ -7412,12 +5694,12 @@ packages:
   vuetify-nuxt-module@0.19.5:
     resolution: {integrity: sha512-B4SgLFqNlxaF/PZacxy+Wdy09G33E/aZXAPjNbFIblT7JOs07+VuNPrGUQuAzKwiGmU30xgkm5PL9opNpVcXTg==}
 
-  vuetify@4.0.7:
-    resolution: {integrity: sha512-SV+YJkBmudY3s9qfZO2ZGUsrD0TDQU8pMBH1ERga9AEyjGvioZuXXh93V9wHxXJphvqRC2NW10Nt2lW9IZQcPw==}
+  vuetify@4.1.8:
+    resolution: {integrity: sha512-003D/8b5462uZCD5CMRTZF3smADmOn47mzthNY0aP/xkslovR5yIc1qXjPdFN0LHcu+p3GEAVmMQabldaIQ5pg==}
     peerDependencies:
       typescript: '>=4.7'
       vite-plugin-vuetify: '>=2.1.0'
-      vue: ^3.5.0
+      vue: ^3.5.0 || ^3.6.0-0
       webpack-plugin-vuetify: '>=3.1.0'
     peerDependenciesMeta:
       typescript:
@@ -7427,11 +5709,11 @@ packages:
       webpack-plugin-vuetify:
         optional: true
 
-  w3c-keyname@2.2.8:
-    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
-
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
+
+  web-worker@1.5.0:
+    resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -7439,8 +5721,8 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -7449,10 +5731,6 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
-  wheel-gestures@2.2.48:
-    resolution: {integrity: sha512-f+Gy33Oa5Z14XY9679Zze+7VFhbsQfBFXodnU2x589l4kxGM9L5Y8zETTmcMR5pWOPQyRv4Z0lNax6xCO0NSlA==}
-    engines: {node: '>=18'}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -7478,10 +5756,6 @@ packages:
   world-flags-sprite@0.0.2:
     resolution: {integrity: sha512-v4Qjd8+5hBNVyn9AKFcVTaKZWaz0fZliHZ7FK0ugPMbAv+oI5BZrT72rBxmGiD6D86yshA08FTo/CcAaZW7buw==}
 
-  wrap-ansi@10.0.0:
-    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
-    engines: {node: '>=20'}
-
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -7502,8 +5776,8 @@ packages:
     resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  ws@8.21.3:
-    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+  ws@8.21.2:
+    resolution: {integrity: sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7518,19 +5792,13 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
-  xml-name-validator@4.0.0:
-    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
-    engines: {node: '>=12'}
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
 
-  xml-naming@0.1.0:
-    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
     engines: {node: '>=16.0.0'}
-
-  y-protocols@1.0.7:
-    resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
-    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
-    peerDependencies:
-      yjs: ^13.0.0
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -7567,21 +5835,13 @@ packages:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
 
-  yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
-
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yargs@18.1.0:
     resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yjs@13.6.31:
-    resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
-    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -7601,16 +5861,11 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
-  zwitch@2.0.4:
-    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
-
 snapshots:
 
-  '@alloc/quick-lru@5.2.0': {}
-
-  '@antfu/install-pkg@1.1.0':
+  '@antfu/install-pkg@2.0.1':
     dependencies:
-      package-manager-detector: 1.6.0
+      package-manager-detector: 1.8.0
       tinyexec: 1.3.0
 
   '@antfu/utils@8.1.1': {}
@@ -7618,7 +5873,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -7660,15 +5915,6 @@ snapshots:
     dependencies:
       '@babel/parser': 8.0.4
       '@babel/types': 8.0.4
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      '@types/jsesc': 2.5.1
-      jsesc: 3.1.0
-
-  '@babel/generator@8.0.0-rc.6':
-    dependencies:
-      '@babel/parser': 8.0.0-rc.6
-      '@babel/types': 8.0.0-rc.6
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       '@types/jsesc': 2.5.1
@@ -7750,11 +5996,7 @@ snapshots:
 
   '@babel/helper-string-parser@8.0.0': {}
 
-  '@babel/helper-string-parser@8.0.0-rc.6': {}
-
   '@babel/helper-validator-identifier@7.29.7': {}
-
-  '@babel/helper-validator-identifier@8.0.0-rc.6': {}
 
   '@babel/helper-validator-identifier@8.0.4': {}
 
@@ -7765,17 +6007,9 @@ snapshots:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.8
 
-  '@babel/parser@7.29.7':
-    dependencies:
-      '@babel/types': 7.29.7
-
   '@babel/parser@7.29.8':
     dependencies:
       '@babel/types': 7.29.8
-
-  '@babel/parser@8.0.0-rc.6':
-    dependencies:
-      '@babel/types': 8.0.0-rc.6
 
   '@babel/parser@8.0.4':
     dependencies:
@@ -7820,61 +6054,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.29.7':
-    dependencies:
-      '@babel/helper-string-parser': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-
   '@babel/types@7.29.8':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-
-  '@babel/types@8.0.0-rc.6':
-    dependencies:
-      '@babel/helper-string-parser': 8.0.0-rc.6
-      '@babel/helper-validator-identifier': 8.0.0-rc.6
 
   '@babel/types@8.0.4':
     dependencies:
       '@babel/helper-string-parser': 8.0.0
       '@babel/helper-validator-identifier': 8.0.4
 
-  '@bomb.sh/tab@0.0.19(cac@6.7.14)(citty@0.2.2)':
+  '@bomb.sh/tab@0.0.19(cac@7.0.0)(citty@0.2.2)':
     optionalDependencies:
-      cac: 6.7.14
+      cac: 7.0.0
       citty: 0.2.2
 
-  '@cacheable/memory@2.0.9':
+  '@cacheable/memory@2.2.0':
     dependencies:
-      '@cacheable/utils': 2.4.1
+      '@cacheable/utils': 2.5.0
       '@keyv/bigmap': 1.3.1(keyv@5.6.0)
       hookified: 1.15.1
       keyv: 5.6.0
 
-  '@cacheable/utils@2.4.1':
+  '@cacheable/utils@2.5.0':
     dependencies:
       hashery: 1.5.1
       keyv: 5.6.0
 
-  '@capsizecss/unpack@4.0.1':
-    dependencies:
-      fontkitten: 1.0.3
-
-  '@clack/core@1.4.2':
-    dependencies:
-      fast-wrap-ansi: 0.2.2
-      sisteransi: 1.0.5
-
   '@clack/core@1.4.3':
     dependencies:
-      fast-wrap-ansi: 0.2.2
-      sisteransi: 1.0.5
-
-  '@clack/prompts@1.6.0':
-    dependencies:
-      '@clack/core': 1.4.2
-      fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
@@ -7889,123 +6097,126 @@ snapshots:
 
   '@colordx/core@5.5.0': {}
 
-  '@commitlint/cli@21.0.2(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
+  '@commitlint/cli@21.2.1(@types/node@26.1.2)(conventional-commits-parser@7.1.2)(typescript@5.9.3)':
     dependencies:
-      '@commitlint/format': 21.0.1
-      '@commitlint/lint': 21.0.2
-      '@commitlint/load': 21.0.2(@types/node@25.9.1)(typescript@5.9.3)
-      '@commitlint/read': 21.0.2(conventional-commits-parser@6.4.0)
-      '@commitlint/types': 21.0.1
-      tinyexec: 1.2.2
-      yargs: 18.0.0
+      '@commitlint/config-conventional': 21.2.0
+      '@commitlint/format': 21.2.0
+      '@commitlint/lint': 21.2.0
+      '@commitlint/load': 21.2.0(@types/node@26.1.2)(typescript@5.9.3)
+      '@commitlint/read': 21.2.1(conventional-commits-parser@7.1.2)
+      '@commitlint/types': 21.2.0
+      tinyexec: 1.3.0
+      yargs: 18.1.0
     transitivePeerDependencies:
       - '@types/node'
       - conventional-commits-filter
       - conventional-commits-parser
       - typescript
 
-  '@commitlint/config-conventional@21.0.2':
+  '@commitlint/config-conventional@21.2.0':
     dependencies:
-      '@commitlint/types': 21.0.1
-      conventional-changelog-conventionalcommits: 9.3.1
+      '@commitlint/types': 21.2.0
+      conventional-changelog-conventionalcommits: 10.2.1
 
-  '@commitlint/config-validator@21.0.1':
+  '@commitlint/config-validator@21.2.0':
     dependencies:
-      '@commitlint/types': 21.0.1
+      '@commitlint/types': 21.2.0
       ajv: 8.20.0
 
-  '@commitlint/ensure@21.0.1':
+  '@commitlint/ensure@21.2.0':
     dependencies:
-      '@commitlint/types': 21.0.1
-      es-toolkit: 1.48.1
+      '@commitlint/types': 21.2.0
+      es-toolkit: 1.50.0
 
   '@commitlint/execute-rule@21.0.1': {}
 
-  '@commitlint/format@21.0.1':
+  '@commitlint/format@21.2.0':
     dependencies:
-      '@commitlint/types': 21.0.1
+      '@commitlint/types': 21.2.0
       picocolors: 1.1.1
 
-  '@commitlint/is-ignored@21.0.2':
+  '@commitlint/is-ignored@21.2.0':
     dependencies:
-      '@commitlint/types': 21.0.1
+      '@commitlint/types': 21.2.0
       semver: 7.8.5
 
-  '@commitlint/lint@21.0.2':
+  '@commitlint/lint@21.2.0':
     dependencies:
-      '@commitlint/is-ignored': 21.0.2
-      '@commitlint/parse': 21.0.2
-      '@commitlint/rules': 21.0.2
-      '@commitlint/types': 21.0.1
+      '@commitlint/is-ignored': 21.2.0
+      '@commitlint/parse': 21.2.0
+      '@commitlint/rules': 21.2.0
+      '@commitlint/types': 21.2.0
 
-  '@commitlint/load@21.0.2(@types/node@25.9.1)(typescript@5.9.3)':
+  '@commitlint/load@21.2.0(@types/node@26.1.2)(typescript@5.9.3)':
     dependencies:
-      '@commitlint/config-validator': 21.0.1
+      '@commitlint/config-validator': 21.2.0
       '@commitlint/execute-rule': 21.0.1
-      '@commitlint/resolve-extends': 21.0.1
-      '@commitlint/types': 21.0.1
+      '@commitlint/resolve-extends': 21.2.0
+      '@commitlint/types': 21.2.0
       cosmiconfig: 9.0.2(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.2(typescript@5.9.3))(typescript@5.9.3)
-      es-toolkit: 1.48.1
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.1.2)(cosmiconfig@9.0.2(typescript@5.9.3))(typescript@5.9.3)
+      es-toolkit: 1.50.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
     transitivePeerDependencies:
       - '@types/node'
       - typescript
 
-  '@commitlint/message@21.0.2': {}
+  '@commitlint/message@21.2.0': {}
 
-  '@commitlint/parse@21.0.2':
+  '@commitlint/parse@21.2.0':
     dependencies:
-      '@commitlint/types': 21.0.1
-      conventional-changelog-angular: 8.3.1
-      conventional-commits-parser: 6.4.0
+      '@commitlint/types': 21.2.0
+      conventional-changelog-angular: 9.2.1
+      conventional-commits-parser: 7.1.2
 
-  '@commitlint/read@21.0.2(conventional-commits-parser@6.4.0)':
+  '@commitlint/read@21.2.1(conventional-commits-parser@7.1.2)':
     dependencies:
-      '@commitlint/top-level': 21.0.2
-      '@commitlint/types': 21.0.1
-      git-raw-commits: 5.0.1(conventional-commits-parser@6.4.0)
-      tinyexec: 1.2.2
+      '@commitlint/top-level': 21.2.0
+      '@commitlint/types': 21.2.0
+      '@conventional-changelog/git-client': 3.1.1(conventional-commits-parser@7.1.2)
+      tinyexec: 1.3.0
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
 
-  '@commitlint/resolve-extends@21.0.1':
+  '@commitlint/resolve-extends@21.2.0':
     dependencies:
-      '@commitlint/config-validator': 21.0.1
-      '@commitlint/types': 21.0.1
-      es-toolkit: 1.48.1
+      '@commitlint/config-validator': 21.2.0
+      '@commitlint/types': 21.2.0
+      es-toolkit: 1.50.0
       global-directory: 5.0.0
       resolve-from: 5.0.0
 
-  '@commitlint/rules@21.0.2':
+  '@commitlint/rules@21.2.0':
     dependencies:
-      '@commitlint/ensure': 21.0.1
-      '@commitlint/message': 21.0.2
+      '@commitlint/ensure': 21.2.0
+      '@commitlint/message': 21.2.0
       '@commitlint/to-lines': 21.0.1
-      '@commitlint/types': 21.0.1
+      '@commitlint/types': 21.2.0
 
   '@commitlint/to-lines@21.0.1': {}
 
-  '@commitlint/top-level@21.0.2':
+  '@commitlint/top-level@21.2.0':
     dependencies:
       escalade: 3.2.0
 
-  '@commitlint/types@21.0.1':
+  '@commitlint/types@21.2.0':
     dependencies:
-      conventional-commits-parser: 6.4.0
+      conventional-commits-parser: 7.1.2
       picocolors: 1.1.1
 
-  '@conventional-changelog/git-client@2.7.0(conventional-commits-parser@6.4.0)':
+  '@conventional-changelog/git-client@3.1.1(conventional-commits-parser@7.1.2)':
     dependencies:
-      '@simple-libs/child-process-utils': 1.0.2
-      '@simple-libs/stream-utils': 1.2.0
+      '@simple-libs/child-process-utils': 2.0.0
+      '@simple-libs/stream-utils': 2.0.0
       semver: 7.8.5
     optionalDependencies:
-      conventional-commits-parser: 6.4.0
+      conventional-commits-parser: 7.1.2
 
-  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@conventional-changelog/template@1.2.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
@@ -8014,7 +6225,7 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
 
@@ -8025,44 +6236,25 @@ snapshots:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/selector-resolve-nested@4.0.0(postcss-selector-parser@7.1.1)':
+  '@csstools/selector-resolve-nested@4.0.1(postcss-selector-parser@7.1.5)':
     dependencies:
-      postcss-selector-parser: 7.1.1
+      postcss-selector-parser: 7.1.5
 
-  '@csstools/selector-specificity@6.0.0(postcss-selector-parser@7.1.1)':
+  '@csstools/selector-specificity@6.0.0(postcss-selector-parser@7.1.5)':
     dependencies:
-      postcss-selector-parser: 7.1.1
+      postcss-selector-parser: 7.1.5
 
-  '@devframes/hub@0.5.4(devframe@0.5.4(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
-    dependencies:
-      birpc: 4.0.0
-      devframe: 0.5.4(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      nostics: 0.2.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      tinyexec: 1.3.0
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@rspack/core'
-      - bun-types-no-globals
-      - esbuild
-      - rolldown
-      - rollup
-      - unloader
-      - vite
-      - webpack
-
-  '@dxup/nuxt@0.5.6(esbuild@0.25.12)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
+  '@dxup/nuxt@0.5.6(esbuild@0.25.12)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))':
     dependencies:
       '@dxup/unimport': 0.1.2
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       '@vue/compiler-dom': 3.5.41
       chokidar: 5.0.0
       knitwork: 1.3.0
       magic-string: 1.1.0
       pathe: 2.0.3
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -8084,7 +6276,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.11.1':
+  '@emnapi/core@1.11.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
@@ -8095,12 +6287,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.1':
+  '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.2':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8115,20 +6307,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@es-joy/jsdoccomment@0.87.0':
+  '@es-joy/jsdoccomment@0.91.0':
     dependencies:
       '@types/estree': 1.0.9
-      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/types': 8.66.0
       comment-parser: 1.4.7
       esquery: 1.7.0
-      jsdoc-type-pratt-parser: 7.2.0
+      jsdoc-type-pratt-parser: 8.0.0
 
   '@es-joy/resolve.exports@1.2.0': {}
 
   '@esbuild/aix-ppc64@0.25.12':
-    optional: true
-
-  '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
   '@esbuild/aix-ppc64@0.28.1':
@@ -8137,16 +6326,10 @@ snapshots:
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
-    optional: true
-
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
-    optional: true
-
-  '@esbuild/android-arm@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.28.1':
@@ -8155,16 +6338,10 @@ snapshots:
   '@esbuild/android-x64@0.25.12':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
-    optional: true
-
   '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.28.1':
@@ -8173,16 +6350,10 @@ snapshots:
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
-    optional: true
-
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.1':
@@ -8191,16 +6362,10 @@ snapshots:
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-arm64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.28.1':
@@ -8209,16 +6374,10 @@ snapshots:
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
-    optional: true
-
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
-    optional: true
-
-  '@esbuild/linux-ia32@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.28.1':
@@ -8227,16 +6386,10 @@ snapshots:
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
-    optional: true
-
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.28.1':
@@ -8245,16 +6398,10 @@ snapshots:
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
-    optional: true
-
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.28.1':
@@ -8263,16 +6410,10 @@ snapshots:
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
-    optional: true
-
   '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.28.1':
@@ -8281,16 +6422,10 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    optional: true
-
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.28.1':
@@ -8299,16 +6434,10 @@ snapshots:
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -8317,16 +6446,10 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    optional: true
-
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.28.1':
@@ -8335,16 +6458,10 @@ snapshots:
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
-    optional: true
-
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.28.1':
@@ -8353,30 +6470,27 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
-    optional: true
-
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0(jiti@2.7.0))':
     dependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/compat@2.1.0(eslint@10.5.0(jiti@2.7.0))':
+  '@eslint/compat@2.1.0(eslint@10.8.0(jiti@2.7.0))':
     dependencies:
       '@eslint/core': 1.2.1
     optionalDependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
 
   '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
     transitivePeerDependencies:
       - supports-color
 
@@ -8384,42 +6498,36 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
 
-  '@eslint/config-helpers@0.6.0':
+  '@eslint/config-helpers@0.7.0':
     dependencies:
       '@eslint/core': 1.2.1
 
-  '@eslint/config-inspector@3.0.4(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
+  '@eslint/config-inspector@3.2.0(eslint@10.8.0(jiti@2.7.0))(srvx@0.11.22)':
     dependencies:
-      ansis: 4.3.0
+      ansis: 4.3.1
       cac: 7.0.0
       chokidar: 5.0.0
-      devframe: 0.5.4(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      eslint: 10.5.0(jiti@2.7.0)
+      devframe: 0.8.2(cac@7.0.0)(srvx@0.11.22)
+      eslint: 10.8.0(jiti@2.7.0)
       jiti: 2.7.0
       tinyglobby: 0.2.17
     transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@modelcontextprotocol/sdk'
-      - '@rspack/core'
-      - bufferutil
-      - bun-types-no-globals
-      - crossws
-      - esbuild
-      - rolldown
-      - rollup
-      - typescript
-      - unloader
-      - utf-8-validate
-      - vite
-      - webpack
+      - '@modelcontextprotocol/client'
+      - '@modelcontextprotocol/server'
+      - srvx
 
   '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.5.0(jiti@2.7.0))':
+  '@eslint/css-tree@4.0.5':
+    dependencies:
+      mdn-data: 2.29.0
+      source-map-js: 1.2.1
+
+  '@eslint/js@10.0.1(eslint@10.8.0(jiti@2.7.0))':
     optionalDependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -8430,220 +6538,221 @@ snapshots:
 
   '@fingerprintjs/botd@2.0.0': {}
 
-  '@firebase/ai@2.12.0(@firebase/app-types@0.9.5)(@firebase/app@0.14.12)':
+  '@firebase/ai@2.14.0(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app': 0.14.12
+      '@firebase/app': 0.16.0
       '@firebase/app-check-interop-types': 0.3.4
       '@firebase/app-types': 0.9.5
-      '@firebase/component': 0.7.3
+      '@firebase/component': 0.7.4
       '@firebase/logger': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
 
-  '@firebase/analytics-compat@0.2.28(@firebase/app-compat@0.5.12)(@firebase/app@0.14.12)':
+  '@firebase/analytics-compat@0.2.29(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/analytics': 0.10.22(@firebase/app@0.14.12)
+      '@firebase/analytics': 0.10.23(@firebase/app@0.16.0)
       '@firebase/analytics-types': 0.8.4
-      '@firebase/app-compat': 0.5.12
-      '@firebase/component': 0.7.3
-      '@firebase/util': 1.15.1
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@firebase/app'
 
   '@firebase/analytics-types@0.8.4': {}
 
-  '@firebase/analytics@0.10.22(@firebase/app@0.14.12)':
+  '@firebase/analytics@0.10.23(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app': 0.14.12
-      '@firebase/component': 0.7.3
-      '@firebase/installations': 0.6.22(@firebase/app@0.14.12)
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/installations': 0.6.23(@firebase/app@0.16.0)
       '@firebase/logger': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
 
-  '@firebase/app-check-compat@0.4.3(@firebase/app-compat@0.5.12)(@firebase/app@0.14.12)':
+  '@firebase/app-check-compat@0.4.6(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app-check': 0.11.3(@firebase/app@0.14.12)
+      '@firebase/app': 0.16.0
+      '@firebase/app-check': 0.13.0(@firebase/app@0.16.0)
       '@firebase/app-check-types': 0.5.4
-      '@firebase/app-compat': 0.5.12
-      '@firebase/component': 0.7.3
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
       '@firebase/logger': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@firebase/app'
 
   '@firebase/app-check-interop-types@0.3.4': {}
 
   '@firebase/app-check-types@0.5.4': {}
 
-  '@firebase/app-check@0.11.3(@firebase/app@0.14.12)':
+  '@firebase/app-check@0.13.0(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app': 0.14.12
-      '@firebase/component': 0.7.3
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
       '@firebase/logger': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
 
-  '@firebase/app-compat@0.5.12':
+  '@firebase/app-compat@0.5.16':
     dependencies:
-      '@firebase/app': 0.14.12
-      '@firebase/component': 0.7.3
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
       '@firebase/logger': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
 
   '@firebase/app-types@0.9.5':
     dependencies:
       '@firebase/logger': 0.5.1
 
-  '@firebase/app@0.14.12':
+  '@firebase/app@0.16.0':
     dependencies:
-      '@firebase/component': 0.7.3
+      '@firebase/component': 0.7.4
       '@firebase/logger': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       idb: 7.1.1
       tslib: 2.8.1
 
-  '@firebase/auth-compat@0.6.6(@firebase/app-compat@0.5.12)(@firebase/app-types@0.9.5)(@firebase/app@0.14.12)':
+  '@firebase/auth-compat@0.6.9(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app-compat': 0.5.12
-      '@firebase/auth': 1.13.1(@firebase/app@0.14.12)
-      '@firebase/auth-types': 0.13.1(@firebase/app-types@0.9.5)(@firebase/util@1.15.1)
-      '@firebase/component': 0.7.3
-      '@firebase/util': 1.15.1
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/auth': 1.13.4(@firebase/app@0.16.0)
+      '@firebase/auth-types': 0.13.1(@firebase/app-types@0.9.5)(@firebase/util@1.15.2)
+      '@firebase/component': 0.7.4
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@firebase/app'
       - '@firebase/app-types'
       - '@react-native-async-storage/async-storage'
 
   '@firebase/auth-interop-types@0.2.5': {}
 
-  '@firebase/auth-types@0.13.1(@firebase/app-types@0.9.5)(@firebase/util@1.15.1)':
+  '@firebase/auth-types@0.13.1(@firebase/app-types@0.9.5)(@firebase/util@1.15.2)':
     dependencies:
       '@firebase/app-types': 0.9.5
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
 
-  '@firebase/auth@1.13.1(@firebase/app@0.14.12)':
+  '@firebase/auth@1.13.4(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app': 0.14.12
-      '@firebase/component': 0.7.3
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
       '@firebase/logger': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
 
-  '@firebase/component@0.7.3':
+  '@firebase/component@0.7.4':
     dependencies:
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
 
-  '@firebase/data-connect@0.7.0(@firebase/app@0.14.12)':
+  '@firebase/data-connect@0.7.3(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app': 0.14.12
+      '@firebase/app': 0.16.0
       '@firebase/auth-interop-types': 0.2.5
-      '@firebase/component': 0.7.3
+      '@firebase/component': 0.7.4
       '@firebase/logger': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
 
-  '@firebase/database-compat@2.1.4':
+  '@firebase/database-compat@2.1.6(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/component': 0.7.3
-      '@firebase/database': 1.1.3
-      '@firebase/database-types': 1.0.20
+      '@firebase/component': 0.7.4
+      '@firebase/database': 1.1.4
+      '@firebase/database-types': 1.0.21
       '@firebase/logger': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
+    optionalDependencies:
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
 
-  '@firebase/database-types@1.0.20':
+  '@firebase/database-types@1.0.21':
     dependencies:
       '@firebase/app-types': 0.9.5
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
 
-  '@firebase/database@1.1.3':
+  '@firebase/database@1.1.4':
     dependencies:
       '@firebase/app-check-interop-types': 0.3.4
       '@firebase/auth-interop-types': 0.2.5
-      '@firebase/component': 0.7.3
+      '@firebase/component': 0.7.4
       '@firebase/logger': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       faye-websocket: 0.11.4
       tslib: 2.8.1
 
-  '@firebase/firestore-compat@0.4.9(@firebase/app-compat@0.5.12)(@firebase/app-types@0.9.5)(@firebase/app@0.14.12)':
+  '@firebase/firestore-compat@0.4.12(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app-compat': 0.5.12
-      '@firebase/component': 0.7.3
-      '@firebase/firestore': 4.14.1(@firebase/app@0.14.12)
-      '@firebase/firestore-types': 3.0.4(@firebase/app-types@0.9.5)(@firebase/util@1.15.1)
-      '@firebase/util': 1.15.1
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/firestore': 4.17.0(@firebase/app@0.16.0)
+      '@firebase/firestore-types': 3.0.4(@firebase/app-types@0.9.5)(@firebase/util@1.15.2)
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@firebase/app'
       - '@firebase/app-types'
 
-  '@firebase/firestore-types@3.0.4(@firebase/app-types@0.9.5)(@firebase/util@1.15.1)':
+  '@firebase/firestore-types@3.0.4(@firebase/app-types@0.9.5)(@firebase/util@1.15.2)':
     dependencies:
       '@firebase/app-types': 0.9.5
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
 
-  '@firebase/firestore@4.14.1(@firebase/app@0.14.12)':
+  '@firebase/firestore@4.17.0(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app': 0.14.12
-      '@firebase/component': 0.7.3
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
       '@firebase/logger': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       '@firebase/webchannel-wrapper': 1.0.6
       '@grpc/grpc-js': 1.9.16
       '@grpc/proto-loader': 0.7.15
+      re2js: 2.8.6
       tslib: 2.8.1
 
-  '@firebase/functions-compat@0.4.4(@firebase/app-compat@0.5.12)(@firebase/app@0.14.12)':
+  '@firebase/functions-compat@0.4.6(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app-compat': 0.5.12
-      '@firebase/component': 0.7.3
-      '@firebase/functions': 0.13.4(@firebase/app@0.14.12)
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/functions': 0.13.6(@firebase/app@0.16.0)
       '@firebase/functions-types': 0.6.4
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@firebase/app'
 
   '@firebase/functions-types@0.6.4': {}
 
-  '@firebase/functions@0.13.4(@firebase/app@0.14.12)':
+  '@firebase/functions@0.13.6(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app': 0.14.12
+      '@firebase/app': 0.16.0
       '@firebase/app-check-interop-types': 0.3.4
       '@firebase/auth-interop-types': 0.2.5
-      '@firebase/component': 0.7.3
-      '@firebase/messaging-interop-types': 0.2.4
-      '@firebase/util': 1.15.1
+      '@firebase/component': 0.7.4
+      '@firebase/messaging-interop-types': 0.2.5
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
 
-  '@firebase/installations-compat@0.2.22(@firebase/app-compat@0.5.12)(@firebase/app-types@0.9.5)(@firebase/app@0.14.12)':
+  '@firebase/installations-compat@0.2.23(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app-compat': 0.5.12
-      '@firebase/component': 0.7.3
-      '@firebase/installations': 0.6.22(@firebase/app@0.14.12)
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/installations': 0.6.23(@firebase/app@0.16.0)
       '@firebase/installations-types': 0.5.4(@firebase/app-types@0.9.5)
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@firebase/app'
       - '@firebase/app-types'
 
   '@firebase/installations-types@0.5.4(@firebase/app-types@0.9.5)':
     dependencies:
       '@firebase/app-types': 0.9.5
 
-  '@firebase/installations@0.6.22(@firebase/app@0.14.12)':
+  '@firebase/installations@0.6.23(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app': 0.14.12
-      '@firebase/component': 0.7.3
-      '@firebase/util': 1.15.1
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/util': 1.15.2
       idb: 7.1.1
       tslib: 2.8.1
 
@@ -8651,147 +6760,113 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@firebase/messaging-compat@0.2.26(@firebase/app-compat@0.5.12)(@firebase/app@0.14.12)':
+  '@firebase/messaging-compat@0.2.28(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app-compat': 0.5.12
-      '@firebase/component': 0.7.3
-      '@firebase/messaging': 0.12.26(@firebase/app@0.14.12)
-      '@firebase/util': 1.15.1
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/messaging': 0.13.1(@firebase/app@0.16.0)
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@firebase/app'
 
-  '@firebase/messaging-interop-types@0.2.4': {}
+  '@firebase/messaging-interop-types@0.2.5': {}
 
-  '@firebase/messaging@0.12.26(@firebase/app@0.14.12)':
+  '@firebase/messaging@0.13.1(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app': 0.14.12
-      '@firebase/component': 0.7.3
-      '@firebase/installations': 0.6.22(@firebase/app@0.14.12)
-      '@firebase/messaging-interop-types': 0.2.4
-      '@firebase/util': 1.15.1
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/installations': 0.6.23(@firebase/app@0.16.0)
+      '@firebase/messaging-interop-types': 0.2.5
+      '@firebase/util': 1.15.2
       idb: 7.1.1
       tslib: 2.8.1
 
-  '@firebase/performance-compat@0.2.25(@firebase/app-compat@0.5.12)(@firebase/app@0.14.12)':
+  '@firebase/performance-compat@0.2.26(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app-compat': 0.5.12
-      '@firebase/component': 0.7.3
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
       '@firebase/logger': 0.5.1
-      '@firebase/performance': 0.7.12(@firebase/app@0.14.12)
+      '@firebase/performance': 0.7.13(@firebase/app@0.16.0)
       '@firebase/performance-types': 0.2.4
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@firebase/app'
 
   '@firebase/performance-types@0.2.4': {}
 
-  '@firebase/performance@0.7.12(@firebase/app@0.14.12)':
+  '@firebase/performance@0.7.13(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app': 0.14.12
-      '@firebase/component': 0.7.3
-      '@firebase/installations': 0.6.22(@firebase/app@0.14.12)
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/installations': 0.6.23(@firebase/app@0.16.0)
       '@firebase/logger': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
       web-vitals: 4.2.4
 
-  '@firebase/remote-config-compat@0.2.24(@firebase/app-compat@0.5.12)(@firebase/app@0.14.12)':
+  '@firebase/remote-config-compat@0.2.28(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app-compat': 0.5.12
-      '@firebase/component': 0.7.3
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
       '@firebase/logger': 0.5.1
-      '@firebase/remote-config': 0.8.3(@firebase/app@0.14.12)
+      '@firebase/remote-config': 0.9.1(@firebase/app@0.16.0)
       '@firebase/remote-config-types': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@firebase/app'
 
   '@firebase/remote-config-types@0.5.1': {}
 
-  '@firebase/remote-config@0.8.3(@firebase/app@0.14.12)':
+  '@firebase/remote-config@0.9.1(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app': 0.14.12
-      '@firebase/component': 0.7.3
-      '@firebase/installations': 0.6.22(@firebase/app@0.14.12)
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/installations': 0.6.23(@firebase/app@0.16.0)
       '@firebase/logger': 0.5.1
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
 
-  '@firebase/storage-compat@0.4.3(@firebase/app-compat@0.5.12)(@firebase/app-types@0.9.5)(@firebase/app@0.14.12)':
+  '@firebase/storage-compat@0.4.4(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app-compat': 0.5.12
-      '@firebase/component': 0.7.3
-      '@firebase/storage': 0.14.3(@firebase/app@0.14.12)
-      '@firebase/storage-types': 0.8.4(@firebase/app-types@0.9.5)(@firebase/util@1.15.1)
-      '@firebase/util': 1.15.1
+      '@firebase/app': 0.16.0
+      '@firebase/app-compat': 0.5.16
+      '@firebase/component': 0.7.4
+      '@firebase/storage': 0.14.4(@firebase/app@0.16.0)
+      '@firebase/storage-types': 0.8.4(@firebase/app-types@0.9.5)(@firebase/util@1.15.2)
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@firebase/app'
       - '@firebase/app-types'
 
-  '@firebase/storage-types@0.8.4(@firebase/app-types@0.9.5)(@firebase/util@1.15.1)':
+  '@firebase/storage-types@0.8.4(@firebase/app-types@0.9.5)(@firebase/util@1.15.2)':
     dependencies:
       '@firebase/app-types': 0.9.5
-      '@firebase/util': 1.15.1
+      '@firebase/util': 1.15.2
 
-  '@firebase/storage@0.14.3(@firebase/app@0.14.12)':
+  '@firebase/storage@0.14.4(@firebase/app@0.16.0)':
     dependencies:
-      '@firebase/app': 0.14.12
-      '@firebase/component': 0.7.3
-      '@firebase/util': 1.15.1
+      '@firebase/app': 0.16.0
+      '@firebase/component': 0.7.4
+      '@firebase/util': 1.15.2
       tslib: 2.8.1
 
-  '@firebase/util@1.15.1':
+  '@firebase/util@1.15.2':
     dependencies:
       tslib: 2.8.1
 
   '@firebase/webchannel-wrapper@1.0.6': {}
 
-  '@floating-ui/core@1.7.5':
-    dependencies:
-      '@floating-ui/utils': 0.2.11
-
-  '@floating-ui/core@1.8.0':
-    dependencies:
-      '@floating-ui/utils': 0.2.12
-
-  '@floating-ui/dom@1.7.6':
-    dependencies:
-      '@floating-ui/core': 1.7.5
-      '@floating-ui/utils': 0.2.11
-
-  '@floating-ui/dom@1.8.0':
-    dependencies:
-      '@floating-ui/core': 1.8.0
-      '@floating-ui/utils': 0.2.12
-
-  '@floating-ui/utils@0.2.11': {}
-
-  '@floating-ui/utils@0.2.12': {}
-
-  '@floating-ui/vue@1.1.11(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@floating-ui/dom': 1.7.6
-      '@floating-ui/utils': 0.2.11
-      vue-demi: 0.14.10(vue@3.5.34(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - vue
-
   '@grpc/grpc-js@1.9.16':
     dependencies:
       '@grpc/proto-loader': 0.7.15
-      '@types/node': 25.9.1
+      '@types/node': 26.1.2
 
   '@grpc/proto-loader@0.7.15':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.1
-      yargs: 17.7.2
+      protobufjs: 7.6.5
+      yargs: 17.7.3
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -8808,27 +6883,6 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
-
-  '@iconify-json/carbon@1.2.24':
-    dependencies:
-      '@iconify/types': 2.0.0
-
-  '@iconify/collections@1.0.705':
-    dependencies:
-      '@iconify/types': 2.0.0
-
-  '@iconify/types@2.0.0': {}
-
-  '@iconify/utils@3.1.3':
-    dependencies:
-      '@antfu/install-pkg': 1.1.0
-      '@iconify/types': 2.0.0
-      import-meta-resolve: 4.2.0
-
-  '@iconify/vue@5.0.1(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@iconify/types': 2.0.0
-      vue: 3.5.34(typescript@5.9.3)
 
   '@img/colour@1.1.0':
     optional: true
@@ -8920,7 +6974,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.35.3':
     dependencies:
-      '@emnapi/runtime': 1.11.2
+      '@emnapi/runtime': 1.11.3
     optional: true
 
   '@img/sharp-webcontainers-wasm32@0.35.3':
@@ -8936,14 +6990,6 @@ snapshots:
 
   '@img/sharp-win32-x64@0.35.3':
     optional: true
-
-  '@internationalized/date@3.12.2':
-    dependencies:
-      '@swc/helpers': 0.5.23
-
-  '@internationalized/number@3.6.7':
-    dependencies:
-      '@swc/helpers': 0.5.23
 
   '@ioredis/commands@1.10.0': {}
 
@@ -9020,21 +7066,21 @@ snapshots:
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@nodable/entities@2.2.0': {}
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@nodable/entities@3.0.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -9048,9 +7094,9 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nuxt/cli@3.37.0(@nuxt/schema@4.5.1)(@parcel/watcher@2.5.6)(cac@6.7.14)(magicast@0.5.4)':
+  '@nuxt/cli@3.37.0(@nuxt/schema@4.5.2)(@parcel/watcher@2.6.0)(cac@7.0.0)(magicast@0.5.4)':
     dependencies:
-      '@bomb.sh/tab': 0.0.19(cac@6.7.14)(citty@0.2.2)
+      '@bomb.sh/tab': 0.0.19(cac@7.0.0)(citty@0.2.2)
       '@clack/prompts': 1.7.0
       c12: 3.3.4(magicast@0.5.4)
       citty: 0.2.2
@@ -9063,7 +7109,7 @@ snapshots:
       fzf: 0.5.2
       giget: 3.3.1
       jiti: 2.7.0
-      listhen: 1.10.1(@parcel/watcher@2.5.6)(srvx@0.11.22)
+      listhen: 1.10.1(@parcel/watcher@2.6.0)(srvx@0.11.22)
       nypm: 0.6.9
       ofetch: 1.5.1
       ohash: 2.0.11
@@ -9079,7 +7125,7 @@ snapshots:
       ufo: 1.6.4
       youch: 4.1.1
     optionalDependencies:
-      '@nuxt/schema': 4.5.1
+      '@nuxt/schema': 4.5.2
     transitivePeerDependencies:
       - '@parcel/watcher'
       - cac
@@ -9089,11 +7135,11 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@3.2.4(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
+  '@nuxt/devtools-kit@3.4.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))':
     dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       execa: 8.0.1
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
     transitivePeerDependencies:
       - magic-string
       - magicast
@@ -9101,59 +7147,11 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/devtools-kit@3.4.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
+  '@nuxt/devtools-kit@4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))':
     dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      execa: 8.0.1
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-
-  '@nuxt/devtools-kit@3.4.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
-    dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      execa: 8.0.1
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-
-  '@nuxt/devtools-kit@4.0.0-alpha.3(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
-    dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       tinyexec: 1.3.0
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-
-  '@nuxt/devtools-kit@4.0.0-alpha.3(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
-    dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      tinyexec: 1.3.0
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-
-  '@nuxt/devtools-kit@4.0.0-alpha.3(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
-    dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      tinyexec: 1.3.0
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
     transitivePeerDependencies:
       - magic-string
       - magicast
@@ -9172,11 +7170,11 @@ snapshots:
       pkg-types: 2.3.1
       semver: 7.8.5
 
-  '@nuxt/devtools@3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
+  '@nuxt/devtools@3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
     dependencies:
-      '@nuxt/devtools-kit': 3.4.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      '@nuxt/devtools-kit': 3.4.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.4.1
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       '@vue/devtools-core': 8.2.1(vue@3.5.41(typescript@5.9.3))
       '@vue/devtools-kit': 8.2.1
       birpc: 4.0.0
@@ -9203,11 +7201,11 @@ snapshots:
       structured-clone-es: 2.0.1
       tinyglobby: 0.2.17
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-      vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      vite-plugin-vue-tracer: 1.4.0(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
+      vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
+      vite-plugin-vue-tracer: 1.4.0(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       which: 6.0.1
-      ws: 8.21.3
+      ws: 8.21.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9237,30 +7235,30 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/eslint-config@1.16.0(@typescript-eslint/utils@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@nuxt/eslint-config@1.17.0(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@antfu/install-pkg': 1.1.0
-      '@clack/prompts': 1.6.0
-      '@eslint/js': 10.0.1(eslint@10.5.0(jiti@2.7.0))
-      '@nuxt/eslint-plugin': 1.16.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
-      '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0(jiti@2.7.0))
-      '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 10.5.0(jiti@2.7.0)
-      eslint-config-flat-gitignore: 2.3.0(eslint@10.5.0(jiti@2.7.0))
+      '@antfu/install-pkg': 2.0.1
+      '@clack/prompts': 1.7.0
+      '@eslint/js': 10.0.1(eslint@10.8.0(jiti@2.7.0))
+      '@nuxt/eslint-plugin': 1.17.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
+      '@stylistic/eslint-plugin': 5.10.0(eslint@10.8.0(jiti@2.7.0))
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 10.8.0(jiti@2.7.0)
+      eslint-config-flat-gitignore: 2.3.0(eslint@10.8.0(jiti@2.7.0))
       eslint-flat-config-utils: 3.2.0
-      eslint-merge-processors: 2.0.0(eslint@10.5.0(jiti@2.7.0))
-      eslint-plugin-import-lite: 0.6.0(eslint@10.5.0(jiti@2.7.0))
-      eslint-plugin-import-x: 4.17.0(@typescript-eslint/utils@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.5.0(jiti@2.7.0))
-      eslint-plugin-jsdoc: 63.0.7(eslint@10.5.0(jiti@2.7.0))
-      eslint-plugin-regexp: 3.1.0(eslint@10.5.0(jiti@2.7.0))
-      eslint-plugin-unicorn: 65.0.1(eslint@10.5.0(jiti@2.7.0))
-      eslint-plugin-vue: 10.9.2(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0(jiti@2.7.0)))(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
-      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.41)(eslint@10.5.0(jiti@2.7.0))
-      globals: 17.7.0
+      eslint-merge-processors: 2.0.0(eslint@10.8.0(jiti@2.7.0))
+      eslint-plugin-import-lite: 0.6.0(eslint@10.8.0(jiti@2.7.0))
+      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))
+      eslint-plugin-jsdoc: 63.3.3(eslint@10.8.0(jiti@2.7.0))
+      eslint-plugin-regexp: 3.1.1(eslint@10.8.0(jiti@2.7.0))
+      eslint-plugin-unicorn: 73.0.0(eslint@10.8.0(jiti@2.7.0))
+      eslint-plugin-vue: 10.10.0(@stylistic/eslint-plugin@5.10.0(eslint@10.8.0(jiti@2.7.0)))(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0)))
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.41)(eslint@10.8.0(jiti@2.7.0))
+      globals: 17.9.0
       local-pkg: 1.2.1
       pathe: 2.0.3
-      vue-eslint-parser: 10.4.1(eslint@10.5.0(jiti@2.7.0))
+      vue-eslint-parser: 10.4.1(eslint@10.8.0(jiti@2.7.0))
     transitivePeerDependencies:
       - '@typescript-eslint/utils'
       - '@vue/compiler-sfc'
@@ -9268,40 +7266,39 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint-plugin@1.16.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@nuxt/eslint-plugin@1.17.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/utils': 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 10.5.0(jiti@2.7.0)
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 10.8.0(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@nuxt/eslint@1.16.0(@typescript-eslint/utils@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
+  '@nuxt/eslint@1.17.0(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(esbuild@0.25.12)(eslint@10.8.0(jiti@2.7.0))(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(srvx@0.11.22)(typescript@5.9.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))':
     dependencies:
-      '@eslint/config-inspector': 3.0.4(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      '@nuxt/devtools-kit': 3.2.4(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      '@nuxt/eslint-config': 1.16.0(@typescript-eslint/utils@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
-      '@nuxt/eslint-plugin': 1.16.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
-      '@nuxt/kit': 4.4.8(magicast@0.5.4)
+      '@eslint/config-inspector': 3.2.0(eslint@10.8.0(jiti@2.7.0))(srvx@0.11.22)
+      '@nuxt/devtools-kit': 3.4.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
+      '@nuxt/eslint-config': 1.17.0(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
+      '@nuxt/eslint-plugin': 1.17.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       chokidar: 5.0.0
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       eslint-flat-config-utils: 3.2.0
-      eslint-typegen: 2.3.1(eslint@10.5.0(jiti@2.7.0))
+      eslint-typegen: 2.3.1(eslint@10.8.0(jiti@2.7.0))
       find-up: 8.0.0
       get-port-please: 3.2.0
       mlly: 1.8.2
       pathe: 2.0.3
-      unimport: 6.3.0(esbuild@0.25.12)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      unimport: 6.4.0(esbuild@0.25.12)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@farmfe/core'
-      - '@modelcontextprotocol/sdk'
+      - '@modelcontextprotocol/client'
+      - '@modelcontextprotocol/server'
       - '@rspack/core'
       - '@typescript-eslint/utils'
       - '@vue/compiler-sfc'
-      - bufferutil
       - bun-types-no-globals
-      - crossws
       - esbuild
       - eslint-import-resolver-node
       - eslint-plugin-format
@@ -9310,90 +7307,15 @@ snapshots:
       - oxc-parser
       - rolldown
       - rollup
+      - srvx
       - supports-color
       - typescript
       - unloader
       - unplugin
-      - utf-8-validate
       - vite
       - webpack
 
-  '@nuxt/fonts@0.14.0(db0@0.3.4)(esbuild@0.25.12)(ioredis@5.11.1)(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
-    dependencies:
-      '@nuxt/devtools-kit': 3.4.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      consola: 3.4.2
-      defu: 6.1.7
-      fontless: 0.2.1(db0@0.3.4)(ioredis@5.11.1)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      h3: 1.15.11
-      magic-regexp: 0.10.0
-      ofetch: 1.5.1
-      pathe: 2.0.3
-      sirv: 3.0.2
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-      unifont: 0.7.4
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@farmfe/core'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@rspack/core'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bun-types-no-globals
-      - db0
-      - esbuild
-      - idb-keyval
-      - ioredis
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - rollup
-      - unloader
-      - uploadthing
-      - vite
-      - webpack
-
-  '@nuxt/icon@2.3.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@iconify/collections': 1.0.705
-      '@iconify/types': 2.0.0
-      '@iconify/utils': 3.1.3
-      '@iconify/vue': 5.0.1(vue@3.5.34(typescript@5.9.3))
-      '@nuxt/devtools-kit': 3.4.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      consola: 3.4.2
-      local-pkg: 1.2.1
-      mlly: 1.8.2
-      ohash: 2.0.11
-      picomatch: 4.0.5
-      std-env: 4.2.0
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-      - vite
-      - vue
-
-  '@nuxt/kit@3.21.6(magicast@0.5.4)':
+  '@nuxt/kit@3.21.11(magicast@0.5.4)':
     dependencies:
       c12: 3.3.4(magicast@0.5.4)
       consola: 3.4.2
@@ -9411,7 +7333,7 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 3.0.1
       scule: 1.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ufo: 1.6.4
       unctx: 2.5.0
@@ -9419,87 +7341,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@4.4.6(magicast@0.5.4)':
-    dependencies:
-      c12: 3.3.4(magicast@0.5.4)
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      errx: 0.1.2
-      exsolve: 1.1.1
-      ignore: 7.0.6
-      jiti: 2.7.0
-      klona: 2.0.6
-      mlly: 1.8.2
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      rc9: 3.0.1
-      scule: 1.3.0
-      semver: 7.8.1
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-      unctx: 2.5.0
-      untyped: 2.0.0
-    transitivePeerDependencies:
-      - magicast
-
-  '@nuxt/kit@4.4.8(magicast@0.5.4)':
-    dependencies:
-      c12: 3.3.4(magicast@0.5.4)
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      errx: 0.1.2
-      exsolve: 1.1.1
-      ignore: 7.0.6
-      jiti: 2.7.0
-      klona: 2.0.6
-      mlly: 1.8.2
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      rc9: 3.0.1
-      scule: 1.3.0
-      semver: 7.8.1
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-      unctx: 2.5.0
-      untyped: 2.0.0
-    transitivePeerDependencies:
-      - magicast
-
-  '@nuxt/kit@4.5.1(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))':
-    dependencies:
-      c12: 3.3.4(magicast@0.5.3)
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      errx: 0.1.2
-      exsolve: 1.1.1
-      ignore: 7.0.6
-      jiti: 2.7.0
-      klona: 2.0.6
-      mlly: 1.8.2
-      nostics: 1.2.0
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      rc9: 3.0.1
-      scule: 1.3.0
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-      unctx: 3.0.0(magic-string@0.30.21)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      untyped: 2.0.0
-      verkit: 0.2.0
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-
-  '@nuxt/kit@4.5.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))':
+  '@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))':
     dependencies:
       c12: 3.3.4(magicast@0.5.4)
       consola: 3.4.2
@@ -9519,9 +7361,9 @@ snapshots:
       scule: 1.3.0
       tinyglobby: 0.2.17
       ufo: 1.6.4
-      unctx: 3.0.0(magic-string@0.30.21)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       untyped: 2.0.0
-      verkit: 0.2.0
+      verkit: 0.3.2
     transitivePeerDependencies:
       - magic-string
       - magicast
@@ -9529,41 +7371,11 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))':
-    dependencies:
-      c12: 3.3.4(magicast@0.5.4)
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      errx: 0.1.2
-      exsolve: 1.1.1
-      ignore: 7.0.6
-      jiti: 2.7.0
-      klona: 2.0.6
-      mlly: 1.8.2
-      nostics: 1.2.0
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      rc9: 3.0.1
-      scule: 1.3.0
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-      unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      untyped: 2.0.0
-      verkit: 0.2.0
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-
-  '@nuxt/nitro-server@4.5.1(e10a0efb5e23c0fd36d3ace2a5e3aeb3)':
+  '@nuxt/nitro-server@4.5.2(a6b4ddeeddf84de6cb7f2a9716ddcc9a)':
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@vue/shared': 3.5.41
       consola: 3.4.2
       defu: 6.1.7
@@ -9573,19 +7385,19 @@ snapshots:
       escape-string-regexp: 5.0.0
       exsolve: 1.1.1
       h3: 1.15.11
-      impound: 1.1.6(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      impound: 1.1.6(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@parcel/watcher@2.5.6)(oxc-parser@0.138.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      nitropack: 2.13.4(@parcel/watcher@2.6.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       nostics: 1.2.0
-      nuxt: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.138.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.13.0(typescript@5.9.3))(terser@5.49.2)(tsx@4.22.3)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.8.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.142.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.102.0)(srvx@0.11.22)(stylelint@17.14.1(typescript@5.9.3))(terser@5.49.2)(tsx@4.23.10)(typescript@5.9.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.9
       ohash: 2.0.11
       pathe: 2.0.3
       rou3: 0.9.1
       std-env: 4.2.0
       ufo: 1.6.4
-      unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
       vue: 3.5.41(typescript@5.9.3)
       vue-bundle-renderer: 2.3.1
@@ -9645,15 +7457,6 @@ snapshots:
       - webpack
       - xml2js
 
-  '@nuxt/schema@4.5.1':
-    dependencies:
-      '@vue/shared': 3.5.41
-      defu: 6.1.7
-      nostics: 1.2.0
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      std-env: 4.2.0
-
   '@nuxt/schema@4.5.2':
     dependencies:
       '@vue/shared': 3.5.41
@@ -9663,139 +7466,20 @@ snapshots:
       pkg-types: 2.3.1
       std-env: 4.2.0
 
-  '@nuxt/telemetry@2.8.0(@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))))':
+  '@nuxt/telemetry@2.8.0(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))))':
     dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       citty: 0.2.2
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/ui@4.9.0(58502101345dd8570863426db89bf8e6)':
+  '@nuxt/vite-builder@4.5.2(52306e9b27341c32cbe02a9c7cda1876)':
     dependencies:
-      '@floating-ui/dom': 1.7.6
-      '@iconify/vue': 5.0.1(vue@3.5.34(typescript@5.9.3))
-      '@nuxt/fonts': 0.14.0(db0@0.3.4)(esbuild@0.25.12)(ioredis@5.11.1)(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      '@nuxt/icon': 2.3.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      '@nuxt/schema': 4.5.2
-      '@nuxtjs/color-mode': 4.0.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      '@standard-schema/spec': 1.1.0
-      '@tailwindcss/postcss': 4.3.2
-      '@tailwindcss/vite': 4.3.2(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      '@tanstack/vue-table': 8.21.3(vue@3.5.34(typescript@5.9.3))
-      '@tanstack/vue-virtual': 3.13.31(vue@3.5.34(typescript@5.9.3))
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/extension-bubble-menu': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/extension-code': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-      '@tiptap/extension-collaboration': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(yjs@13.6.31)
-      '@tiptap/extension-drag-handle': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/extension-collaboration@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(yjs@13.6.31))(@tiptap/extension-node-range@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))
-      '@tiptap/extension-drag-handle-vue-3': 3.27.1(@tiptap/extension-drag-handle@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/extension-collaboration@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(yjs@13.6.31))(@tiptap/extension-node-range@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)))(@tiptap/pm@3.27.1)(@tiptap/vue-3@3.27.1(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
-      '@tiptap/extension-floating-menu': 3.27.1(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/extension-horizontal-rule': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/extension-image': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-      '@tiptap/extension-mention': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/suggestion@3.27.1(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-      '@tiptap/extension-node-range': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/extension-placeholder': 3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-      '@tiptap/markdown': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-      '@tiptap/starter-kit': 3.27.1
-      '@tiptap/suggestion': 3.27.1(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/vue-3': 3.27.1(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(vue@3.5.34(typescript@5.9.3))
-      '@unhead/vue': 2.1.17(vue@3.5.34(typescript@5.9.3))
-      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.9.3))
-      '@vueuse/integrations': 14.3.0(change-case@5.4.4)(fuse.js@7.5.0)(qrcode@1.5.4)(vue@3.5.34(typescript@5.9.3))
-      '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@5.9.3))
-      colortranslator: 5.0.0
-      consola: 3.4.2
-      defu: 6.1.7
-      embla-carousel-auto-height: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-auto-scroll: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-autoplay: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-class-names: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-fade: 8.6.0(embla-carousel@8.6.0)
-      embla-carousel-vue: 8.6.0(vue@3.5.34(typescript@5.9.3))
-      embla-carousel-wheel-gestures: 8.1.0(embla-carousel@8.6.0)
-      fuse.js: 7.5.0
-      hookable: 6.1.1
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      motion-v: 2.3.0(@vueuse/core@14.3.0(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
-      ohash: 2.0.11
-      pathe: 2.0.3
-      reka-ui: 2.9.10(vue@3.5.34(typescript@5.9.3))
-      scule: 1.3.0
-      tailwind-merge: 3.6.0
-      tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
-      tailwindcss: 4.3.2
-      tinyglobby: 0.2.17
-      typescript: 5.9.3
-      ufo: 1.6.4
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      unplugin-auto-import: 21.0.0(@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))))(@vueuse/core@14.3.0(vue@3.5.34(typescript@5.9.3)))
-      unplugin-vue-components: 32.1.0(@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))))(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
-      vaul-vue: 0.4.1(reka-ui@2.9.10(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
-      vue-component-type-helpers: 3.3.6
-    optionalDependencies:
-      '@internationalized/date': 3.12.2
-      '@internationalized/number': 3.6.7
-      valibot: 1.4.1(typescript@5.9.3)
-      vue-router: 5.0.7(@vue/compiler-sfc@3.5.41)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@emotion/is-prop-valid'
-      - '@farmfe/core'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@rspack/core'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vue/composition-api'
-      - async-validator
-      - aws4fetch
-      - axios
-      - bun-types-no-globals
-      - change-case
-      - db0
-      - drauu
-      - embla-carousel
-      - esbuild
-      - focus-trap
-      - idb-keyval
-      - ioredis
-      - jwt-decode
-      - magicast
-      - nprogress
-      - oxc-parser
-      - qrcode
-      - react
-      - react-dom
-      - rolldown
-      - rollup
-      - sortablejs
-      - universal-cookie
-      - unloader
-      - uploadthing
-      - vite
-      - vue
-      - webpack
-
-  '@nuxt/vite-builder@4.5.1(0261b043a53150a2c4b40251899787e8)':
-    dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.6(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
+      '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.6(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       autoprefixer: 10.5.4(postcss@8.5.26)
       consola: 3.4.2
       cssnano: 8.0.4(postcss@8.5.26)
@@ -9809,7 +7493,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.138.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.13.0(typescript@5.9.3))(terser@5.49.2)(tsx@4.22.3)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.8.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.142.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.102.0)(srvx@0.11.22)(stylelint@17.14.1(typescript@5.9.3))(terser@5.49.2)(tsx@4.23.10)(typescript@5.9.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -9819,9 +7503,9 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unenv: 2.0.0-rc.24
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-      vite-node: 6.0.0(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-      vite-plugin-checker: 0.14.5(eslint@10.5.0(jiti@2.7.0))(meow@14.1.0)(optionator@0.9.4)(stylelint@17.13.0(typescript@5.9.3))(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
+      vite-node: 6.0.0(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
+      vite-plugin-checker: 0.14.5(eslint@10.8.0(jiti@2.7.0))(meow@14.1.0)(optionator@0.9.4)(stylelint@17.14.1(typescript@5.9.3))(typescript@5.9.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       vue: 3.5.41(typescript@5.9.3)
       vue-bundle-renderer: 2.3.1
     optionalDependencies:
@@ -9854,37 +7538,23 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxtjs/color-mode@4.0.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))':
-    dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      exsolve: 1.1.1
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      semver: 7.8.5
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-
   '@nuxtjs/google-fonts@3.2.0(magicast@0.5.4)':
     dependencies:
-      '@nuxt/kit': 3.21.6(magicast@0.5.4)
+      '@nuxt/kit': 3.21.11(magicast@0.5.4)
       google-fonts-helper: 3.7.4
       pathe: 1.1.2
     transitivePeerDependencies:
       - magicast
 
-  '@nuxtjs/robots@6.1.2(4d79e2cd154eafd0ae5acf0b0945c71b)':
+  '@nuxtjs/robots@6.1.3(30f44f47b1ac7bbdc0a379b9883293fe)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config: 4.1.1(4d79e2cd154eafd0ae5acf0b0945c71b)
-      nuxtseo-shared: 5.3.2(043985539a50ea96924caeb25844c44e)
+      nuxt-site-config: 4.2.0(30f44f47b1ac7bbdc0a379b9883293fe)
+      nuxtseo-shared: 5.3.10(0cd7c915431e46e6b683eb9a96b16f83)
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -9899,18 +7569,18 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/seo@5.3.2(cbbecbeff1ef288b5e7e848ce0fbb97f)':
+  '@nuxtjs/seo@5.3.10(d400cf9599512c720fc974c3468a396f)':
     dependencies:
-      '@nuxt/kit': 4.4.8(magicast@0.5.4)
-      '@nuxtjs/robots': 6.1.2(4d79e2cd154eafd0ae5acf0b0945c71b)
-      '@nuxtjs/sitemap': 8.2.2(4d79e2cd154eafd0ae5acf0b0945c71b)
-      nuxt: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.138.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.13.0(typescript@5.9.3))(terser@5.49.2)(tsx@4.22.3)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
-      nuxt-link-checker: 5.1.2(44f4b2b7d2f9ee8e362dff21d5ae9b48)
-      nuxt-og-image: 6.7.2(da6d5f553c655a51bde07ce599cb019e)
-      nuxt-schema-org: 6.2.3(932aeff8fdec8e3ce6179ad3f7827f8b)
-      nuxt-seo-utils: 8.3.1(175313bbf896de2adf74b471bfbf40bf)
-      nuxt-site-config: 4.1.1(4d79e2cd154eafd0ae5acf0b0945c71b)
-      nuxtseo-shared: 5.3.2(043985539a50ea96924caeb25844c44e)
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
+      '@nuxtjs/robots': 6.1.3(30f44f47b1ac7bbdc0a379b9883293fe)
+      '@nuxtjs/sitemap': 8.3.3(30f44f47b1ac7bbdc0a379b9883293fe)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.8.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.142.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.102.0)(srvx@0.11.22)(stylelint@17.14.1(typescript@5.9.3))(terser@5.49.2)(tsx@4.23.10)(typescript@5.9.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt-link-checker: 5.1.3(f18257b9155498110349a5e9ade5d532)
+      nuxt-og-image: 6.7.6(1e2b93cf07dca500f5d39a59f8d1103b)
+      nuxt-schema-org: 6.2.8(a988b73004e9a24d278f96bbfdb2520c)
+      nuxt-seo-utils: 8.3.3(e53b46e74e5782014a591da31257fe78)
+      nuxt-site-config: 4.2.0(30f44f47b1ac7bbdc0a379b9883293fe)
+      nuxtseo-shared: 5.3.10(0cd7c915431e46e6b683eb9a96b16f83)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9920,14 +7590,8 @@ snapshots:
       - '@azure/storage-blob'
       - '@capacitor/preferences'
       - '@deno/kv'
-      - '@emotion/is-prop-valid'
       - '@farmfe/core'
-      - '@inertiajs/vue3'
-      - '@internationalized/date'
-      - '@internationalized/number'
-      - '@modelcontextprotocol/sdk'
       - '@netlify/blobs'
-      - '@nuxt/content'
       - '@nuxt/schema'
       - '@oxc-project/types'
       - '@planetscale/database'
@@ -9936,95 +7600,57 @@ snapshots:
       - '@rspack/core'
       - '@takumi-rs/core'
       - '@takumi-rs/wasm'
-      - '@tiptap/core'
-      - '@tiptap/extension-bubble-menu'
-      - '@tiptap/extension-code'
-      - '@tiptap/extension-collaboration'
-      - '@tiptap/extension-drag-handle'
-      - '@tiptap/extension-drag-handle-vue-3'
-      - '@tiptap/extension-floating-menu'
-      - '@tiptap/extension-horizontal-rule'
-      - '@tiptap/extension-image'
-      - '@tiptap/extension-mention'
-      - '@tiptap/extension-node-range'
-      - '@tiptap/extension-placeholder'
-      - '@tiptap/markdown'
-      - '@tiptap/pm'
-      - '@tiptap/starter-kit'
-      - '@tiptap/suggestion'
-      - '@tiptap/vue-3'
       - '@types/node'
-      - '@unhead/cli'
+      - '@unhead/bundler'
       - '@unhead/vue'
+      - '@unocss/config'
+      - '@unocss/core'
       - '@upstash/redis'
       - '@vercel/blob'
       - '@vercel/functions'
       - '@vercel/kv'
-      - '@vue/composition-api'
-      - async-validator
       - aws4fetch
-      - axios
-      - bufferutil
       - bun-types-no-globals
-      - change-case
-      - crossws
       - db0
-      - drauu
-      - embla-carousel
       - esbuild
-      - focus-trap
       - fontless
       - idb-keyval
       - ioredis
-      - joi
-      - jwt-decode
       - lightningcss
       - magic-string
       - magicast
       - nitropack
-      - nprogress
       - oxc-parser
       - playwright-core
-      - qrcode
-      - react
-      - react-dom
       - rolldown
       - rollup
       - satori
       - sharp
-      - sortablejs
-      - superstruct
       - supports-color
       - tailwindcss
-      - typescript
       - unhead
       - unifont
-      - universal-cookie
       - unloader
       - unplugin
       - unstorage
       - uploadthing
-      - utf-8-validate
-      - valibot
       - vite
       - vue
-      - vue-router
       - webpack
-      - yup
       - zod
 
-  '@nuxtjs/sitemap@8.2.2(4d79e2cd154eafd0ae5acf0b0945c71b)':
+  '@nuxtjs/sitemap@8.3.3(30f44f47b1ac7bbdc0a379b9883293fe)':
     dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       consola: 3.4.2
       defu: 6.1.7
-      fast-xml-parser: 5.9.3
-      nuxt-site-config: 4.1.1(4d79e2cd154eafd0ae5acf0b0945c71b)
-      nuxtseo-shared: 5.3.2(043985539a50ea96924caeb25844c44e)
+      nuxt-site-config: 4.2.0(30f44f47b1ac7bbdc0a379b9883293fe)
+      nuxtseo-shared: 5.3.10(0cd7c915431e46e6b683eb9a96b16f83)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
       radix3: 1.1.2
+      sitemapd: 0.2.1
       ufo: 1.6.4
       ultrahtml: 1.7.0
     transitivePeerDependencies:
@@ -10038,234 +7664,102 @@ snapshots:
       - vite
       - vue
 
-  '@oxc-parser/binding-android-arm-eabi@0.132.0':
+  '@oxc-parser/binding-android-arm-eabi@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm-eabi@0.137.0':
+  '@oxc-parser/binding-android-arm64@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm-eabi@0.138.0':
+  '@oxc-parser/binding-darwin-arm64@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm64@0.132.0':
+  '@oxc-parser/binding-darwin-x64@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm64@0.137.0':
+  '@oxc-parser/binding-freebsd-x64@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm64@0.138.0':
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.132.0':
+  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.137.0':
+  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.138.0':
+  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.132.0':
+  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.137.0':
+  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.138.0':
+  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.132.0':
+  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.137.0':
+  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.138.0':
+  '@oxc-parser/binding-linux-x64-musl@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
+  '@oxc-parser/binding-openharmony-arm64@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.138.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.138.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-gnu@0.138.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-musl@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-musl@0.138.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-ppc64-gnu@0.138.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-gnu@0.138.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-riscv64-musl@0.138.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-s390x-gnu@0.138.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-gnu@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-gnu@0.138.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-musl@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-musl@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-musl@0.138.0':
-    optional: true
-
-  '@oxc-parser/binding-openharmony-arm64@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-openharmony-arm64@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-openharmony-arm64@0.138.0':
-    optional: true
-
-  '@oxc-parser/binding-wasm32-wasi@0.132.0':
+  '@oxc-parser/binding-wasm32-wasi@0.142.0':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.137.0':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.138.0':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
+  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
     optional: true
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.138.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-ia32-msvc@0.138.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-x64-msvc@0.137.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-x64-msvc@0.138.0':
-    optional: true
-
-  '@oxc-project/types@0.132.0': {}
-
-  '@oxc-project/types@0.137.0': {}
-
-  '@oxc-project/types@0.138.0': {}
+  '@oxc-project/types@0.142.0': {}
 
   '@oxc-project/types@0.143.0': {}
 
-  '@parcel/watcher-android-arm64@2.5.6':
+  '@parcel/watcher-android-arm64@2.6.0':
     optional: true
 
-  '@parcel/watcher-darwin-arm64@2.5.6':
+  '@parcel/watcher-darwin-arm64@2.6.0':
     optional: true
 
-  '@parcel/watcher-darwin-x64@2.5.6':
+  '@parcel/watcher-darwin-x64@2.6.0':
     optional: true
 
-  '@parcel/watcher-freebsd-x64@2.5.6':
+  '@parcel/watcher-freebsd-x64@2.6.0':
     optional: true
 
-  '@parcel/watcher-linux-arm-glibc@2.5.6':
+  '@parcel/watcher-linux-arm-glibc@2.6.0':
     optional: true
 
-  '@parcel/watcher-linux-arm-musl@2.5.6':
+  '@parcel/watcher-linux-arm-musl@2.6.0':
     optional: true
 
-  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+  '@parcel/watcher-linux-arm64-glibc@2.6.0':
     optional: true
 
-  '@parcel/watcher-linux-arm64-musl@2.5.6':
+  '@parcel/watcher-linux-arm64-musl@2.6.0':
     optional: true
 
-  '@parcel/watcher-linux-x64-glibc@2.5.6':
+  '@parcel/watcher-linux-x64-glibc@2.6.0':
     optional: true
 
-  '@parcel/watcher-linux-x64-musl@2.5.6':
+  '@parcel/watcher-linux-x64-musl@2.6.0':
     optional: true
 
   '@parcel/watcher-wasm@2.6.0':
@@ -10273,43 +7767,43 @@ snapshots:
       is-glob: 4.0.3
       picomatch: 4.0.5
 
-  '@parcel/watcher-win32-arm64@2.5.6':
+  '@parcel/watcher-win32-arm64@2.6.0':
     optional: true
 
-  '@parcel/watcher-win32-ia32@2.5.6':
+  '@parcel/watcher-win32-x64@2.6.0':
     optional: true
 
-  '@parcel/watcher-win32-x64@2.5.6':
-    optional: true
-
-  '@parcel/watcher@2.5.6':
+  '@parcel/watcher@2.6.0':
     dependencies:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
       picomatch: 4.0.5
     optionalDependencies:
-      '@parcel/watcher-android-arm64': 2.5.6
-      '@parcel/watcher-darwin-arm64': 2.5.6
-      '@parcel/watcher-darwin-x64': 2.5.6
-      '@parcel/watcher-freebsd-x64': 2.5.6
-      '@parcel/watcher-linux-arm-glibc': 2.5.6
-      '@parcel/watcher-linux-arm-musl': 2.5.6
-      '@parcel/watcher-linux-arm64-glibc': 2.5.6
-      '@parcel/watcher-linux-arm64-musl': 2.5.6
-      '@parcel/watcher-linux-x64-glibc': 2.5.6
-      '@parcel/watcher-linux-x64-musl': 2.5.6
-      '@parcel/watcher-win32-arm64': 2.5.6
-      '@parcel/watcher-win32-ia32': 2.5.6
-      '@parcel/watcher-win32-x64': 2.5.6
+      '@parcel/watcher-android-arm64': 2.6.0
+      '@parcel/watcher-darwin-arm64': 2.6.0
+      '@parcel/watcher-darwin-x64': 2.6.0
+      '@parcel/watcher-freebsd-x64': 2.6.0
+      '@parcel/watcher-linux-arm-glibc': 2.6.0
+      '@parcel/watcher-linux-arm-musl': 2.6.0
+      '@parcel/watcher-linux-arm64-glibc': 2.6.0
+      '@parcel/watcher-linux-arm64-musl': 2.6.0
+      '@parcel/watcher-linux-x64-glibc': 2.6.0
+      '@parcel/watcher-linux-x64-musl': 2.6.0
+      '@parcel/watcher-win32-arm64': 2.6.0
+      '@parcel/watcher-win32-x64': 2.6.0
     optional: true
 
-  '@pinia/nuxt@0.11.3(magicast@0.5.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))':
+  '@pinia/nuxt@0.11.3(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))':
     dependencies:
-      '@nuxt/kit': 4.4.6(magicast@0.5.4)
-      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
+      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3))
     transitivePeerDependencies:
+      - magic-string
       - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -10342,17 +7836,11 @@ snapshots:
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.2': {}
-
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.1': {}
-
-  '@quansync/fs@1.0.0':
-    dependencies:
-      quansync: 1.0.0
+  '@protobufjs/utf8@1.1.2': {}
 
   '@rolldown/binding-android-arm64@1.2.3':
     optional: true
@@ -10536,57 +8024,17 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
 
-  '@shikijs/core@4.3.1':
-    dependencies:
-      '@shikijs/primitive': 4.3.1
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-      hast-util-to-html: 9.0.5
-
-  '@shikijs/engine-javascript@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.6
-
-  '@shikijs/engine-oniguruma@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-
-  '@shikijs/langs@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
-
-  '@shikijs/primitive@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-
-  '@shikijs/themes@4.3.1':
-    dependencies:
-      '@shikijs/types': 4.3.1
-
-  '@shikijs/types@4.3.1':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-
-  '@shikijs/vscode-textmate@10.0.2': {}
-
   '@simple-git/args-pathspec@1.0.3': {}
 
   '@simple-git/argv-parser@1.1.1':
     dependencies:
       '@simple-git/args-pathspec': 1.0.3
 
-  '@simple-libs/child-process-utils@1.0.2':
+  '@simple-libs/child-process-utils@2.0.0':
     dependencies:
-      '@simple-libs/stream-utils': 1.2.0
+      '@simple-libs/stream-utils': 2.0.0
 
-  '@simple-libs/stream-utils@1.2.0': {}
+  '@simple-libs/stream-utils@2.0.0': {}
 
   '@sindresorhus/base62@1.0.0': {}
 
@@ -10598,346 +8046,15 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@stylistic/eslint-plugin@5.10.0(eslint@10.5.0(jiti@2.7.0))':
+  '@stylistic/eslint-plugin@5.10.0(eslint@10.8.0(jiti@2.7.0))':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
-      '@typescript-eslint/types': 8.62.0
-      eslint: 10.5.0(jiti@2.7.0)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0))
+      '@typescript-eslint/types': 8.66.0
+      eslint: 10.8.0(jiti@2.7.0)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
       picomatch: 4.0.5
-
-  '@swc/helpers@0.5.23':
-    dependencies:
-      tslib: 2.8.1
-
-  '@tailwindcss/node@4.3.2':
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.21.6
-      jiti: 2.7.0
-      lightningcss: 1.32.0
-      magic-string: 0.30.21
-      source-map-js: 1.2.1
-      tailwindcss: 4.3.2
-
-  '@tailwindcss/oxide-android-arm64@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-darwin-arm64@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-darwin-x64@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-freebsd-x64@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
-    optional: true
-
-  '@tailwindcss/oxide@4.3.2':
-    optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.3.2
-      '@tailwindcss/oxide-darwin-arm64': 4.3.2
-      '@tailwindcss/oxide-darwin-x64': 4.3.2
-      '@tailwindcss/oxide-freebsd-x64': 4.3.2
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.2
-      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.2
-      '@tailwindcss/oxide-linux-arm64-musl': 4.3.2
-      '@tailwindcss/oxide-linux-x64-gnu': 4.3.2
-      '@tailwindcss/oxide-linux-x64-musl': 4.3.2
-      '@tailwindcss/oxide-wasm32-wasi': 4.3.2
-      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
-      '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
-
-  '@tailwindcss/postcss@4.3.2':
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      '@tailwindcss/node': 4.3.2
-      '@tailwindcss/oxide': 4.3.2
-      postcss: 8.5.26
-      tailwindcss: 4.3.2
-
-  '@tailwindcss/vite@4.3.2(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
-    dependencies:
-      '@tailwindcss/node': 4.3.2
-      '@tailwindcss/oxide': 4.3.2
-      tailwindcss: 4.3.2
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-
-  '@tanstack/table-core@8.21.3': {}
-
-  '@tanstack/virtual-core@3.17.3': {}
-
-  '@tanstack/vue-table@8.21.3(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@tanstack/table-core': 8.21.3
-      vue: 3.5.34(typescript@5.9.3)
-
-  '@tanstack/vue-virtual@3.13.31(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@tanstack/virtual-core': 3.17.3
-      vue: 3.5.34(typescript@5.9.3)
-
-  '@tiptap/core@3.27.1(@tiptap/pm@3.27.1)':
-    dependencies:
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extension-blockquote@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extension-bold@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-bubble-menu@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-    dependencies:
-      '@floating-ui/dom': 1.8.0
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extension-bullet-list@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-code-block@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extension-code@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-collaboration@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(yjs@13.6.31)':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-      '@tiptap/y-tiptap': 3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
-      yjs: 13.6.31
-
-  '@tiptap/extension-document@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-drag-handle-vue-3@3.27.1(@tiptap/extension-drag-handle@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/extension-collaboration@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(yjs@13.6.31))(@tiptap/extension-node-range@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)))(@tiptap/pm@3.27.1)(@tiptap/vue-3@3.27.1(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@tiptap/extension-drag-handle': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/extension-collaboration@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(yjs@13.6.31))(@tiptap/extension-node-range@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))
-      '@tiptap/pm': 3.27.1
-      '@tiptap/vue-3': 3.27.1(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(vue@3.5.34(typescript@5.9.3))
-      vue: 3.5.34(typescript@5.9.3)
-
-  '@tiptap/extension-drag-handle@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/extension-collaboration@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(yjs@13.6.31))(@tiptap/extension-node-range@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))':
-    dependencies:
-      '@floating-ui/dom': 1.8.0
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/extension-collaboration': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(yjs@13.6.31)
-      '@tiptap/extension-node-range': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-      '@tiptap/y-tiptap': 3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
-
-  '@tiptap/extension-dropcursor@3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/extensions': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-floating-menu@3.27.1(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-    dependencies:
-      '@floating-ui/dom': 1.8.0
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extension-gapcursor@3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/extensions': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-hard-break@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-heading@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-horizontal-rule@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extension-image@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-italic@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-link@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-      linkifyjs: 4.3.3
-
-  '@tiptap/extension-list-item@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-list-keymap@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-list@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extension-mention@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@tiptap/suggestion@3.27.1(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-      '@tiptap/suggestion': 3.27.1(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-node-range@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extension-ordered-list@3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-paragraph@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-placeholder@3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-strike@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-text@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-  '@tiptap/extension-underline@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-
-  '@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/extensions@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/markdown@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-      marked: 17.0.6
-
-  '@tiptap/pm@3.27.1':
-    dependencies:
-      prosemirror-changeset: 2.4.1
-      prosemirror-commands: 1.7.2
-      prosemirror-dropcursor: 1.8.3
-      prosemirror-gapcursor: 1.4.1
-      prosemirror-history: 1.5.0
-      prosemirror-inputrules: 1.5.1
-      prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.11
-      prosemirror-schema-list: 1.5.1
-      prosemirror-state: 1.4.4
-      prosemirror-tables: 1.8.5
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.42.2
-
-  '@tiptap/starter-kit@3.27.1':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/extension-blockquote': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/extension-bold': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-      '@tiptap/extension-bullet-list': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-      '@tiptap/extension-code': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-      '@tiptap/extension-code-block': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/extension-document': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-      '@tiptap/extension-dropcursor': 3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-      '@tiptap/extension-gapcursor': 3.29.2(@tiptap/extensions@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-      '@tiptap/extension-hard-break': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-      '@tiptap/extension-heading': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-      '@tiptap/extension-horizontal-rule': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/extension-italic': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-      '@tiptap/extension-link': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/extension-list': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/extension-list-item': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-      '@tiptap/extension-list-keymap': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-      '@tiptap/extension-ordered-list': 3.29.2(@tiptap/extension-list@3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1))
-      '@tiptap/extension-paragraph': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-      '@tiptap/extension-strike': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-      '@tiptap/extension-text': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-      '@tiptap/extension-underline': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))
-      '@tiptap/extensions': 3.29.2(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/suggestion@3.27.1(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)':
-    dependencies:
-      '@floating-ui/dom': 1.8.0
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-
-  '@tiptap/vue-3@3.27.1(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@floating-ui/dom': 1.8.0
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
-      '@tiptap/pm': 3.27.1
-      vue: 3.5.34(typescript@5.9.3)
-    optionalDependencies:
-      '@tiptap/extension-bubble-menu': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-      '@tiptap/extension-floating-menu': 3.27.1(@floating-ui/dom@1.8.0)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)
-
-  '@tiptap/y-tiptap@3.0.6(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.2)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)':
-    dependencies:
-      lib0: 0.2.117
-      prosemirror-model: 1.25.11
-      prosemirror-state: 1.4.4
-      prosemirror-view: 1.42.2
-      y-protocols: 1.0.7(yjs@13.6.31)
-      yjs: 13.6.31
-
-  '@tybys/wasm-util@0.10.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -10948,43 +8065,31 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/hast@3.0.4':
-    dependencies:
-      '@types/unist': 3.0.3
-
   '@types/jsesc@2.5.1': {}
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/mdast@4.0.4':
+  '@types/node@26.1.2':
     dependencies:
-      '@types/unist': 3.0.3
-
-  '@types/node@25.9.1':
-    dependencies:
-      undici-types: 7.24.6
+      undici-types: 8.3.0
 
   '@types/qrcode@1.5.6':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.2
 
   '@types/resolve@1.20.2': {}
 
-  '@types/unist@3.0.3': {}
-
-  '@types/web-bluetooth@0.0.20': {}
-
   '@types/web-bluetooth@0.0.21': {}
 
-  '@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.62.0
-      '@typescript-eslint/type-utils': 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.62.0
-      eslint: 10.5.0(jiti@2.7.0)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.66.0
+      eslint: 10.8.0(jiti@2.7.0)
       ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -10992,58 +8097,58 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.62.0
-      '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.62.0
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.66.0
       debug: 4.4.3
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.62.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.66.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.62.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.66.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.62.0':
+  '@typescript-eslint/scope-manager@8.66.0':
     dependencies:
-      '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/visitor-keys': 8.62.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/visitor-keys': 8.66.0
 
-  '@typescript-eslint/tsconfig-utils@8.62.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.66.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.62.0': {}
+  '@typescript-eslint/types@8.66.0': {}
 
-  '@typescript-eslint/typescript-estree@8.62.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.66.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.62.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.62.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/visitor-keys': 8.62.0
+      '@typescript-eslint/project-service': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/visitor-keys': 8.66.0
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -11051,63 +8156,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
-      '@typescript-eslint/scope-manager': 8.62.0
-      '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/typescript-estree': 8.62.0(typescript@5.9.3)
-      eslint: 10.5.0(jiti@2.7.0)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
+      eslint: 10.8.0(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.62.0':
+  '@typescript-eslint/visitor-keys@8.66.0':
     dependencies:
-      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/types': 8.66.0
       eslint-visitor-keys: 5.0.1
 
-  '@ungap/structured-clone@1.3.2': {}
-
-  '@unhead/bundler@3.1.7(@oxc-project/types@0.143.0)(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(lightningcss@1.33.0)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(unhead@3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
-    dependencies:
-      '@vitejs/devtools-kit': 0.3.4(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      magic-string: 0.30.21
-      oxc-parser: 0.137.0
-      oxc-walker: 1.1.1(@oxc-project/types@0.143.0)(oxc-parser@0.137.0)(rolldown@1.2.3)
-      ufo: 1.6.4
-      unhead: 3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-    optionalDependencies:
-      esbuild: 0.25.12
-      lightningcss: 1.33.0
-      rolldown: 1.2.3
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@modelcontextprotocol/sdk'
-      - '@oxc-project/types'
-      - '@rspack/core'
-      - bufferutil
-      - bun-types-no-globals
-      - crossws
-      - rollup
-      - typescript
-      - unloader
-      - utf-8-validate
-
-  '@unhead/bundler@3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(unhead@3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
+  '@unhead/bundler@3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(unhead@3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))':
     dependencies:
       magic-string: 1.1.0
-      oxc-walker: 1.1.1(@oxc-project/types@0.143.0)(oxc-parser@0.138.0)(rolldown@1.2.3)
-      unhead: 3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      oxc-walker: 1.1.1(@oxc-project/types@0.143.0)(oxc-parser@0.142.0)(rolldown@1.2.3)
+      unhead: 3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
     optionalDependencies:
       esbuild: 0.25.12
       lightningcss: 1.33.0
-      oxc-parser: 0.138.0
+      oxc-parser: 0.142.0
       rolldown: 1.2.3
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@oxc-project/types'
@@ -11116,44 +8192,15 @@ snapshots:
       - rollup
       - unloader
 
-  '@unhead/vue@2.1.17(vue@3.5.34(typescript@5.9.3))':
+  '@unhead/vue@3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
     dependencies:
+      '@unhead/bundler': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(unhead@3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       hookable: 6.1.1
-      unhead: 2.1.17
-      vue: 3.5.34(typescript@5.9.3)
-
-  '@unhead/vue@3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@unhead/bundler': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(unhead@3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      hookable: 6.1.1
-      unhead: 3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      vue: 3.5.34(typescript@5.9.3)
-    optionalDependencies:
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@oxc-project/types'
-      - '@rspack/core'
-      - '@unhead/cli'
-      - '@vitejs/devtools-kit'
-      - bun-types-no-globals
-      - esbuild
-      - lightningcss
-      - oxc-parser
-      - rolldown
-      - rollup
-      - unloader
-
-  '@unhead/vue@3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
-    dependencies:
-      '@unhead/bundler': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(unhead@3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      hookable: 6.1.1
-      unhead: 3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      unhead: 3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       vue: 3.5.41(typescript@5.9.3)
     optionalDependencies:
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@oxc-project/types'
@@ -11167,15 +8214,6 @@ snapshots:
       - rolldown
       - rollup
       - unloader
-
-  '@unocss/config@66.7.4':
-    dependencies:
-      '@unocss/core': 66.7.4
-      colorette: 2.0.20
-      consola: 3.4.2
-      unconfig: 7.5.0
-
-  '@unocss/core@66.7.4': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.12.2':
     optional: true
@@ -11235,7 +8273,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
@@ -11246,10 +8284,6 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
-
-  '@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@5.9.3))':
-    dependencies:
-      valibot: 1.4.1(typescript@5.9.3)
 
   '@vercel/nft@1.10.2(rollup@4.62.4)':
     dependencies:
@@ -11270,59 +8304,23 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/devtools-kit@0.3.4(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))':
-    dependencies:
-      '@devframes/hub': 0.5.4(devframe@0.5.4(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      birpc: 4.0.0
-      devframe: 0.5.4(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      mlly: 1.8.2
-      nostics: 1.2.0
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      tinyexec: 1.3.0
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@modelcontextprotocol/sdk'
-      - '@rspack/core'
-      - bufferutil
-      - bun-types-no-globals
-      - crossws
-      - esbuild
-      - rolldown
-      - rollup
-      - typescript
-      - unloader
-      - utf-8-validate
-      - webpack
-
-  '@vitejs/plugin-vue-jsx@5.1.6(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
+  '@vitejs/plugin-vue-jsx@5.1.6(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.1
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.7)
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
       vue: 3.5.41(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.8(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.8(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
       vue: 3.5.41(typescript@5.9.3)
-
-  '@vue-macros/common@3.1.2(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@vue/compiler-sfc': 3.5.41
-      ast-kit: 2.2.0
-      local-pkg: 1.2.1
-      magic-string-ast: 1.0.3
-      unplugin-utils: 0.3.1
-    optionalDependencies:
-      vue: 3.5.34(typescript@5.9.3)
 
   '@vue-macros/common@3.1.4(vue@3.5.41(typescript@5.9.3))':
     dependencies:
@@ -11363,22 +8361,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/compiler-core@3.5.34':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@vue/shared': 3.5.34
-      entities: 7.0.1
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
-
-  '@vue/compiler-core@3.5.39':
-    dependencies:
-      '@babel/parser': 7.29.8
-      '@vue/shared': 3.5.39
-      entities: 7.0.1
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
-
   '@vue/compiler-core@3.5.41':
     dependencies:
       '@babel/parser': 7.29.8
@@ -11387,44 +8369,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.34':
-    dependencies:
-      '@vue/compiler-core': 3.5.34
-      '@vue/shared': 3.5.34
-
-  '@vue/compiler-dom@3.5.39':
-    dependencies:
-      '@vue/compiler-core': 3.5.39
-      '@vue/shared': 3.5.39
-
   '@vue/compiler-dom@3.5.41':
     dependencies:
       '@vue/compiler-core': 3.5.41
       '@vue/shared': 3.5.41
-
-  '@vue/compiler-sfc@3.5.34':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@vue/compiler-core': 3.5.34
-      '@vue/compiler-dom': 3.5.34
-      '@vue/compiler-ssr': 3.5.34
-      '@vue/shared': 3.5.34
-      estree-walker: 2.0.2
-      magic-string: 0.30.21
-      postcss: 8.5.15
-      source-map-js: 1.2.1
-
-  '@vue/compiler-sfc@3.5.39':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@vue/compiler-core': 3.5.39
-      '@vue/compiler-dom': 3.5.39
-      '@vue/compiler-ssr': 3.5.39
-      '@vue/shared': 3.5.39
-      estree-walker: 2.0.2
-      magic-string: 0.30.21
-      postcss: 8.5.26
-      source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.41':
     dependencies:
@@ -11438,28 +8386,14 @@ snapshots:
       postcss: 8.5.26
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.5.34':
-    dependencies:
-      '@vue/compiler-dom': 3.5.34
-      '@vue/shared': 3.5.34
-
-  '@vue/compiler-ssr@3.5.39':
-    dependencies:
-      '@vue/compiler-dom': 3.5.39
-      '@vue/shared': 3.5.39
-
   '@vue/compiler-ssr@3.5.41':
     dependencies:
       '@vue/compiler-dom': 3.5.41
       '@vue/shared': 3.5.41
 
-  '@vue/devtools-api@7.7.9':
+  '@vue/devtools-api@7.7.10':
     dependencies:
-      '@vue/devtools-kit': 7.7.9
-
-  '@vue/devtools-api@8.1.2':
-    dependencies:
-      '@vue/devtools-kit': 8.1.2
+      '@vue/devtools-kit': 7.7.10
 
   '@vue/devtools-api@8.2.1':
     dependencies:
@@ -11471,22 +8405,15 @@ snapshots:
       '@vue/devtools-shared': 8.2.1
       vue: 3.5.41(typescript@5.9.3)
 
-  '@vue/devtools-kit@7.7.9':
+  '@vue/devtools-kit@7.7.10':
     dependencies:
-      '@vue/devtools-shared': 7.7.9
+      '@vue/devtools-shared': 7.7.10
       birpc: 2.9.0
       hookable: 5.5.3
       mitt: 3.0.1
       perfect-debounce: 1.0.0
       speakingurl: 14.0.1
       superjson: 2.2.6
-
-  '@vue/devtools-kit@8.1.2':
-    dependencies:
-      '@vue/devtools-shared': 8.1.2
-      birpc: 2.9.0
-      hookable: 5.5.3
-      perfect-debounce: 2.1.0
 
   '@vue/devtools-kit@8.2.1':
     dependencies:
@@ -11495,38 +8422,20 @@ snapshots:
       hookable: 5.5.3
       perfect-debounce: 2.1.0
 
-  '@vue/devtools-shared@7.7.9':
+  '@vue/devtools-shared@7.7.10':
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/devtools-shared@8.1.2': {}
-
   '@vue/devtools-shared@8.2.1': {}
-
-  '@vue/reactivity@3.5.34':
-    dependencies:
-      '@vue/shared': 3.5.34
 
   '@vue/reactivity@3.5.41':
     dependencies:
       '@vue/shared': 3.5.41
 
-  '@vue/runtime-core@3.5.34':
-    dependencies:
-      '@vue/reactivity': 3.5.34
-      '@vue/shared': 3.5.34
-
   '@vue/runtime-core@3.5.41':
     dependencies:
       '@vue/reactivity': 3.5.41
       '@vue/shared': 3.5.41
-
-  '@vue/runtime-dom@3.5.34':
-    dependencies:
-      '@vue/reactivity': 3.5.34
-      '@vue/runtime-core': 3.5.34
-      '@vue/shared': 3.5.34
-      csstype: 3.2.3
 
   '@vue/runtime-dom@3.5.41':
     dependencies:
@@ -11535,86 +8444,32 @@ snapshots:
       '@vue/shared': 3.5.41
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.34
-      '@vue/shared': 3.5.34
-      vue: 3.5.34(typescript@5.9.3)
-
   '@vue/server-renderer@3.5.41':
     dependencies:
       '@vue/compiler-ssr': 3.5.41
       '@vue/runtime-dom': 3.5.41
       '@vue/shared': 3.5.41
 
-  '@vue/shared@3.5.34': {}
-
-  '@vue/shared@3.5.39': {}
-
   '@vue/shared@3.5.41': {}
 
-  '@vuetify/loader-shared@2.1.2(vue@3.5.34(typescript@5.9.3))(vuetify@4.0.7)':
+  '@vuetify/loader-shared@2.1.2(vue@3.5.41(typescript@5.9.3))(vuetify@4.1.8)':
     dependencies:
       upath: 2.0.1
-      vue: 3.5.34(typescript@5.9.3)
-      vuetify: 4.0.7(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.34(typescript@5.9.3))
+      vue: 3.5.41(typescript@5.9.3)
+      vuetify: 4.1.8(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@5.9.3))
 
-  '@vueuse/core@10.11.1(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      '@types/web-bluetooth': 0.0.20
-      '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.34(typescript@5.9.3))
-      vue-demi: 0.14.10(vue@3.5.34(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - vue
-
-  '@vueuse/core@14.3.0(vue@3.5.34(typescript@5.9.3))':
+  '@vueuse/core@14.4.0(vue@3.5.41(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
-      '@vueuse/metadata': 14.3.0
-      '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@5.9.3))
-      vue: 3.5.34(typescript@5.9.3)
+      '@vueuse/metadata': 14.4.0
+      '@vueuse/shared': 14.4.0(vue@3.5.41(typescript@5.9.3))
+      vue: 3.5.41(typescript@5.9.3)
 
-  '@vueuse/integrations@14.3.0(change-case@5.4.4)(fuse.js@7.5.0)(qrcode@1.5.4)(vue@3.5.34(typescript@5.9.3))':
+  '@vueuse/metadata@14.4.0': {}
+
+  '@vueuse/shared@14.4.0(vue@3.5.41(typescript@5.9.3))':
     dependencies:
-      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.9.3))
-      '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@5.9.3))
-      vue: 3.5.34(typescript@5.9.3)
-    optionalDependencies:
-      change-case: 5.4.4
-      fuse.js: 7.5.0
-      qrcode: 1.5.4
-
-  '@vueuse/metadata@10.11.1': {}
-
-  '@vueuse/metadata@14.3.0': {}
-
-  '@vueuse/nuxt@14.3.0(d41a3947a020e9f1740412568023ae47)':
-    dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.9.3))
-      '@vueuse/metadata': 14.3.0
-      local-pkg: 1.2.1
-      nuxt: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.138.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.13.0(typescript@5.9.3))(terser@5.49.2)(tsx@4.22.3)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
-      vue: 3.5.34(typescript@5.9.3)
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-
-  '@vueuse/shared@10.11.1(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      vue-demi: 0.14.10(vue@3.5.34(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - vue
-
-  '@vueuse/shared@14.3.0(vue@3.5.34(typescript@5.9.3))':
-    dependencies:
-      vue: 3.5.34(typescript@5.9.3)
+      vue: 3.5.41(typescript@5.9.3)
 
   abbrev@3.0.1: {}
 
@@ -11626,15 +8481,9 @@ snapshots:
     dependencies:
       acorn: 8.18.0
 
-  acorn-jsx@5.3.2(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
-
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
-
-  acorn@8.16.0: {}
 
   acorn@8.18.0: {}
 
@@ -11650,13 +8499,9 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-
-  ansi-escapes@7.3.0:
-    dependencies:
-      environment: 1.1.0
 
   ansi-regex@5.0.1: {}
 
@@ -11667,8 +8512,6 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.3: {}
-
-  ansis@4.3.0: {}
 
   ansis@4.3.1: {}
 
@@ -11707,21 +8550,12 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  aria-hidden@1.2.6:
-    dependencies:
-      tslib: 2.8.1
-
-  array-ify@1.0.0: {}
+  argue-cli@3.1.0: {}
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       pathe: 2.0.3
-
-  ast-walker-scope@0.8.3:
-    dependencies:
-      '@babel/parser': 7.29.7
-      ast-kit: 2.2.0
 
   ast-walker-scope@0.9.0:
     dependencies:
@@ -11759,7 +8593,7 @@ snapshots:
       bare-events: 2.9.1
       bare-path: 3.1.1
       bare-stream: 2.13.3(bare-events@2.9.1)
-      bare-url: 2.5.1
+      bare-url: 2.4.7
       fast-fifo: 1.3.2
     transitivePeerDependencies:
       - bare-abort-controller
@@ -11777,7 +8611,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
-  bare-url@2.5.1:
+  bare-url@2.4.7:
     dependencies:
       bare-path: 3.1.1
 
@@ -11798,10 +8632,6 @@ snapshots:
   brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.6:
-    dependencies:
-      balanced-match: 4.0.4
 
   brace-expansion@5.0.9:
     dependencies:
@@ -11828,7 +8658,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  builtin-modules@5.2.0: {}
+  builtin-modules@5.3.0: {}
 
   bundle-name@4.1.0:
     dependencies:
@@ -11838,23 +8668,6 @@ snapshots:
     dependencies:
       esbuild: 0.25.12
       load-tsconfig: 0.2.5
-
-  c12@3.3.4(magicast@0.5.3):
-    dependencies:
-      chokidar: 5.0.0
-      confbox: 0.2.4
-      defu: 6.1.7
-      dotenv: 17.4.2
-      exsolve: 1.1.1
-      giget: 3.3.1
-      jiti: 2.7.0
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      pkg-types: 2.3.1
-      rc9: 3.0.1
-    optionalDependencies:
-      magicast: 0.5.3
 
   c12@3.3.4(magicast@0.5.4):
     dependencies:
@@ -11873,15 +8686,12 @@ snapshots:
     optionalDependencies:
       magicast: 0.5.4
 
-  cac@6.7.14:
-    optional: true
-
   cac@7.0.0: {}
 
-  cacheable@2.3.5:
+  cacheable@2.5.0:
     dependencies:
-      '@cacheable/memory': 2.0.9
-      '@cacheable/utils': 2.4.1
+      '@cacheable/memory': 2.2.0
+      '@cacheable/utils': 2.5.0
       hookified: 1.15.1
       keyv: 5.6.0
       qified: 0.10.1
@@ -11897,13 +8707,7 @@ snapshots:
 
   caniuse-lite@1.0.30001809: {}
 
-  ccount@2.0.1: {}
-
   change-case@5.4.4: {}
-
-  character-entities-html4@2.1.0: {}
-
-  character-entities-legacy@3.0.0: {}
 
   chart.js@4.5.1:
     dependencies:
@@ -11922,7 +8726,7 @@ snapshots:
 
   chrome-launcher@1.2.1:
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.2
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2
@@ -11936,15 +8740,6 @@ snapshots:
       consola: 3.4.2
 
   citty@0.2.2: {}
-
-  cli-cursor@5.0.0:
-    dependencies:
-      restore-cursor: 5.1.0
-
-  cli-truncate@5.2.0:
-    dependencies:
-      slice-ansi: 8.0.0
-      string-width: 8.2.1
 
   cliui@6.0.0:
     dependencies:
@@ -11974,12 +8769,6 @@ snapshots:
 
   colord@2.9.3: {}
 
-  colorette@2.0.20: {}
-
-  colortranslator@5.0.0: {}
-
-  comma-separated-tokens@2.0.3: {}
-
   commander@11.1.0: {}
 
   commander@2.20.3: {}
@@ -11987,11 +8776,6 @@ snapshots:
   comment-parser@1.4.7: {}
 
   commondir@1.0.1: {}
-
-  compare-func@2.0.0:
-    dependencies:
-      array-ify: 1.0.0
-      dot-prop: 5.3.0
 
   compatx@0.2.0: {}
 
@@ -12009,18 +8793,20 @@ snapshots:
 
   consola@3.4.2: {}
 
-  conventional-changelog-angular@8.3.1:
+  conventional-changelog-angular@9.2.1:
     dependencies:
-      compare-func: 2.0.0
+      '@conventional-changelog/template': 1.2.1
 
-  conventional-changelog-conventionalcommits@9.3.1:
+  conventional-changelog-conventionalcommits@10.2.1:
     dependencies:
-      compare-func: 2.0.0
+      '@conventional-changelog/template': 1.2.1
 
-  conventional-commits-parser@6.4.0:
+  conventional-commits-parser@7.1.2:
     dependencies:
-      '@simple-libs/stream-utils': 1.2.0
-      meow: 13.2.0
+      '@simple-libs/stream-utils': 2.0.0
+      argue-cli: 3.1.0
+
+  convert-hrtime@5.0.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -12034,15 +8820,15 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
-  core-js-compat@3.49.0:
+  core-js-compat@3.50.0:
     dependencies:
       browserslist: 4.28.7
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.2(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@26.1.2)(cosmiconfig@9.0.2(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.2
       cosmiconfig: 9.0.2(typescript@5.9.3)
       jiti: 2.6.1
       typescript: 5.9.3
@@ -12051,12 +8837,12 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
 
-  countries-list@3.3.0: {}
+  countries-list@3.4.1: {}
 
   crc-32@1.2.2: {}
 
@@ -12154,9 +8940,7 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  culori@4.0.2: {}
-
-  date-fns@4.3.0: {}
+  date-fns@4.4.0: {}
 
   db0@0.3.4: {}
 
@@ -12185,8 +8969,6 @@ snapshots:
 
   depd@2.0.0: {}
 
-  dequal@2.0.3: {}
-
   destr@2.0.5: {}
 
   detect-indent@7.0.2: {}
@@ -12195,35 +8977,21 @@ snapshots:
 
   devalue@5.9.0: {}
 
-  devframe@0.5.4(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
+  devframe@0.8.2(cac@7.0.0)(srvx@0.11.22):
     dependencies:
-      '@valibot/to-json-schema': 1.7.1(valibot@1.4.1(typescript@5.9.3))
+      '@standard-schema/spec': 1.1.0
       birpc: 4.0.0
-      cac: 7.0.0
-      h3: 2.0.1-rc.22(crossws@0.4.10(srvx@0.11.22))
+      crossws: 0.4.10(srvx@0.11.22)
+      destr: 2.0.5
+      h3: 2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22))
       mrmime: 2.0.1
-      nostics: 0.2.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      nostics: 1.2.0
       pathe: 2.0.3
-      valibot: 1.4.1(typescript@5.9.3)
-      ws: 8.21.3
+      ufo: 1.6.4
+    optionalDependencies:
+      cac: 7.0.0
     transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@rspack/core'
-      - bufferutil
-      - bun-types-no-globals
-      - crossws
-      - esbuild
-      - rolldown
-      - rollup
-      - typescript
-      - unloader
-      - utf-8-validate
-      - vite
-      - webpack
-
-  devlop@1.1.0:
-    dependencies:
-      dequal: 2.0.3
+      - srvx
 
   diff@8.0.4: {}
 
@@ -12253,10 +9021,6 @@ snapshots:
     dependencies:
       type-fest: 5.8.0
 
-  dot-prop@5.3.0:
-    dependencies:
-      is-obj: 2.0.0
-
   dotenv@17.4.2: {}
 
   duplexer@0.1.2: {}
@@ -12267,43 +9031,6 @@ snapshots:
 
   electron-to-chromium@1.5.402: {}
 
-  embla-carousel-auto-height@8.6.0(embla-carousel@8.6.0):
-    dependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel-auto-scroll@8.6.0(embla-carousel@8.6.0):
-    dependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel-autoplay@8.6.0(embla-carousel@8.6.0):
-    dependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel-class-names@8.6.0(embla-carousel@8.6.0):
-    dependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel-fade@8.6.0(embla-carousel@8.6.0):
-    dependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
-    dependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel-vue@8.6.0(vue@3.5.34(typescript@5.9.3)):
-    dependencies:
-      embla-carousel: 8.6.0
-      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
-      vue: 3.5.34(typescript@5.9.3)
-
-  embla-carousel-wheel-gestures@8.1.0(embla-carousel@8.6.0):
-    dependencies:
-      embla-carousel: 8.6.0
-      wheel-gestures: 2.2.48
-
-  embla-carousel@8.6.0: {}
-
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -12312,18 +9039,11 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
-  enhanced-resolve@5.21.6:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.3
-
   entities@4.5.0: {}
 
   entities@7.0.1: {}
 
   env-paths@2.2.1: {}
-
-  environment@1.1.0: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -12339,7 +9059,7 @@ snapshots:
 
   es-module-lexer@2.3.1: {}
 
-  es-toolkit@1.48.1: {}
+  es-toolkit@1.50.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -12369,35 +9089,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
-
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -12436,14 +9127,14 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-flat-gitignore@2.3.0(eslint@10.5.0(jiti@2.7.0)):
+  eslint-config-flat-gitignore@2.3.0(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      '@eslint/compat': 2.1.0(eslint@10.5.0(jiti@2.7.0))
-      eslint: 10.5.0(jiti@2.7.0)
+      '@eslint/compat': 2.1.0(eslint@10.8.0(jiti@2.7.0))
+      eslint: 10.8.0(jiti@2.7.0)
 
-  eslint-config-prettier@10.1.8(eslint@10.5.0(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
 
   eslint-flat-config-utils@3.2.0:
     dependencies:
@@ -12452,104 +9143,109 @@ snapshots:
 
   eslint-import-context@0.1.9(unrs-resolver@1.12.2):
     dependencies:
-      get-tsconfig: 4.14.0
+      get-tsconfig: 4.14.1
       stable-hash-x: 0.2.0
     optionalDependencies:
       unrs-resolver: 1.12.2
 
-  eslint-merge-processors@2.0.0(eslint@10.5.0(jiti@2.7.0)):
+  eslint-merge-processors@2.0.0(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
 
-  eslint-plugin-import-lite@0.6.0(eslint@10.5.0(jiti@2.7.0)):
+  eslint-plugin-import-lite@0.6.0(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
 
-  eslint-plugin-import-x@4.17.0(@typescript-eslint/utils@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.5.0(jiti@2.7.0)):
+  eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/types': 8.66.0
       comment-parser: 1.4.7
       debug: 4.4.3
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       eslint-import-context: 0.1.9(unrs-resolver@1.12.2)
       is-glob: 4.0.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       semver: 7.8.5
       stable-hash-x: 0.2.0
       unrs-resolver: 1.12.2
     optionalDependencies:
-      '@typescript-eslint/utils': 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsdoc@63.0.7(eslint@10.5.0(jiti@2.7.0)):
+  eslint-plugin-jsdoc@63.3.3(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      '@es-joy/jsdoccomment': 0.87.0
+      '@es-joy/jsdoccomment': 0.91.0
       '@es-joy/resolve.exports': 1.2.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.7
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       espree: 11.2.0
       esquery: 1.7.0
       html-entities: 2.6.0
       object-deep-merge: 2.0.1
       parse-imports-exports: 0.2.4
       semver: 7.8.5
-      spdx-expression-parse: 4.0.0
+      spdx-expression-parse: 5.0.0
       to-valid-identifier: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-regexp@3.1.0(eslint@10.5.0(jiti@2.7.0)):
+  eslint-plugin-regexp@3.1.1(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       comment-parser: 1.4.7
-      eslint: 10.5.0(jiti@2.7.0)
-      jsdoc-type-pratt-parser: 7.2.0
+      eslint: 10.8.0(jiti@2.7.0)
+      jsdoc-type-pratt-parser: 7.3.0
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-unicorn@65.0.1(eslint@10.5.0(jiti@2.7.0)):
+  eslint-plugin-unicorn@73.0.0(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0))
+      '@eslint/css-tree': 4.0.5
+      browserslist: 4.28.7
       change-case: 5.4.4
       ci-info: 4.4.0
-      core-js-compat: 3.49.0
+      core-js-compat: 3.50.0
       detect-indent: 7.0.2
-      eslint: 10.5.0(jiti@2.7.0)
+      entities: 4.5.0
+      eslint: 10.8.0(jiti@2.7.0)
       find-up-simple: 1.0.1
-      globals: 17.7.0
+      globals: 17.9.0
       indent-string: 5.0.0
       is-builtin-module: 5.0.0
-      jsesc: 3.1.0
+      is-identifier: 1.1.0
       pluralize: 8.0.0
+      quote-js-string: 0.1.0
       regjsparser: 0.13.2
+      reserved-identifiers: 1.2.0
       semver: 7.8.5
       strip-indent: 4.1.1
+      yaml: 2.9.0
 
-  eslint-plugin-vue@10.9.2(@stylistic/eslint-plugin@5.10.0(eslint@10.5.0(jiti@2.7.0)))(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0))):
+  eslint-plugin-vue@10.10.0(@stylistic/eslint-plugin@5.10.0(eslint@10.8.0(jiti@2.7.0)))(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
-      eslint: 10.5.0(jiti@2.7.0)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0))
+      eslint: 10.8.0(jiti@2.7.0)
       natural-compare: 1.4.0
       nth-check: 2.1.1
-      postcss-selector-parser: 7.1.1
+      postcss-selector-parser: 7.1.5
       semver: 7.8.5
-      vue-eslint-parser: 10.4.1(eslint@10.5.0(jiti@2.7.0))
-      xml-name-validator: 4.0.0
+      vue-eslint-parser: 10.4.1(eslint@10.8.0(jiti@2.7.0))
+      xml-name-validator: 5.0.0
     optionalDependencies:
-      '@stylistic/eslint-plugin': 5.10.0(eslint@10.5.0(jiti@2.7.0))
-      '@typescript-eslint/parser': 8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
+      '@stylistic/eslint-plugin': 5.10.0(eslint@10.8.0(jiti@2.7.0))
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
 
-  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.41)(eslint@10.5.0(jiti@2.7.0)):
+  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.41)(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
       '@vue/compiler-sfc': 3.5.41
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -12558,9 +9254,9 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-typegen@2.3.1(eslint@10.5.0(jiti@2.7.0)):
+  eslint-typegen@2.3.1(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       json-schema-to-typescript-lite: 15.0.0
       ohash: 2.0.11
 
@@ -12570,12 +9266,12 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.5.0(jiti@2.7.0):
+  eslint@10.8.0(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.6.0
+      '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       '@humanfs/node': 0.16.8
@@ -12599,7 +9295,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -12615,8 +9311,8 @@ snapshots:
 
   espree@11.2.0:
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
       eslint-visitor-keys: 5.0.1
 
   esquery@1.7.0:
@@ -12640,8 +9336,6 @@ snapshots:
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
-
-  eventemitter3@5.0.4: {}
 
   events-universal@1.0.1:
     dependencies:
@@ -12691,25 +9385,25 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
 
-  fast-xml-builder@1.2.1:
+  fast-xml-builder@1.3.0:
     dependencies:
-      path-expression-matcher: 1.6.1
-      xml-naming: 0.1.0
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
 
-  fast-xml-parser@5.9.3:
+  fast-xml-parser@5.10.1:
     dependencies:
-      '@nodable/entities': 2.2.0
-      fast-xml-builder: 1.2.1
-      is-unsafe: 1.0.1
-      path-expression-matcher: 1.6.1
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.3.0
+      is-unsafe: 2.0.0
+      path-expression-matcher: 1.6.2
       strnum: 2.4.1
-      xml-naming: 0.1.0
+      xml-naming: 0.3.0
 
   fastest-levenshtein@1.0.16: {}
 
@@ -12719,15 +9413,15 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
 
-  file-entry-cache@11.1.3:
+  file-entry-cache@11.1.5:
     dependencies:
-      flat-cache: 6.1.22
+      flat-cache: 6.1.23
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -12756,36 +9450,36 @@ snapshots:
       locate-path: 8.0.0
       unicorn-magic: 0.3.0
 
-  firebase@12.13.0:
+  firebase@12.17.1:
     dependencies:
-      '@firebase/ai': 2.12.0(@firebase/app-types@0.9.5)(@firebase/app@0.14.12)
-      '@firebase/analytics': 0.10.22(@firebase/app@0.14.12)
-      '@firebase/analytics-compat': 0.2.28(@firebase/app-compat@0.5.12)(@firebase/app@0.14.12)
-      '@firebase/app': 0.14.12
-      '@firebase/app-check': 0.11.3(@firebase/app@0.14.12)
-      '@firebase/app-check-compat': 0.4.3(@firebase/app-compat@0.5.12)(@firebase/app@0.14.12)
-      '@firebase/app-compat': 0.5.12
+      '@firebase/ai': 2.14.0(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)
+      '@firebase/analytics': 0.10.23(@firebase/app@0.16.0)
+      '@firebase/analytics-compat': 0.2.29(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/app': 0.16.0
+      '@firebase/app-check': 0.13.0(@firebase/app@0.16.0)
+      '@firebase/app-check-compat': 0.4.6(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/app-compat': 0.5.16
       '@firebase/app-types': 0.9.5
-      '@firebase/auth': 1.13.1(@firebase/app@0.14.12)
-      '@firebase/auth-compat': 0.6.6(@firebase/app-compat@0.5.12)(@firebase/app-types@0.9.5)(@firebase/app@0.14.12)
-      '@firebase/data-connect': 0.7.0(@firebase/app@0.14.12)
-      '@firebase/database': 1.1.3
-      '@firebase/database-compat': 2.1.4
-      '@firebase/firestore': 4.14.1(@firebase/app@0.14.12)
-      '@firebase/firestore-compat': 0.4.9(@firebase/app-compat@0.5.12)(@firebase/app-types@0.9.5)(@firebase/app@0.14.12)
-      '@firebase/functions': 0.13.4(@firebase/app@0.14.12)
-      '@firebase/functions-compat': 0.4.4(@firebase/app-compat@0.5.12)(@firebase/app@0.14.12)
-      '@firebase/installations': 0.6.22(@firebase/app@0.14.12)
-      '@firebase/installations-compat': 0.2.22(@firebase/app-compat@0.5.12)(@firebase/app-types@0.9.5)(@firebase/app@0.14.12)
-      '@firebase/messaging': 0.12.26(@firebase/app@0.14.12)
-      '@firebase/messaging-compat': 0.2.26(@firebase/app-compat@0.5.12)(@firebase/app@0.14.12)
-      '@firebase/performance': 0.7.12(@firebase/app@0.14.12)
-      '@firebase/performance-compat': 0.2.25(@firebase/app-compat@0.5.12)(@firebase/app@0.14.12)
-      '@firebase/remote-config': 0.8.3(@firebase/app@0.14.12)
-      '@firebase/remote-config-compat': 0.2.24(@firebase/app-compat@0.5.12)(@firebase/app@0.14.12)
-      '@firebase/storage': 0.14.3(@firebase/app@0.14.12)
-      '@firebase/storage-compat': 0.4.3(@firebase/app-compat@0.5.12)(@firebase/app-types@0.9.5)(@firebase/app@0.14.12)
-      '@firebase/util': 1.15.1
+      '@firebase/auth': 1.13.4(@firebase/app@0.16.0)
+      '@firebase/auth-compat': 0.6.9(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)
+      '@firebase/data-connect': 0.7.3(@firebase/app@0.16.0)
+      '@firebase/database': 1.1.4
+      '@firebase/database-compat': 2.1.6(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/firestore': 4.17.0(@firebase/app@0.16.0)
+      '@firebase/firestore-compat': 0.4.12(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)
+      '@firebase/functions': 0.13.6(@firebase/app@0.16.0)
+      '@firebase/functions-compat': 0.4.6(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/installations': 0.6.23(@firebase/app@0.16.0)
+      '@firebase/installations-compat': 0.2.23(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)
+      '@firebase/messaging': 0.13.1(@firebase/app@0.16.0)
+      '@firebase/messaging-compat': 0.2.28(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/performance': 0.7.13(@firebase/app@0.16.0)
+      '@firebase/performance-compat': 0.2.26(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/remote-config': 0.9.1(@firebase/app@0.16.0)
+      '@firebase/remote-config-compat': 0.2.28(@firebase/app-compat@0.5.16)(@firebase/app@0.16.0)
+      '@firebase/storage': 0.14.4(@firebase/app@0.16.0)
+      '@firebase/storage-compat': 0.4.4(@firebase/app-compat@0.5.16)(@firebase/app-types@0.9.5)(@firebase/app@0.16.0)
+      '@firebase/util': 1.15.2
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
 
@@ -12793,70 +9487,18 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.2
+      flatted: 3.4.4
       keyv: 4.5.4
 
-  flat-cache@6.1.22:
+  flat-cache@6.1.23:
     dependencies:
-      cacheable: 2.3.5
-      flatted: 3.4.2
+      cacheable: 2.5.0
+      flatted: 3.4.4
       hookified: 1.15.1
 
-  flatted@3.4.2: {}
+  flatted@3.4.4: {}
 
   fnv1a-64@0.1.2: {}
-
-  fontaine@0.8.0:
-    dependencies:
-      '@capsizecss/unpack': 4.0.1
-      css-tree: 3.2.1
-      magic-regexp: 0.10.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      ufo: 1.6.4
-      unplugin: 2.3.11
-
-  fontkitten@1.0.3:
-    dependencies:
-      tiny-inflate: 1.0.3
-
-  fontless@0.2.1(db0@0.3.4)(ioredis@5.11.1)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
-    dependencies:
-      consola: 3.4.2
-      css-tree: 3.2.1
-      defu: 6.1.7
-      esbuild: 0.27.7
-      fontaine: 0.8.0
-      jiti: 2.7.0
-      lightningcss: 1.33.0
-      magic-string: 0.30.21
-      ohash: 2.0.11
-      pathe: 2.0.3
-      ufo: 1.6.4
-      unifont: 0.7.4
-      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
-    optionalDependencies:
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - db0
-      - idb-keyval
-      - ioredis
-      - uploadthing
 
   foreground-child@3.3.1:
     dependencies:
@@ -12865,12 +9507,6 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
-  framer-motion@12.42.2:
-    dependencies:
-      motion-dom: 12.42.2
-      motion-utils: 12.39.0
-      tslib: 2.8.1
-
   fresh@2.0.0: {}
 
   fsevents@2.3.3:
@@ -12878,7 +9514,7 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  fuse.js@7.4.2: {}
+  function-timeout@1.0.2: {}
 
   fuse.js@7.5.0: {}
 
@@ -12898,19 +9534,11 @@ snapshots:
 
   get-stream@8.0.1: {}
 
-  get-tsconfig@4.14.0:
+  get-tsconfig@4.14.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
   giget@3.3.1: {}
-
-  git-raw-commits@5.0.1(conventional-commits-parser@6.4.0):
-    dependencies:
-      '@conventional-changelog/git-client': 2.7.0(conventional-commits-parser@6.4.0)
-      meow: 13.2.0
-    transitivePeerDependencies:
-      - conventional-commits-filter
-      - conventional-commits-parser
 
   glob-parent@5.1.2:
     dependencies:
@@ -12953,18 +9581,9 @@ snapshots:
       kind-of: 6.0.3
       which: 1.3.1
 
-  globals@17.7.0: {}
+  globals@17.9.0: {}
 
-  globby@16.2.0:
-    dependencies:
-      '@sindresorhus/merge-streams': 4.0.0
-      fast-glob: 3.3.3
-      ignore: 7.0.6
-      is-path-inside: 4.0.0
-      slash: 5.1.0
-      unicorn-magic: 0.4.0
-
-  globby@16.2.3:
+  globby@16.2.2:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
       fast-glob: 3.3.3
@@ -13000,10 +9619,10 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
-  h3@2.0.1-rc.22(crossws@0.4.10(srvx@0.11.22)):
+  h3@2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22)):
     dependencies:
-      rou3: 0.8.1
-      srvx: 0.11.22
+      rou3: 0.9.1
+      srvx: 0.12.5
     optionalDependencies:
       crossws: 0.4.10(srvx@0.11.22)
 
@@ -13016,26 +9635,6 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
-
-  hast-util-to-html@9.0.5:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      ccount: 2.0.1
-      comma-separated-tokens: 2.0.3
-      hast-util-whitespace: 3.0.0
-      html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.1
-      property-information: 7.2.0
-      space-separated-tokens: 2.0.2
-      stringify-entities: 4.0.4
-      zwitch: 2.0.4
-
-  hast-util-whitespace@3.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-
-  hey-listen@1.0.8: {}
 
   highlight.js@11.11.1: {}
 
@@ -13050,8 +9649,6 @@ snapshots:
   html-entities@2.6.0: {}
 
   html-tags@5.1.0: {}
-
-  html-void-elements@3.0.0: {}
 
   htmlparser2@8.0.2:
     dependencies:
@@ -13087,11 +9684,13 @@ snapshots:
 
   idb@7.1.1: {}
 
+  identifier-regex@1.1.0:
+    dependencies:
+      reserved-identifiers: 1.2.0
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
-
-  ignore@7.0.5: {}
 
   ignore@7.0.6: {}
 
@@ -13099,7 +9698,7 @@ snapshots:
 
   image-size@2.0.2: {}
 
-  immutable@5.1.5: {}
+  immutable@5.1.9: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -13115,16 +9714,16 @@ snapshots:
       esbuild: 0.25.12
       jiti: 2.7.0
       pathe: 2.0.3
-      tsx: 4.22.3
+      tsx: 4.23.10
     transitivePeerDependencies:
       - supports-color
 
-  impound@1.1.6(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
+  impound@1.1.6(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       es-module-lexer: 2.3.1
       pathe: 2.0.3
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       unplugin-utils: 0.3.2
     transitivePeerDependencies:
       - '@farmfe/core'
@@ -13167,7 +9766,7 @@ snapshots:
 
   is-builtin-module@5.0.0:
     dependencies:
-      builtin-modules: 5.2.0
+      builtin-modules: 5.3.0
 
   is-core-module@2.16.2:
     dependencies:
@@ -13181,13 +9780,14 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-fullwidth-code-point@5.1.0:
-    dependencies:
-      get-east-asian-width: 1.6.0
-
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-identifier@1.1.0:
+    dependencies:
+      identifier-regex: 1.1.0
+      super-regex: 1.1.0
 
   is-in-ssh@1.0.0: {}
 
@@ -13204,8 +9804,6 @@ snapshots:
 
   is-number@7.0.0: {}
 
-  is-obj@2.0.0: {}
-
   is-path-inside@4.0.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -13218,7 +9816,7 @@ snapshots:
 
   is-stream@3.0.0: {}
 
-  is-unsafe@1.0.1: {}
+  is-unsafe@2.0.0: {}
 
   is-what@5.5.0: {}
 
@@ -13236,8 +9834,6 @@ snapshots:
 
   isexe@4.0.0: {}
 
-  isomorphic.js@0.2.5: {}
-
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -13254,11 +9850,13 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
-  jsdoc-type-pratt-parser@7.2.0: {}
+  jsdoc-type-pratt-parser@7.3.0: {}
+
+  jsdoc-type-pratt-parser@8.0.0: {}
 
   jsesc@3.1.0: {}
 
@@ -13309,11 +9907,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lib0@0.2.117:
-    dependencies:
-      isomorphic.js: 0.2.5
-
-  libphonenumber-js@1.13.3: {}
+  libphonenumber-js@1.13.10: {}
 
   lighthouse-logger@2.0.2:
     dependencies:
@@ -13322,87 +9916,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  lightningcss-android-arm64@1.32.0:
-    optional: true
-
   lightningcss-android-arm64@1.33.0:
-    optional: true
-
-  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-arm64@1.33.0:
     optional: true
 
-  lightningcss-darwin-x64@1.32.0:
-    optional: true
-
   lightningcss-darwin-x64@1.33.0:
-    optional: true
-
-  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-freebsd-x64@1.33.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    optional: true
-
   lightningcss-linux-arm-gnueabihf@1.33.0:
-    optional: true
-
-  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    optional: true
-
   lightningcss-linux-arm64-musl@1.33.0:
-    optional: true
-
-  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.32.0:
-    optional: true
-
   lightningcss-linux-x64-musl@1.33.0:
-    optional: true
-
-  lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.33.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.32.0:
-    optional: true
-
   lightningcss-win32-x64-msvc@1.33.0:
     optional: true
-
-  lightningcss@1.32.0:
-    dependencies:
-      detect-libc: 2.1.2
-    optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
-      lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
-      lightningcss-linux-arm64-gnu: 1.32.0
-      lightningcss-linux-arm64-musl: 1.32.0
-      lightningcss-linux-x64-gnu: 1.32.0
-      lightningcss-linux-x64-musl: 1.32.0
-      lightningcss-win32-arm64-msvc: 1.32.0
-      lightningcss-win32-x64-msvc: 1.32.0
 
   lightningcss@1.33.0:
     dependencies:
@@ -13424,18 +9969,15 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkifyjs@4.3.3: {}
-
-  lint-staged@17.0.8:
+  lint-staged@17.3.0:
     dependencies:
-      listr2: 10.2.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       string-argv: 0.3.2
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
     optionalDependencies:
       yaml: 2.9.0
 
-  listhen@1.10.1(@parcel/watcher@2.5.6)(srvx@0.11.22):
+  listhen@1.10.1(@parcel/watcher@2.6.0)(srvx@0.11.22):
     dependencies:
       '@parcel/watcher-wasm': 2.6.0
       citty: 0.2.2
@@ -13454,17 +9996,9 @@ snapshots:
       untun: 0.2.2
       uqr: 0.1.3
     optionalDependencies:
-      '@parcel/watcher': 2.5.6
+      '@parcel/watcher': 2.6.0
     transitivePeerDependencies:
       - srvx
-
-  listr2@10.2.1:
-    dependencies:
-      cli-truncate: 5.2.0
-      eventemitter3: 5.0.4
-      log-update: 6.1.0
-      rfdc: 1.4.1
-      wrap-ansi: 10.0.0
 
   load-tsconfig@0.2.5: {}
 
@@ -13494,14 +10028,6 @@ snapshots:
 
   lodash@4.18.1: {}
 
-  log-update@6.1.0:
-    dependencies:
-      ansi-escapes: 7.3.0
-      cli-cursor: 5.0.0
-      slice-ansi: 7.1.2
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
-
   long@5.3.2: {}
 
   lru-cache@10.4.3: {}
@@ -13511,16 +10037,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  magic-regexp@0.10.0:
-    dependencies:
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      regexp-tree: 0.1.27
-      type-level-regexp: 0.1.17
-      ufo: 1.6.4
-      unplugin: 2.3.11
 
   magic-string-ast@1.0.3:
     dependencies:
@@ -13534,64 +10050,33 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.5.3:
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      source-map-js: 1.2.1
-
   magicast@0.5.4:
     dependencies:
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
       source-map-js: 1.2.1
 
-  marked@17.0.6: {}
+  make-asynchronous@1.1.0:
+    dependencies:
+      p-event: 6.0.1
+      type-fest: 4.41.0
+      web-worker: 1.5.0
 
   marky@1.3.0: {}
 
   mathml-tag-names@4.0.0: {}
 
-  mdast-util-to-hast@13.2.1:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.3.2
-      devlop: 1.1.0
-      micromark-util-sanitize-uri: 2.0.1
-      trim-lines: 3.0.1
-      unist-util-position: 5.0.0
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-
   mdn-data@2.0.28: {}
 
   mdn-data@2.27.1: {}
 
-  meow@13.2.0: {}
+  mdn-data@2.29.0: {}
 
   meow@14.1.0: {}
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
-
-  micromark-util-character@2.1.1:
-    dependencies:
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
-  micromark-util-encode@2.0.1: {}
-
-  micromark-util-sanitize-uri@2.0.1:
-    dependencies:
-      micromark-util-character: 2.1.1
-      micromark-util-encode: 2.0.1
-      micromark-util-symbol: 2.0.1
-
-  micromark-util-symbol@2.0.1: {}
-
-  micromark-util-types@2.0.2: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -13607,12 +10092,6 @@ snapshots:
   mime@4.1.0: {}
 
   mimic-fn@4.0.0: {}
-
-  mimic-function@5.0.1: {}
-
-  minimatch@10.2.5:
-    dependencies:
-      brace-expansion: 5.0.6
 
   minimatch@10.2.6:
     dependencies:
@@ -13645,32 +10124,11 @@ snapshots:
 
   moment@2.30.1: {}
 
-  motion-dom@12.42.2:
-    dependencies:
-      motion-utils: 12.39.0
-
-  motion-utils@12.39.0: {}
-
-  motion-v@2.3.0(@vueuse/core@14.3.0(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)):
-    dependencies:
-      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.9.3))
-      framer-motion: 12.42.2
-      hey-listen: 1.0.8
-      motion-dom: 12.42.2
-      motion-utils: 12.39.0
-      vue: 3.5.34(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - react
-      - react-dom
-
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
-
-  nanoid@3.3.12: {}
 
   nanoid@3.3.17: {}
 
@@ -13680,7 +10138,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  nitropack@2.13.4(@parcel/watcher@2.5.6)(oxc-parser@0.138.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
+  nitropack@2.13.4(@parcel/watcher@2.6.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.4)
@@ -13709,7 +10167,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       etag: 1.8.1
       exsolve: 1.1.1
-      globby: 16.2.3
+      globby: 16.2.2
       gzip-size: 7.0.0
       h3: 1.15.11
       hookable: 5.5.3
@@ -13718,7 +10176,7 @@ snapshots:
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
-      listhen: 1.10.1(@parcel/watcher@2.5.6)(srvx@0.11.22)
+      listhen: 1.10.1(@parcel/watcher@2.6.0)(srvx@0.11.22)
       magic-string: 0.30.21
       magicast: 0.5.4
       mime: 4.1.0
@@ -13745,7 +10203,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.5.0
       unenv: 2.0.0-rc.24
-      unimport: 6.4.0(esbuild@0.28.1)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      unimport: 6.4.0(esbuild@0.28.1)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       unplugin-utils: 0.3.2
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
       untyped: 2.0.0
@@ -13815,22 +10273,6 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
-  nostics@0.2.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
-    dependencies:
-      magic-string: 0.30.21
-      oxc-parser: 0.132.0
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@rspack/core'
-      - bun-types-no-globals
-      - esbuild
-      - rolldown
-      - rollup
-      - unloader
-      - vite
-      - webpack
-
   nostics@1.2.0: {}
 
   npm-run-path@5.3.0:
@@ -13846,23 +10288,23 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt-link-checker@5.1.2(44f4b2b7d2f9ee8e362dff21d5ae9b48):
+  nuxt-link-checker@5.1.3(f18257b9155498110349a5e9ade5d532):
     dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.9.3))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
+      '@vueuse/core': 14.4.0(vue@3.5.41(typescript@5.9.3))
       consola: 3.4.2
       diff: 9.0.0
-      fuse.js: 7.4.2
+      fuse.js: 7.5.0
       h3: 1.15.11
-      magic-string: 0.30.21
-      nuxt: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.138.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.13.0(typescript@5.9.3))(terser@5.49.2)(tsx@4.22.3)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
-      nuxt-site-config: 4.1.1(7877631f0cf65e725df80f294cd86891)
-      nuxtseo-shared: 5.3.2(9a4742efa56a00a44e3e94e40a26a5f7)
+      magic-string: 1.1.0
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.8.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.142.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.102.0)(srvx@0.11.22)(stylelint@17.14.1(typescript@5.9.3))(terser@5.49.2)(tsx@4.23.10)(typescript@5.9.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt-site-config: 4.2.0(30f44f47b1ac7bbdc0a379b9883293fe)
+      nuxtseo-shared: 5.3.10(0cd7c915431e46e6b683eb9a96b16f83)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
       radix3: 1.1.2
-      site-config-stack: 4.1.1(vue@3.5.34(typescript@5.9.3))
+      site-config-stack: 4.2.0(vue@3.5.41(typescript@5.9.3))
       ufo: 1.6.4
       ultrahtml: 1.7.0
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
@@ -13895,47 +10337,42 @@ snapshots:
       - vue
       - zod
 
-  nuxt-og-image@6.7.2(da6d5f553c655a51bde07ce599cb019e):
+  nuxt-og-image@6.7.6(1e2b93cf07dca500f5d39a59f8d1103b):
     dependencies:
-      '@clack/prompts': 1.6.0
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
-      '@unocss/config': 66.7.4
-      '@unocss/core': 66.7.4
-      '@vue/compiler-sfc': 3.5.39
+      '@clack/prompts': 1.7.0
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@vue/compiler-sfc': 3.5.41
       chrome-launcher: 1.2.1
       consola: 3.4.2
-      culori: 4.0.2
       defu: 6.1.7
       devalue: 5.9.0
       exsolve: 1.1.1
-      lightningcss: 1.32.0
-      magic-string: 0.30.21
-      magicast: 0.5.3
+      fnv1a-64: 0.1.2
+      lightningcss: 1.33.0
+      magic-string: 1.1.0
+      magicast: 0.5.4
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.1.1(da50f1e9fdc48b596813f24331f87232)
-      nuxtseo-shared: 5.3.2(28af55199f4cc9df90f9ffd6fd2b2367)
+      nuxt-site-config: 4.2.0(30f44f47b1ac7bbdc0a379b9883293fe)
+      nuxtseo-shared: 5.3.10(0cd7c915431e46e6b683eb9a96b16f83)
       nypm: 0.6.9
+      object-identity: 0.2.3
       ofetch: 1.5.1
       ohash: 2.0.11
-      oxc-parser: 0.138.0
-      oxc-walker: 1.1.1(@oxc-project/types@0.143.0)(oxc-parser@0.138.0)(rolldown@1.2.3)
+      oxc-parser: 0.142.0
+      oxc-walker: 1.1.1(@oxc-project/types@0.143.0)(oxc-parser@0.142.0)(rolldown@1.2.3)
       pathe: 2.0.3
       pkg-types: 2.3.1
       radix3: 1.1.2
       std-env: 4.2.0
-      strip-literal: 3.1.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
+      strip-literal: 4.0.0
+      tinyexec: 1.3.0
       ufo: 1.6.4
       ultrahtml: 1.7.0
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
     optionalDependencies:
-      fontless: 0.2.1(db0@0.3.4)(ioredis@5.11.1)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      nitropack: 2.13.4(@parcel/watcher@2.5.6)(oxc-parser@0.138.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      tailwindcss: 4.3.2
-      unifont: 0.7.4
+      nitropack: 2.13.4(@parcel/watcher@2.6.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@nuxt/schema'
@@ -13952,17 +10389,17 @@ snapshots:
       - vue
       - webpack
 
-  nuxt-schema-org@6.2.3(932aeff8fdec8e3ce6179ad3f7827f8b):
+  nuxt-schema-org@6.2.8(a988b73004e9a24d278f96bbfdb2520c):
     dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       defu: 6.1.7
-      nuxt-site-config: 4.1.1(4d79e2cd154eafd0ae5acf0b0945c71b)
-      nuxtseo-shared: 5.3.2(043985539a50ea96924caeb25844c44e)
+      nuxt-site-config: 4.2.0(30f44f47b1ac7bbdc0a379b9883293fe)
+      nuxtseo-shared: 5.3.10(0cd7c915431e46e6b683eb9a96b16f83)
       pkg-types: 2.3.1
       ufo: 1.6.4
     optionalDependencies:
-      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
-      unhead: 3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      unhead: 3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@nuxt/schema'
       - magic-string
@@ -13974,120 +10411,46 @@ snapshots:
       - vite
       - vue
 
-  nuxt-seo-utils@8.3.1(175313bbf896de2adf74b471bfbf40bf):
+  nuxt-seo-utils@8.3.3(e53b46e74e5782014a591da31257fe78):
     dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      '@unhead/bundler': 3.1.7(@oxc-project/types@0.143.0)(crossws@0.4.10(srvx@0.11.22))(esbuild@0.25.12)(lightningcss@1.33.0)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(unhead@3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       citty: 0.2.2
       consola: 3.4.2
       defu: 6.1.7
       escape-string-regexp: 5.0.0
       exsolve: 1.1.1
       image-size: 2.0.2
-      nuxt: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.138.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.13.0(typescript@5.9.3))(terser@5.49.2)(tsx@4.22.3)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
-      nuxt-site-config: 4.1.1(4d79e2cd154eafd0ae5acf0b0945c71b)
-      nuxtseo-layer-devtools: 5.3.2(228959972d51119f78b2f06547565ac7)
-      nuxtseo-shared: 5.3.2(043985539a50ea96924caeb25844c44e)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.8.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.142.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.102.0)(srvx@0.11.22)(stylelint@17.14.1(typescript@5.9.3))(terser@5.49.2)(tsx@4.23.10)(typescript@5.9.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt-site-config: 4.2.0(30f44f47b1ac7bbdc0a379b9883293fe)
+      nuxtseo-shared: 5.3.10(0cd7c915431e46e6b683eb9a96b16f83)
       pathe: 2.0.3
       pkg-types: 2.3.1
       scule: 1.3.0
       tinyglobby: 0.2.17
       ufo: 1.6.4
     optionalDependencies:
-      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
+      '@unhead/bundler': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(unhead@3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       esbuild: 0.25.12
       lightningcss: 1.33.0
       rolldown: 1.2.3
-      sharp: 0.35.3(@types/node@25.9.1)
-      unhead: 3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      sharp: 0.35.3(@types/node@26.1.2)
+      unhead: 3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
     transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@emotion/is-prop-valid'
-      - '@farmfe/core'
-      - '@inertiajs/vue3'
-      - '@internationalized/date'
-      - '@internationalized/number'
-      - '@modelcontextprotocol/sdk'
-      - '@netlify/blobs'
-      - '@nuxt/content'
       - '@nuxt/schema'
-      - '@oxc-project/types'
-      - '@planetscale/database'
-      - '@rspack/core'
-      - '@tiptap/core'
-      - '@tiptap/extension-bubble-menu'
-      - '@tiptap/extension-code'
-      - '@tiptap/extension-collaboration'
-      - '@tiptap/extension-drag-handle'
-      - '@tiptap/extension-drag-handle-vue-3'
-      - '@tiptap/extension-floating-menu'
-      - '@tiptap/extension-horizontal-rule'
-      - '@tiptap/extension-image'
-      - '@tiptap/extension-mention'
-      - '@tiptap/extension-node-range'
-      - '@tiptap/extension-placeholder'
-      - '@tiptap/markdown'
-      - '@tiptap/pm'
-      - '@tiptap/starter-kit'
-      - '@tiptap/suggestion'
-      - '@tiptap/vue-3'
       - '@types/node'
-      - '@unhead/cli'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vue/composition-api'
-      - async-validator
-      - aws4fetch
-      - axios
-      - bufferutil
-      - bun-types-no-globals
-      - change-case
-      - crossws
-      - db0
-      - drauu
-      - embla-carousel
-      - focus-trap
-      - idb-keyval
-      - ioredis
-      - joi
-      - jwt-decode
       - magic-string
       - magicast
-      - nprogress
       - oxc-parser
-      - qrcode
-      - react
-      - react-dom
-      - rollup
-      - sortablejs
-      - superstruct
-      - typescript
-      - universal-cookie
-      - unloader
       - unplugin
-      - uploadthing
-      - utf-8-validate
-      - valibot
       - vite
       - vue
-      - vue-router
-      - webpack
-      - yup
       - zod
 
-  nuxt-site-config-kit@4.1.1(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vue@3.5.34(typescript@5.9.3)):
+  nuxt-site-config-kit@4.2.0(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3)):
     dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      site-config-stack: 4.1.1(vue@3.5.34(typescript@5.9.3))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
+      site-config-stack: 4.2.0(vue@3.5.41(typescript@5.9.3))
       std-env: 4.2.0
       ufo: 1.6.4
     transitivePeerDependencies:
@@ -14098,45 +10461,20 @@ snapshots:
       - unplugin
       - vue
 
-  nuxt-site-config-kit@4.1.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vue@3.5.34(typescript@5.9.3)):
-    dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      site-config-stack: 4.1.1(vue@3.5.34(typescript@5.9.3))
-      std-env: 4.2.0
-      ufo: 1.6.4
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-      - vue
-
-  nuxt-site-config-kit@4.1.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vue@3.5.34(typescript@5.9.3)):
-    dependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      site-config-stack: 4.1.1(vue@3.5.34(typescript@5.9.3))
-      std-env: 4.2.0
-      ufo: 1.6.4
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-      - vue
-
-  nuxt-site-config@4.1.1(4d79e2cd154eafd0ae5acf0b0945c71b):
+  nuxt-site-config@4.2.0(30f44f47b1ac7bbdc0a379b9883293fe):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
+      consola: 3.4.2
+      defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config-kit: 4.1.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vue@3.5.34(typescript@5.9.3))
-      nuxtseo-shared: 5.3.2(043985539a50ea96924caeb25844c44e)
+      nuxt-site-config-kit: 4.2.0(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3))
+      nuxtseo-shared: 5.3.10(0cd7c915431e46e6b683eb9a96b16f83)
       pathe: 2.0.3
       pkg-types: 2.3.1
-      site-config-stack: 4.1.1(vue@3.5.34(typescript@5.9.3))
+      site-config-stack: 4.2.0(vue@3.5.41(typescript@5.9.3))
       ufo: 1.6.4
+      vue: 3.5.41(typescript@5.9.3)
     transitivePeerDependencies:
       - '@nuxt/schema'
       - magic-string
@@ -14146,66 +10484,19 @@ snapshots:
       - rolldown
       - unplugin
       - vite
-      - vue
       - zod
 
-  nuxt-site-config@4.1.1(7877631f0cf65e725df80f294cd86891):
+  nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.8.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.142.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.102.0)(srvx@0.11.22)(stylelint@17.14.1(typescript@5.9.3))(terser@5.49.2)(tsx@4.23.10)(typescript@5.9.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      h3: 1.15.11
-      nuxt-site-config-kit: 4.1.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vue@3.5.34(typescript@5.9.3))
-      nuxtseo-shared: 5.3.2(9a4742efa56a00a44e3e94e40a26a5f7)
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      site-config-stack: 4.1.1(vue@3.5.34(typescript@5.9.3))
-      ufo: 1.6.4
-    transitivePeerDependencies:
-      - '@nuxt/schema'
-      - magic-string
-      - magicast
-      - nuxt
-      - oxc-parser
-      - rolldown
-      - unplugin
-      - vite
-      - vue
-      - zod
-
-  nuxt-site-config@4.1.1(da50f1e9fdc48b596813f24331f87232):
-    dependencies:
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      h3: 1.15.11
-      nuxt-site-config-kit: 4.1.1(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vue@3.5.34(typescript@5.9.3))
-      nuxtseo-shared: 5.3.2(28af55199f4cc9df90f9ffd6fd2b2367)
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      site-config-stack: 4.1.1(vue@3.5.34(typescript@5.9.3))
-      ufo: 1.6.4
-    transitivePeerDependencies:
-      - '@nuxt/schema'
-      - magic-string
-      - magicast
-      - nuxt
-      - oxc-parser
-      - rolldown
-      - unplugin
-      - vite
-      - vue
-      - zod
-
-  nuxt@4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.138.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.13.0(typescript@5.9.3))(terser@5.49.2)(tsx@4.22.3)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0):
-    dependencies:
-      '@dxup/nuxt': 0.5.6(esbuild@0.25.12)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.1)(@parcel/watcher@2.5.6)(cac@6.7.14)(magicast@0.5.4)
-      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      '@nuxt/nitro-server': 4.5.1(e10a0efb5e23c0fd36d3ace2a5e3aeb3)
-      '@nuxt/schema': 4.5.1
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.1(0261b043a53150a2c4b40251899787e8)
-      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@dxup/nuxt': 0.5.6(esbuild@0.25.12)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
+      '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(@parcel/watcher@2.6.0)(cac@7.0.0)(magicast@0.5.4)
+      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
+      '@nuxt/nitro-server': 4.5.2(a6b4ddeeddf84de6cb7f2a9716ddcc9a)
+      '@nuxt/schema': 4.5.2
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))))
+      '@nuxt/vite-builder': 4.5.2(52306e9b27341c32cbe02a9c7cda1876)
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.25.12)(lightningcss@1.33.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@vue/shared': 3.5.41
       chokidar: 5.0.0
       compatx: 0.2.0
@@ -14219,7 +10510,7 @@ snapshots:
       fnv1a-64: 0.1.2
       hookable: 6.1.1
       ignore: 7.0.6
-      impound: 1.1.6(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      impound: 1.1.6(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
@@ -14232,7 +10523,7 @@ snapshots:
       ofetch: 1.5.1
       ohash: 2.0.11
       on-change: 6.0.2
-      oxc-walker: 1.1.1(@oxc-project/types@0.143.0)(oxc-parser@0.138.0)(rolldown@1.2.3)
+      oxc-walker: 1.1.1(@oxc-project/types@0.143.0)(oxc-parser@0.142.0)(rolldown@1.2.3)
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       picomatch: 4.0.5
@@ -14246,19 +10537,20 @@ snapshots:
       ufo: 1.6.4
       ultrahtml: 1.7.0
       uncrypto: 0.1.3
-      unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       undici: 8.10.0
-      unhead: 3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      unimport: 6.4.0(esbuild@0.25.12)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      unhead: 3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
+      unimport: 6.4.0(esbuild@0.25.12)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       unrouting: 0.2.2
       untyped: 2.0.0
-      verkit: 0.2.0
+      verkit: 0.3.2
       vue: 3.5.41(typescript@5.9.3)
-      vue-router: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.25.12)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      vue-component-type-helpers: 3.3.9
+      vue-router: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.25.12)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
     optionalDependencies:
-      '@parcel/watcher': 2.5.6
-      '@types/node': 25.9.1
+      '@parcel/watcher': 2.6.0
+      '@types/node': 26.1.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -14336,112 +10628,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxtseo-layer-devtools@5.3.2(228959972d51119f78b2f06547565ac7):
+  nuxtseo-shared@5.3.10(0cd7c915431e46e6b683eb9a96b16f83):
     dependencies:
-      '@iconify-json/carbon': 1.2.24
-      '@nuxt/devtools-kit': 4.0.0-alpha.3(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      '@nuxt/ui': 4.9.0(58502101345dd8570863426db89bf8e6)
-      '@shikijs/langs': 4.3.1
-      '@shikijs/themes': 4.3.1
-      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.9.3))
-      '@vueuse/nuxt': 14.3.0(d41a3947a020e9f1740412568023ae47)
-      nuxtseo-shared: 5.3.2(043985539a50ea96924caeb25844c44e)
-      ofetch: 1.5.1
-      shiki: 4.3.1
-      tailwindcss: 4.3.2
-      ufo: 1.6.4
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@emotion/is-prop-valid'
-      - '@farmfe/core'
-      - '@inertiajs/vue3'
-      - '@internationalized/date'
-      - '@internationalized/number'
-      - '@netlify/blobs'
-      - '@nuxt/content'
-      - '@nuxt/schema'
-      - '@planetscale/database'
-      - '@rspack/core'
-      - '@tiptap/core'
-      - '@tiptap/extension-bubble-menu'
-      - '@tiptap/extension-code'
-      - '@tiptap/extension-collaboration'
-      - '@tiptap/extension-drag-handle'
-      - '@tiptap/extension-drag-handle-vue-3'
-      - '@tiptap/extension-floating-menu'
-      - '@tiptap/extension-horizontal-rule'
-      - '@tiptap/extension-image'
-      - '@tiptap/extension-mention'
-      - '@tiptap/extension-node-range'
-      - '@tiptap/extension-placeholder'
-      - '@tiptap/markdown'
-      - '@tiptap/pm'
-      - '@tiptap/starter-kit'
-      - '@tiptap/suggestion'
-      - '@tiptap/vue-3'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vue/composition-api'
-      - async-validator
-      - aws4fetch
-      - axios
-      - bun-types-no-globals
-      - change-case
-      - db0
-      - drauu
-      - embla-carousel
-      - esbuild
-      - focus-trap
-      - idb-keyval
-      - ioredis
-      - joi
-      - jwt-decode
-      - magic-string
-      - magicast
-      - nprogress
-      - nuxt
-      - nuxt-site-config
-      - oxc-parser
-      - qrcode
-      - react
-      - react-dom
-      - rolldown
-      - rollup
-      - sortablejs
-      - superstruct
-      - typescript
-      - universal-cookie
-      - unloader
-      - unplugin
-      - uploadthing
-      - valibot
-      - vite
-      - vue
-      - vue-router
-      - webpack
-      - yup
-      - zod
-
-  nuxtseo-shared@5.3.2(043985539a50ea96924caeb25844c44e):
-    dependencies:
-      '@clack/prompts': 1.6.0
-      '@nuxt/devtools-kit': 4.0.0-alpha.3(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      '@clack/prompts': 1.7.0
+      '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       '@nuxt/schema': 4.5.2
       birpc: 4.0.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.138.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.13.0(typescript@5.9.3))(terser@5.49.2)(tsx@4.22.3)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.1.2)(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.8.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.142.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.102.0)(srvx@0.11.22)(stylelint@17.14.1(typescript@5.9.3))(terser@5.49.2)(tsx@4.23.10)(typescript@5.9.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.9
       ofetch: 1.5.1
       pathe: 2.0.3
@@ -14450,67 +10646,9 @@ snapshots:
       sirv: 3.0.2
       std-env: 4.2.0
       ufo: 1.6.4
-      vue: 3.5.34(typescript@5.9.3)
+      vue: 3.5.41(typescript@5.9.3)
     optionalDependencies:
-      nuxt-site-config: 4.1.1(4d79e2cd154eafd0ae5acf0b0945c71b)
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-      - vite
-
-  nuxtseo-shared@5.3.2(28af55199f4cc9df90f9ffd6fd2b2367):
-    dependencies:
-      '@clack/prompts': 1.6.0
-      '@nuxt/devtools-kit': 4.0.0-alpha.3(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      '@nuxt/schema': 4.5.2
-      birpc: 4.0.0
-      consola: 3.4.2
-      defu: 6.1.7
-      nuxt: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.138.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.13.0(typescript@5.9.3))(terser@5.49.2)(tsx@4.22.3)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
-      nypm: 0.6.9
-      ofetch: 1.5.1
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      radix3: 1.1.2
-      sirv: 3.0.2
-      std-env: 4.2.0
-      ufo: 1.6.4
-      vue: 3.5.34(typescript@5.9.3)
-    optionalDependencies:
-      nuxt-site-config: 4.1.1(4d79e2cd154eafd0ae5acf0b0945c71b)
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-      - vite
-
-  nuxtseo-shared@5.3.2(9a4742efa56a00a44e3e94e40a26a5f7):
-    dependencies:
-      '@clack/prompts': 1.6.0
-      '@nuxt/devtools-kit': 4.0.0-alpha.3(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      '@nuxt/schema': 4.5.2
-      birpc: 4.0.0
-      consola: 3.4.2
-      defu: 6.1.7
-      nuxt: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.25.12)(eslint@10.5.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.138.0)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.13.0(typescript@5.9.3))(terser@5.49.2)(tsx@4.22.3)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
-      nypm: 0.6.9
-      ofetch: 1.5.1
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      radix3: 1.1.2
-      sirv: 3.0.2
-      std-env: 4.2.0
-      ufo: 1.6.4
-      vue: 3.5.34(typescript@5.9.3)
-    optionalDependencies:
-      nuxt-site-config: 4.1.1(4d79e2cd154eafd0ae5acf0b0945c71b)
+      nuxt-site-config: 4.2.0(30f44f47b1ac7bbdc0a379b9883293fe)
     transitivePeerDependencies:
       - magic-string
       - magicast
@@ -14551,18 +10689,6 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
-  onetime@7.0.0:
-    dependencies:
-      mimic-function: 5.0.1
-
-  oniguruma-parser@0.12.2: {}
-
-  oniguruma-to-es@4.3.6:
-    dependencies:
-      oniguruma-parser: 0.12.2
-      regex: 6.1.0
-      regex-recursion: 6.0.2
-
   open@11.0.0:
     dependencies:
       default-browser: 5.5.0
@@ -14581,94 +10707,40 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  orderedmap@2.1.1: {}
-
-  oxc-parser@0.132.0:
+  oxc-parser@0.142.0:
     dependencies:
-      '@oxc-project/types': 0.132.0
+      '@oxc-project/types': 0.142.0
     optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.132.0
-      '@oxc-parser/binding-android-arm64': 0.132.0
-      '@oxc-parser/binding-darwin-arm64': 0.132.0
-      '@oxc-parser/binding-darwin-x64': 0.132.0
-      '@oxc-parser/binding-freebsd-x64': 0.132.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.132.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.132.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.132.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.132.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.132.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.132.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.132.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.132.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.132.0
-      '@oxc-parser/binding-linux-x64-musl': 0.132.0
-      '@oxc-parser/binding-openharmony-arm64': 0.132.0
-      '@oxc-parser/binding-wasm32-wasi': 0.132.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.132.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.132.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.132.0
+      '@oxc-parser/binding-android-arm-eabi': 0.142.0
+      '@oxc-parser/binding-android-arm64': 0.142.0
+      '@oxc-parser/binding-darwin-arm64': 0.142.0
+      '@oxc-parser/binding-darwin-x64': 0.142.0
+      '@oxc-parser/binding-freebsd-x64': 0.142.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.142.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.142.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.142.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.142.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.142.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-x64-musl': 0.142.0
+      '@oxc-parser/binding-openharmony-arm64': 0.142.0
+      '@oxc-parser/binding-wasm32-wasi': 0.142.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.142.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.142.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.142.0
 
-  oxc-parser@0.137.0:
-    dependencies:
-      '@oxc-project/types': 0.137.0
-    optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.137.0
-      '@oxc-parser/binding-android-arm64': 0.137.0
-      '@oxc-parser/binding-darwin-arm64': 0.137.0
-      '@oxc-parser/binding-darwin-x64': 0.137.0
-      '@oxc-parser/binding-freebsd-x64': 0.137.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.137.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.137.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.137.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.137.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.137.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.137.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.137.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.137.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.137.0
-      '@oxc-parser/binding-linux-x64-musl': 0.137.0
-      '@oxc-parser/binding-openharmony-arm64': 0.137.0
-      '@oxc-parser/binding-wasm32-wasi': 0.137.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.137.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.137.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.137.0
-
-  oxc-parser@0.138.0:
-    dependencies:
-      '@oxc-project/types': 0.138.0
-    optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.138.0
-      '@oxc-parser/binding-android-arm64': 0.138.0
-      '@oxc-parser/binding-darwin-arm64': 0.138.0
-      '@oxc-parser/binding-darwin-x64': 0.138.0
-      '@oxc-parser/binding-freebsd-x64': 0.138.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.138.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.138.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.138.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.138.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.138.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.138.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.138.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.138.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.138.0
-      '@oxc-parser/binding-linux-x64-musl': 0.138.0
-      '@oxc-parser/binding-openharmony-arm64': 0.138.0
-      '@oxc-parser/binding-wasm32-wasi': 0.138.0
-      '@oxc-parser/binding-win32-arm64-msvc': 0.138.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.138.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.138.0
-
-  oxc-walker@1.1.1(@oxc-project/types@0.143.0)(oxc-parser@0.137.0)(rolldown@1.2.3):
+  oxc-walker@1.1.1(@oxc-project/types@0.143.0)(oxc-parser@0.142.0)(rolldown@1.2.3):
     optionalDependencies:
       '@oxc-project/types': 0.143.0
-      oxc-parser: 0.137.0
+      oxc-parser: 0.142.0
       rolldown: 1.2.3
 
-  oxc-walker@1.1.1(@oxc-project/types@0.143.0)(oxc-parser@0.138.0)(rolldown@1.2.3):
-    optionalDependencies:
-      '@oxc-project/types': 0.143.0
-      oxc-parser: 0.138.0
-      rolldown: 1.2.3
+  p-event@6.0.1:
+    dependencies:
+      p-timeout: 6.1.4
 
   p-limit@2.3.0:
     dependencies:
@@ -14694,11 +10766,13 @@ snapshots:
     dependencies:
       p-limit: 4.0.0
 
+  p-timeout@6.1.4: {}
+
   p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
 
-  package-manager-detector@1.6.0: {}
+  package-manager-detector@1.8.0: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -14721,7 +10795,7 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.6.1: {}
+  path-expression-matcher@1.6.2: {}
 
   path-key@3.1.1: {}
 
@@ -14751,14 +10825,12 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.4: {}
-
   picomatch@4.0.5: {}
 
-  pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)):
+  pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)):
     dependencies:
-      '@vue/devtools-api': 7.7.9
-      vue: 3.5.34(typescript@5.9.3)
+      '@vue/devtools-api': 7.7.10
+      vue: 3.5.41(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -14819,8 +10891,8 @@ snapshots:
     dependencies:
       htmlparser2: 8.0.2
       js-tokens: 9.0.1
-      postcss: 8.5.15
-      postcss-safe-parser: 6.0.0(postcss@8.5.15)
+      postcss: 8.5.26
+      postcss-safe-parser: 6.0.0(postcss@8.5.26)
 
   postcss-merge-longhand@8.0.2(postcss@8.5.26):
     dependencies:
@@ -14925,18 +10997,13 @@ snapshots:
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-safe-parser@6.0.0(postcss@8.5.15):
+  postcss-safe-parser@6.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.26
 
-  postcss-safe-parser@7.0.1(postcss@8.5.15):
+  postcss-safe-parser@7.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.15
-
-  postcss-selector-parser@7.1.1:
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
+      postcss: 8.5.26
 
   postcss-selector-parser@7.1.5:
     dependencies:
@@ -14956,12 +11023,6 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.26:
     dependencies:
       nanoid: 3.3.17
@@ -14972,7 +11033,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.4: {}
+  prettier@3.9.6: {}
 
   pretty-bytes@7.1.1: {}
 
@@ -14986,83 +11047,7 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  property-information@7.2.0: {}
-
-  prosemirror-changeset@2.4.1:
-    dependencies:
-      prosemirror-transform: 1.12.0
-
-  prosemirror-commands@1.7.2:
-    dependencies:
-      prosemirror-model: 1.25.11
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
-
-  prosemirror-dropcursor@1.8.3:
-    dependencies:
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.42.2
-
-  prosemirror-gapcursor@1.4.1:
-    dependencies:
-      prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.11
-      prosemirror-state: 1.4.4
-      prosemirror-view: 1.42.2
-
-  prosemirror-history@1.5.0:
-    dependencies:
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.42.2
-      rope-sequence: 1.3.4
-
-  prosemirror-inputrules@1.5.1:
-    dependencies:
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
-
-  prosemirror-keymap@1.2.3:
-    dependencies:
-      prosemirror-state: 1.4.4
-      w3c-keyname: 2.2.8
-
-  prosemirror-model@1.25.11:
-    dependencies:
-      orderedmap: 2.1.1
-
-  prosemirror-schema-list@1.5.1:
-    dependencies:
-      prosemirror-model: 1.25.11
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
-
-  prosemirror-state@1.4.4:
-    dependencies:
-      prosemirror-model: 1.25.11
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.42.2
-
-  prosemirror-tables@1.8.5:
-    dependencies:
-      prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.11
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.42.2
-
-  prosemirror-transform@1.12.0:
-    dependencies:
-      prosemirror-model: 1.25.11
-
-  prosemirror-view@1.42.2:
-    dependencies:
-      prosemirror-model: 1.25.11
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
-
-  protobufjs@7.6.1:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -15070,16 +11055,15 @@ snapshots:
       '@protobufjs/eventemitter': 1.1.1
       '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
-      '@types/node': 25.9.1
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 26.1.2
       long: 5.3.2
 
   punycode@2.3.1: {}
 
-  pusher-js@8.5.0:
+  pusher-js@8.6.0:
     dependencies:
       tweetnacl: 1.0.3
 
@@ -15095,9 +11079,9 @@ snapshots:
 
   quansync@0.2.11: {}
 
-  quansync@1.0.0: {}
-
   queue-microtask@1.2.3: {}
+
+  quote-js-string@0.1.0: {}
 
   radix3@1.1.2: {}
 
@@ -15107,6 +11091,8 @@ snapshots:
     dependencies:
       defu: 6.1.7
       destr: 2.0.5
+
+  re2js@2.8.6: {}
 
   readable-stream@2.3.8:
     dependencies:
@@ -15142,42 +11128,14 @@ snapshots:
     dependencies:
       '@eslint-community/regexpp': 4.12.2
 
-  regex-recursion@6.0.2:
-    dependencies:
-      regex-utilities: 2.3.0
-
-  regex-utilities@2.3.0: {}
-
-  regex@6.1.0:
-    dependencies:
-      regex-utilities: 2.3.0
-
   regexp-ast-analysis@0.7.1:
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       refa: 0.12.1
 
-  regexp-tree@0.1.27: {}
-
   regjsparser@0.13.2:
     dependencies:
       jsesc: 3.1.0
-
-  reka-ui@2.9.10(vue@3.5.34(typescript@5.9.3)):
-    dependencies:
-      '@floating-ui/dom': 1.7.6
-      '@floating-ui/vue': 1.1.11(vue@3.5.34(typescript@5.9.3))
-      '@internationalized/date': 3.12.2
-      '@internationalized/number': 3.6.7
-      '@tanstack/vue-virtual': 3.13.31(vue@3.5.34(typescript@5.9.3))
-      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.9.3))
-      '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@5.9.3))
-      aria-hidden: 1.2.6
-      defu: 6.1.7
-      ohash: 2.0.11
-      vue: 3.5.34(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@vue/composition-api'
 
   require-directory@2.1.1: {}
 
@@ -15199,11 +11157,6 @@ snapshots:
       is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-
-  restore-cursor@5.1.0:
-    dependencies:
-      onetime: 7.0.0
-      signal-exit: 4.1.0
 
   retry@0.12.0: {}
 
@@ -15279,10 +11232,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
-  rope-sequence@1.3.4: {}
-
-  rou3@0.8.1: {}
-
   rou3@0.9.1: {}
 
   run-applescript@7.1.0: {}
@@ -15295,13 +11244,13 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  sass@1.100.0:
+  sass@1.102.0:
     dependencies:
       chokidar: 5.0.0
-      immutable: 5.1.5
+      immutable: 5.1.9
       source-map-js: 1.2.1
     optionalDependencies:
-      '@parcel/watcher': 2.5.6
+      '@parcel/watcher': 2.6.0
 
   sax@1.6.1: {}
 
@@ -15314,8 +11263,6 @@ snapshots:
   scule@1.3.0: {}
 
   semver@6.3.1: {}
-
-  semver@7.8.1: {}
 
   semver@7.8.5: {}
 
@@ -15356,7 +11303,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sharp@0.35.3(@types/node@25.9.1):
+  sharp@0.35.3(@types/node@26.1.2):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
@@ -15387,7 +11334,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.35.3
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 25.9.1
+      '@types/node': 26.1.2
     optional: true
 
   shebang-command@2.0.0:
@@ -15397,17 +11344,6 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.10.0: {}
-
-  shiki@4.3.1:
-    dependencies:
-      '@shikijs/core': 4.3.1
-      '@shikijs/engine-javascript': 4.3.1
-      '@shikijs/engine-oniguruma': 4.3.1
-      '@shikijs/langs': 4.3.1
-      '@shikijs/themes': 4.3.1
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
 
   signal-exit@3.0.7: {}
 
@@ -15431,10 +11367,14 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  site-config-stack@4.1.1(vue@3.5.34(typescript@5.9.3)):
+  site-config-stack@4.2.0(vue@3.5.41(typescript@5.9.3)):
     dependencies:
       ufo: 1.6.4
-      vue: 3.5.34(typescript@5.9.3)
+      vue: 3.5.41(typescript@5.9.3)
+
+  sitemapd@0.2.1:
+    dependencies:
+      fast-xml-parser: 5.10.1
 
   slash@5.1.0: {}
 
@@ -15443,16 +11383,6 @@ snapshots:
       ansi-styles: 4.3.0
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
-
-  slice-ansi@7.1.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
-  slice-ansi@8.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
 
   smob@1.6.2: {}
 
@@ -15467,11 +11397,9 @@ snapshots:
 
   source-map@0.7.6: {}
 
-  space-separated-tokens@2.0.2: {}
-
   spdx-exceptions@2.5.0: {}
 
-  spdx-expression-parse@4.0.0:
+  spdx-expression-parse@5.0.0:
     dependencies:
       spdx-exceptions: 2.5.0
       spdx-license-ids: 3.0.23
@@ -15481,6 +11409,8 @@ snapshots:
   speakingurl@14.0.1: {}
 
   srvx@0.11.22: {}
+
+  srvx@0.12.5: {}
 
   stable-hash-x@0.2.0: {}
 
@@ -15519,11 +11449,6 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
-  string-width@8.2.1:
-    dependencies:
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
-
   string-width@8.2.2:
     dependencies:
       get-east-asian-width: 1.6.0
@@ -15537,11 +11462,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  stringify-entities@4.0.4:
-    dependencies:
-      character-entities-html4: 2.1.0
-      character-entities-legacy: 3.0.0
-
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -15553,10 +11473,6 @@ snapshots:
   strip-final-newline@3.0.0: {}
 
   strip-indent@4.1.1: {}
-
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
 
   strip-literal@4.0.0:
     dependencies:
@@ -15574,37 +11490,37 @@ snapshots:
       postcss: 8.5.26
       postcss-selector-parser: 7.1.5
 
-  stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@17.13.0(typescript@5.9.3)):
+  stylelint-config-html@2.0.0(postcss-html@1.8.1)(stylelint@17.14.1(typescript@5.9.3)):
     dependencies:
       postcss-html: 1.8.1
-      stylelint: 17.13.0(typescript@5.9.3)
+      stylelint: 17.14.1(typescript@5.9.3)
 
-  stylelint-config-recommended-vue@1.6.1(postcss-html@1.8.1)(stylelint@17.13.0(typescript@5.9.3)):
+  stylelint-config-recommended-vue@1.6.1(postcss-html@1.8.1)(stylelint@17.14.1(typescript@5.9.3)):
     dependencies:
       postcss-html: 1.8.1
-      semver: 7.8.1
-      stylelint: 17.13.0(typescript@5.9.3)
-      stylelint-config-html: 1.1.0(postcss-html@1.8.1)(stylelint@17.13.0(typescript@5.9.3))
-      stylelint-config-recommended: 18.0.0(stylelint@17.13.0(typescript@5.9.3))
+      semver: 7.8.5
+      stylelint: 17.14.1(typescript@5.9.3)
+      stylelint-config-html: 2.0.0(postcss-html@1.8.1)(stylelint@17.14.1(typescript@5.9.3))
+      stylelint-config-recommended: 18.0.0(stylelint@17.14.1(typescript@5.9.3))
 
-  stylelint-config-recommended@18.0.0(stylelint@17.13.0(typescript@5.9.3)):
+  stylelint-config-recommended@18.0.0(stylelint@17.14.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 17.13.0(typescript@5.9.3)
+      stylelint: 17.14.1(typescript@5.9.3)
 
-  stylelint-config-standard@40.0.0(stylelint@17.13.0(typescript@5.9.3)):
+  stylelint-config-standard@40.0.0(stylelint@17.14.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 17.13.0(typescript@5.9.3)
-      stylelint-config-recommended: 18.0.0(stylelint@17.13.0(typescript@5.9.3))
+      stylelint: 17.14.1(typescript@5.9.3)
+      stylelint-config-recommended: 18.0.0(stylelint@17.14.1(typescript@5.9.3))
 
-  stylelint@17.13.0(typescript@5.9.3):
+  stylelint@17.14.1(typescript@5.9.3):
     dependencies:
-      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
       '@csstools/css-tokenizer': 4.0.0
       '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/selector-resolve-nested': 4.0.0(postcss-selector-parser@7.1.1)
-      '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.1)
+      '@csstools/selector-resolve-nested': 4.0.1(postcss-selector-parser@7.1.5)
+      '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.5)
       colord: 2.9.3
       cosmiconfig: 9.0.2(typescript@5.9.3)
       css-functions-list: 3.3.3
@@ -15612,23 +11528,23 @@ snapshots:
       debug: 4.4.3
       fast-glob: 3.3.3
       fastest-levenshtein: 1.0.16
-      file-entry-cache: 11.1.3
+      file-entry-cache: 11.1.5
       global-modules: 2.0.0
-      globby: 16.2.0
+      globby: 16.2.2
       globjoin: 0.1.4
       html-tags: 5.1.0
-      ignore: 7.0.5
+      ignore: 7.0.6
       import-meta-resolve: 4.2.0
       mathml-tag-names: 4.0.0
       meow: 14.1.0
       micromatch: 4.0.8
       normalize-path: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.15
-      postcss-safe-parser: 7.0.1(postcss@8.5.15)
-      postcss-selector-parser: 7.1.1
+      postcss: 8.5.26
+      postcss-safe-parser: 7.0.1(postcss@8.5.26)
+      postcss-selector-parser: 7.1.5
       postcss-value-parser: 4.2.0
-      string-width: 8.2.1
+      string-width: 8.2.2
       supports-hyperlinks: 4.5.0
       svg-tags: 1.0.0
       table: 6.9.0
@@ -15636,6 +11552,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  super-regex@1.1.0:
+    dependencies:
+      function-timeout: 1.0.2
+      make-asynchronous: 1.1.0
+      time-span: 5.1.0
 
   superjson@2.2.6:
     dependencies:
@@ -15671,18 +11593,6 @@ snapshots:
       strip-ansi: 6.0.1
 
   tagged-tag@1.0.0: {}
-
-  tailwind-merge@3.6.0: {}
-
-  tailwind-variants@3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2):
-    dependencies:
-      tailwindcss: 4.3.2
-    optionalDependencies:
-      tailwind-merge: 3.6.0
-
-  tailwindcss@4.3.2: {}
-
-  tapable@2.3.3: {}
 
   tar-stream@3.2.0:
     dependencies:
@@ -15723,22 +11633,15 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
-  tiny-inflate@1.0.3: {}
+  time-span@5.1.0:
+    dependencies:
+      convert-hrtime: 5.0.0
 
   tiny-invariant@1.3.3: {}
 
   tinyclip@0.1.15: {}
 
-  tinyexec@1.2.2: {}
-
-  tinyexec@1.2.4: {}
-
   tinyexec@1.3.0: {}
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:
@@ -15760,15 +11663,13 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  trim-lines@3.0.1: {}
-
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
 
   tslib@2.8.1: {}
 
-  tsx@4.22.3:
+  tsx@4.23.10:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
@@ -15780,22 +11681,17 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@4.41.0: {}
+
   type-fest@5.8.0:
     dependencies:
       tagged-tag: 1.0.0
-
-  type-level-regexp@0.1.17: {}
 
   typescript@5.9.3: {}
 
   ufo@1.6.4: {}
 
   ultrahtml@1.7.0: {}
-
-  unconfig-core@7.5.0:
-    dependencies:
-      '@quansync/fs': 1.0.0
-      quansync: 1.0.0
 
   unconfig@0.6.1:
     dependencies:
@@ -15804,14 +11700,6 @@ snapshots:
       importx: 0.5.2
     transitivePeerDependencies:
       - supports-color
-
-  unconfig@7.5.0:
-    dependencies:
-      '@quansync/fs': 1.0.0
-      defu: 6.1.7
-      jiti: 2.7.0
-      quansync: 1.0.0
-      unconfig-core: 7.5.0
 
   uncrypto@0.1.3: {}
 
@@ -15822,21 +11710,14 @@ snapshots:
       magic-string: 0.30.21
       unplugin: 2.3.11
 
-  unctx@3.0.0(magic-string@0.30.21)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))):
-    optionalDependencies:
-      magic-string: 0.30.21
-      oxc-parser: 0.138.0
-      rolldown: 1.2.3
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-
-  unctx@3.0.0(magic-string@1.1.0)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))):
+  unctx@3.0.0(magic-string@1.1.0)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))):
     optionalDependencies:
       magic-string: 1.1.0
-      oxc-parser: 0.138.0
+      oxc-parser: 0.142.0
       rolldown: 1.2.3
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
 
-  undici-types@7.24.6: {}
+  undici-types@8.3.0: {}
 
   undici@8.10.0: {}
 
@@ -15844,16 +11725,12 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
-  unhead@2.1.17:
+  unhead@3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)):
     dependencies:
       hookable: 6.1.1
-
-  unhead@3.3.1(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
-    dependencies:
-      hookable: 6.1.1
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
     optionalDependencies:
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -15868,59 +11745,7 @@ snapshots:
 
   unicorn-magic@0.4.0: {}
 
-  unifont@0.7.4:
-    dependencies:
-      css-tree: 3.2.1
-      ofetch: 1.5.1
-      ohash: 2.0.11
-
-  unimport@5.7.0:
-    dependencies:
-      acorn: 8.18.0
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      pkg-types: 2.3.1
-      scule: 1.3.0
-      strip-literal: 3.1.0
-      tinyglobby: 0.2.17
-      unplugin: 2.3.11
-      unplugin-utils: 0.3.2
-
-  unimport@6.3.0(esbuild@0.25.12)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
-    dependencies:
-      acorn: 8.16.0
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      pkg-types: 2.3.1
-      scule: 1.3.0
-      strip-literal: 3.1.0
-      tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      unplugin-utils: 0.3.1
-    optionalDependencies:
-      oxc-parser: 0.138.0
-      rolldown: 1.2.3
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@rspack/core'
-      - bun-types-no-globals
-      - esbuild
-      - rollup
-      - unloader
-      - vite
-      - webpack
-
-  unimport@6.4.0(esbuild@0.25.12)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
+  unimport@6.4.0(esbuild@0.25.12)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)):
     dependencies:
       acorn: 8.18.0
       escape-string-regexp: 5.0.0
@@ -15934,10 +11759,10 @@ snapshots:
       scule: 1.3.0
       strip-literal: 4.0.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       unplugin-utils: 0.3.2
     optionalDependencies:
-      oxc-parser: 0.138.0
+      oxc-parser: 0.142.0
       rolldown: 1.2.3
     transitivePeerDependencies:
       - '@farmfe/core'
@@ -15949,7 +11774,7 @@ snapshots:
       - vite
       - webpack
 
-  unimport@6.4.0(esbuild@0.28.1)(oxc-parser@0.138.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
+  unimport@6.4.0(esbuild@0.28.1)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)):
     dependencies:
       acorn: 8.18.0
       escape-string-regexp: 5.0.0
@@ -15963,10 +11788,10 @@ snapshots:
       scule: 1.3.0
       strip-literal: 4.0.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       unplugin-utils: 0.3.2
     optionalDependencies:
-      oxc-parser: 0.138.0
+      oxc-parser: 0.142.0
       rolldown: 1.2.3
     transitivePeerDependencies:
       - '@farmfe/core'
@@ -15977,76 +11802,11 @@ snapshots:
       - unloader
       - vite
       - webpack
-
-  unist-util-is@6.0.1:
-    dependencies:
-      '@types/unist': 3.0.3
-
-  unist-util-position@5.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-
-  unist-util-stringify-position@4.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-
-  unist-util-visit-parents@6.0.2:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.1
-
-  unist-util-visit@5.1.0:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.1
-      unist-util-visit-parents: 6.0.2
-
-  unplugin-auto-import@21.0.0(@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))))(@vueuse/core@14.3.0(vue@3.5.34(typescript@5.9.3))):
-    dependencies:
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      picomatch: 4.0.5
-      unimport: 5.7.0
-      unplugin: 2.3.11
-      unplugin-utils: 0.3.2
-    optionalDependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-      '@vueuse/core': 14.3.0(vue@3.5.34(typescript@5.9.3))
-
-  unplugin-utils@0.3.1:
-    dependencies:
-      pathe: 2.0.3
-      picomatch: 4.0.5
 
   unplugin-utils@0.3.2:
     dependencies:
       pathe: 2.0.3
       picomatch: 4.0.5
-
-  unplugin-vue-components@32.1.0(@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))))(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3)):
-    dependencies:
-      chokidar: 5.0.0
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      obug: 2.1.4
-      picomatch: 4.0.5
-      tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
-      unplugin-utils: 0.3.2
-      vue: 3.5.34(typescript@5.9.3)
-    optionalDependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
-    transitivePeerDependencies:
-      - '@farmfe/core'
-      - '@rspack/core'
-      - bun-types-no-globals
-      - esbuild
-      - rolldown
-      - rollup
-      - unloader
-      - vite
-      - webpack
 
   unplugin@2.3.11:
     dependencies:
@@ -16055,13 +11815,7 @@ snapshots:
       picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.0.0:
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.5
-      webpack-virtual-modules: 0.6.2
-
-  unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
+  unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.5
@@ -16070,9 +11824,9 @@ snapshots:
       esbuild: 0.25.12
       rolldown: 1.2.3
       rollup: 4.62.4
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
 
-  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
+  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.5
@@ -16081,7 +11835,7 @@ snapshots:
       esbuild: 0.28.1
       rolldown: 1.2.3
       rollup: 4.62.4
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
 
   unrouting@0.2.2:
     dependencies:
@@ -16164,61 +11918,39 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  v-phone-input@7.0.0(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.34(typescript@5.9.3)):
+  v-phone-input@7.0.0(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@5.9.3)):
     dependencies:
       awesome-phonenumber: 7.8.0
-      countries-list: 3.3.0
-      vue: 3.5.34(typescript@5.9.3)
+      countries-list: 3.4.1
+      vue: 3.5.41(typescript@5.9.3)
     optionalDependencies:
       flag-icons: 7.5.0
-      vuetify: 4.0.7(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.34(typescript@5.9.3))
+      vuetify: 4.1.8(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@5.9.3))
       world-flags-sprite: 0.0.2
     transitivePeerDependencies:
       - typescript
       - vite-plugin-vuetify
       - webpack-plugin-vuetify
 
-  valibot@1.4.1(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
+  verkit@0.3.2: {}
 
-  vaul-vue@0.4.1(reka-ui@2.9.10(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)):
-    dependencies:
-      '@vueuse/core': 10.11.1(vue@3.5.34(typescript@5.9.3))
-      reka-ui: 2.9.10(vue@3.5.34(typescript@5.9.3))
-      vue: 3.5.34(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-
-  verkit@0.2.0: {}
-
-  vfile-message@4.0.3:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-stringify-position: 4.0.0
-
-  vfile@6.0.3:
-    dependencies:
-      '@types/unist': 3.0.3
-      vfile-message: 4.0.3
-
-  vite-dev-rpc@2.0.0(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
+  vite-dev-rpc@2.0.0(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)):
     dependencies:
       birpc: 4.0.0
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-      vite-hot-client: 2.2.0(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
+      vite-hot-client: 2.2.0(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
 
-  vite-hot-client@2.2.0(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
+  vite-hot-client@2.2.0(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)):
     dependencies:
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
 
-  vite-node@6.0.0(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0):
+  vite-node@6.0.0(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0):
     dependencies:
       cac: 7.0.0
       es-module-lexer: 2.3.1
       obug: 2.1.4
       pathe: 2.0.3
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -16233,7 +11965,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.14.5(eslint@10.5.0(jiti@2.7.0))(meow@14.1.0)(optionator@0.9.4)(stylelint@17.13.0(typescript@5.9.3))(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
+  vite-plugin-checker@0.14.5(eslint@10.8.0(jiti@2.7.0))(meow@14.1.0)(optionator@0.9.4)(stylelint@17.14.1(typescript@5.9.3))(typescript@5.9.3)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -16242,15 +11974,15 @@ snapshots:
       picomatch: 4.0.5
       proper-lockfile: 4.1.2
       tiny-invariant: 1.3.3
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
     optionalDependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       meow: 14.1.0
       optionator: 0.9.4
-      stylelint: 17.13.0(typescript@5.9.3)
+      stylelint: 17.14.1(typescript@5.9.3)
       typescript: 5.9.3
 
-  vite-plugin-inspect@11.4.1(@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))))(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)):
+  vite-plugin-inspect@11.4.1(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)):
     dependencies:
       ansis: 4.3.1
       error-stack-parser-es: 1.0.5
@@ -16260,33 +11992,33 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       unplugin-utils: 0.3.2
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-      vite-dev-rpc: 2.0.0(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
+      vite-dev-rpc: 2.0.0(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
     optionalDependencies:
-      '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.138.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
 
-  vite-plugin-vue-tracer@1.4.0(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3)):
+  vite-plugin-vue-tracer@1.4.0(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.1.1
       magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
       vue: 3.5.41(typescript@5.9.3)
 
-  vite-plugin-vuetify@2.1.3(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(vuetify@4.0.7):
+  vite-plugin-vuetify@2.1.3(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))(vuetify@4.1.8):
     dependencies:
-      '@vuetify/loader-shared': 2.1.2(vue@3.5.34(typescript@5.9.3))(vuetify@4.0.7)
+      '@vuetify/loader-shared': 2.1.2(vue@3.5.41(typescript@5.9.3))(vuetify@4.1.8)
       debug: 4.4.3
       upath: 2.0.1
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
-      vue: 3.5.34(typescript@5.9.3)
-      vuetify: 4.0.7(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.34(typescript@5.9.3))
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
+      vue: 3.5.41(typescript@5.9.3)
+      vuetify: 4.1.8(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
 
-  vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0):
+  vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -16294,36 +12026,32 @@ snapshots:
       rolldown: 1.2.3
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.2
       esbuild: 0.25.12
       fsevents: 2.3.3
       jiti: 2.7.0
-      sass: 1.100.0
+      sass: 1.102.0
       terser: 5.49.2
-      tsx: 4.22.3
+      tsx: 4.23.10
       yaml: 2.9.0
 
   vue-bundle-renderer@2.3.1:
     dependencies:
       ufo: 1.6.4
 
-  vue-chartjs@5.3.3(chart.js@4.5.1)(vue@3.5.34(typescript@5.9.3)):
+  vue-chartjs@5.3.4(chart.js@4.5.1)(vue@3.5.41(typescript@5.9.3)):
     dependencies:
       chart.js: 4.5.1
-      vue: 3.5.34(typescript@5.9.3)
+      vue: 3.5.41(typescript@5.9.3)
 
-  vue-component-type-helpers@3.3.6: {}
-
-  vue-demi@0.14.10(vue@3.5.34(typescript@5.9.3)):
-    dependencies:
-      vue: 3.5.34(typescript@5.9.3)
+  vue-component-type-helpers@3.3.9: {}
 
   vue-devtools-stub@0.1.0: {}
 
-  vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)):
+  vue-eslint-parser@10.4.1(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
       debug: 4.4.3
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
       espree: 11.2.0
@@ -16332,31 +12060,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@5.0.7(@vue/compiler-sfc@3.5.41)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3)):
-    dependencies:
-      '@babel/generator': 8.0.0-rc.6
-      '@vue-macros/common': 3.1.2(vue@3.5.34(typescript@5.9.3))
-      '@vue/devtools-api': 8.1.2
-      ast-walker-scope: 0.8.3
-      chokidar: 5.0.0
-      json5: 2.2.3
-      local-pkg: 1.2.1
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      muggle-string: 0.4.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      scule: 1.3.0
-      tinyglobby: 0.2.16
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
-      vue: 3.5.34(typescript@5.9.3)
-      yaml: 2.9.0
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.5.41
-      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
-
-  vue-router@5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.25.12)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3)):
+  vue-router@5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.25.12)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 8.0.0
       '@vue-macros/common': 3.1.4(vue@3.5.41(typescript@5.9.3))
@@ -16373,14 +12077,14 @@ snapshots:
       picomatch: 4.0.5
       scule: 1.3.0
       tinyglobby: 0.2.17
-      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))
       unplugin-utils: 0.3.2
       vue: 3.5.41(typescript@5.9.3)
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.41
-      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
-      vite: 8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0)
+      pinia: 3.0.4(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3))
+      vite: 8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -16390,16 +12094,6 @@ snapshots:
       - rollup
       - unloader
       - webpack
-
-  vue@3.5.34(typescript@5.9.3):
-    dependencies:
-      '@vue/compiler-dom': 3.5.34
-      '@vue/compiler-sfc': 3.5.34
-      '@vue/runtime-dom': 3.5.34
-      '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@5.9.3))
-      '@vue/shared': 3.5.34
-    optionalDependencies:
-      typescript: 5.9.3
 
   vue@3.5.41(typescript@5.9.3):
     dependencies:
@@ -16411,44 +12105,48 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  vuetify-nuxt-module@0.19.5(magicast@0.5.4)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3)):
+  vuetify-nuxt-module@0.19.5(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(typescript@5.9.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3)):
     dependencies:
-      '@nuxt/kit': 4.4.6(magicast@0.5.4)
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.25.12)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0)))
       defu: 6.1.7
       destr: 2.0.5
       local-pkg: 1.2.1
       pathe: 1.1.2
       perfect-debounce: 1.0.0
-      semver: 7.8.1
+      semver: 7.8.5
       ufo: 1.6.4
       unconfig: 0.6.1
       upath: 2.0.1
-      vite-plugin-vuetify: 2.1.3(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(vuetify@4.0.7)
-      vuetify: 4.0.7(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.34(typescript@5.9.3))
+      vite-plugin-vuetify: 2.1.3(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))(vuetify@4.1.8)
+      vuetify: 4.1.8(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@5.9.3))
     transitivePeerDependencies:
+      - magic-string
       - magicast
+      - oxc-parser
+      - rolldown
       - supports-color
       - typescript
+      - unplugin
       - vite
       - vue
       - webpack-plugin-vuetify
 
-  vuetify@4.0.7(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.34(typescript@5.9.3)):
+  vuetify@4.1.8(typescript@5.9.3)(vite-plugin-vuetify@2.1.3)(vue@3.5.41(typescript@5.9.3)):
     dependencies:
-      vue: 3.5.34(typescript@5.9.3)
+      vue: 3.5.41(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
-      vite-plugin-vuetify: 2.1.3(vite@8.2.1(@types/node@25.9.1)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.100.0)(terser@5.49.2)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))(vuetify@4.0.7)
-
-  w3c-keyname@2.2.8: {}
+      vite-plugin-vuetify: 2.1.3(vite@8.2.1(@types/node@26.1.2)(esbuild@0.25.12)(jiti@2.7.0)(sass@1.102.0)(terser@5.49.2)(tsx@4.23.10)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))(vuetify@4.1.8)
 
   web-vitals@4.2.4: {}
+
+  web-worker@1.5.0: {}
 
   webidl-conversions@3.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1
@@ -16460,8 +12158,6 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-
-  wheel-gestures@2.2.48: {}
 
   which-module@2.0.1: {}
 
@@ -16481,12 +12177,6 @@ snapshots:
 
   world-flags-sprite@0.0.2:
     optional: true
-
-  wrap-ansi@10.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 8.2.1
-      strip-ansi: 7.2.0
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -16516,21 +12206,16 @@ snapshots:
     dependencies:
       signal-exit: 4.1.0
 
-  ws@8.21.3: {}
+  ws@8.21.2: {}
 
   wsl-utils@0.3.1:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  xml-name-validator@4.0.0: {}
+  xml-name-validator@5.0.0: {}
 
-  xml-naming@0.1.0: {}
-
-  y-protocols@1.0.7(yjs@13.6.31):
-    dependencies:
-      lib0: 0.2.117
-      yjs: 13.6.31
+  xml-naming@0.3.0: {}
 
   y18n@4.0.3: {}
 
@@ -16565,7 +12250,7 @@ snapshots:
       y18n: 4.0.3
       yargs-parser: 18.1.3
 
-  yargs@17.7.2:
+  yargs@17.7.3:
     dependencies:
       cliui: 8.0.1
       escalade: 3.2.0
@@ -16575,15 +12260,6 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yargs@18.0.0:
-    dependencies:
-      cliui: 9.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      string-width: 7.2.0
-      y18n: 5.0.8
-      yargs-parser: 22.0.0
-
   yargs@18.1.0:
     dependencies:
       cliui: 9.0.1
@@ -16592,10 +12268,6 @@ snapshots:
       string-width: 8.2.2
       y18n: 5.0.8
       yargs-parser: 22.0.0
-
-  yjs@13.6.31:
-    dependencies:
-      lib0: 0.2.117
 
   yocto-queue@0.1.0: {}
 
@@ -16619,5 +12291,3 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
-
-  zwitch@2.0.4: {}

--- a/web/public/templates/httpsms-contacts.csv
+++ b/web/public/templates/httpsms-contacts.csv
@@ -1,0 +1,4 @@
+Name,Emails,PhoneNumbers
+John Doe,john@example.com,+18005550199
+Jane Smith,jane@example.com;jane.work@example.com,+18005550100;+18005550111
+Acme Support,,+18005550122

--- a/web/shared/types/api.ts
+++ b/web/shared/types/api.ts
@@ -679,6 +679,12 @@ export interface ResponsesContactsResponse {
   message: string;
   /** @example "success" */
   status: string;
+  /**
+   * Total is the number of contacts matching the request filter for the
+   * user, independent of the pagination skip/limit applied to Data.
+   * @example 57
+   */
+  total: number;
 }
 
 export interface ResponsesDiscordResponse {

--- a/web/shared/types/api.ts
+++ b/web/shared/types/api.ts
@@ -71,6 +71,24 @@ export interface EntitiesBulkMessage {
   total: number;
 }
 
+export interface EntitiesContact {
+  /** @example "2022-06-05T14:26:02.302718+03:00" */
+  created_at: string;
+  /** @example ["alice@example.com"] */
+  emails: string[];
+  /** @example "32343a19-da5e-4b1b-a767-3298a73703cb" */
+  id: string;
+  /** @example "Alice Smith" */
+  name: string;
+  /** @example ["+18005550199","+18005550100"] */
+  phone_numbers: string[];
+  properties: Record<string, string>;
+  /** @example "2022-06-05T14:26:02.302718+03:00" */
+  updated_at: string;
+  /** @example "WB7DRDWrJZRGbYrv2CKGkqbzvqdC" */
+  user_id: string;
+}
+
 export interface EntitiesDiscord {
   /** @example "2022-06-05T14:26:02.302718+03:00" */
   created_at: string;
@@ -199,6 +217,8 @@ export interface EntitiesMessageThread {
   color: string;
   /** @example "+18005550100" */
   contact: string;
+  /** ContactDetails is resolved at read time and never persisted. */
+  contact_details?: EntitiesContact;
   /** @example "2022-06-05T14:26:09.527976+03:00" */
   created_at: string;
   /** @example "32343a19-da5e-4b1b-a767-3298a73703ca" */
@@ -330,6 +350,26 @@ export interface EntitiesWebhook {
   url: string;
   /** @example "WB7DRDWrJZRGbYrv2CKGkqbzvqdC" */
   user_id: string;
+}
+
+export interface RequestsContactItem {
+  emails?: string[];
+  /** @example "Alice Smith" */
+  name: string;
+  phone_numbers: string[];
+  properties?: Record<string, string>;
+}
+
+export interface RequestsContactStoreRequest {
+  contacts: RequestsContactItem[];
+}
+
+export interface RequestsContactUpdateRequest {
+  emails?: string[];
+  /** @example "Alice Smith" */
+  name: string;
+  phone_numbers: string[];
+  properties?: Record<string, string>;
 }
 
 export interface RequestsDiscordStore {
@@ -619,6 +659,22 @@ export interface ResponsesBillingUsagesResponse {
 
 export interface ResponsesBulkMessagesResponse {
   data: EntitiesBulkMessage[];
+  /** @example "Request handled successfully" */
+  message: string;
+  /** @example "success" */
+  status: string;
+}
+
+export interface ResponsesContactResponse {
+  data: EntitiesContact;
+  /** @example "Request handled successfully" */
+  message: string;
+  /** @example "success" */
+  status: string;
+}
+
+export interface ResponsesContactsResponse {
+  data: EntitiesContact[];
   /** @example "Request handled successfully" */
   message: string;
   /** @example "success" */

--- a/web/shared/types/api.ts
+++ b/web/shared/types/api.ts
@@ -673,6 +673,14 @@ export interface ResponsesContactResponse {
   status: string;
 }
 
+export interface ResponsesContactsCreatedResponse {
+  data: EntitiesContact[];
+  /** @example "Request handled successfully" */
+  message: string;
+  /** @example "success" */
+  status: string;
+}
+
 export interface ResponsesContactsResponse {
   data: EntitiesContact[];
   /** @example "Request handled successfully" */


### PR DESCRIPTION
## Summary
- add contact CRUD, one-or-many JSON creation, CSV import, validation, Swagger, and cached phone-to-contact resolution
- add the Contacts management page with server-side search/pagination and add/edit/delete/import dialogs
- display resolved contact names in message threads and add Contacts navigation

## Testing
- `cd api && go test -vet=off ./...`
- `cd api && go build ./...`
- `cd web && pnpm lint`
- `cd web && pnpm generate`