### PR TITLE
feat(web): collect name during signup

### DIFF
--- a/web/app/components/FirebaseAuth.vue
+++ b/web/app/components/FirebaseAuth.vue
@@ -7,6 +7,8 @@ import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
   sendPasswordResetEmail,
+  updateProfile,
+  deleteUser,
 } from 'firebase/auth'
 import { mdiGoogle, mdiGithub, mdiEmail } from '@mdi/js'
 import type { User as FirebaseUser } from 'firebase/auth'
@@ -29,6 +31,7 @@ const showEmailForm = ref(false)
 const isSignUp = ref(false)
 const showForgotPassword = ref(false)
 const resetEmailSent = ref(false)
+const name = ref('')
 const email = ref('')
 const password = ref('')
 const generalError = ref('')
@@ -71,6 +74,10 @@ function validateEmail(): boolean {
 function validateLoginForm(): boolean {
   clearErrors()
   let valid = true
+  if (isSignUp.value && !name.value.trim()) {
+    errorMessages.value.add('name', 'Please provide your name')
+    valid = false
+  }
   if (!email.value.trim()) {
     errorMessages.value.add('email', 'Please provide an email address')
     valid = false
@@ -126,6 +133,14 @@ async function submitEmail() {
         email.value.trim(),
         password.value,
       )
+      try {
+        await updateProfile(result.user, {
+          displayName: name.value.trim(),
+        })
+      } catch (error) {
+        await deleteUser(result.user)
+        throw error
+      }
     } else {
       result = await signInWithEmailAndPassword(
         auth,
@@ -165,6 +180,11 @@ function backToSignIn() {
   clearErrors()
   resetEmailSent.value = false
   showForgotPassword.value = false
+}
+
+function toggleAuthMode() {
+  clearErrors()
+  isSignUp.value = !isSignUp.value
 }
 
 function onSuccess(user: FirebaseUser, method: LoginMethod) {
@@ -406,6 +426,20 @@ function getGeneralErrorMessage(
       @submit.prevent="submitEmail"
     >
       <v-text-field
+        v-if="isSignUp"
+        v-model="name"
+        label="Name"
+        color="primary"
+        type="text"
+        variant="outlined"
+        density="comfortable"
+        class="mb-2"
+        persistent-hint
+        hint="e.g John Doe"
+        :error="errorMessages.has('name')"
+        :error-messages="errorMessages.get('name')"
+      />
+      <v-text-field
         v-model="email"
         label="Email Address"
         color="primary"
@@ -455,7 +489,7 @@ function getGeneralErrorMessage(
         size="small"
         color="primary"
         class="mt-2"
-        @click="isSignUp = !isSignUp"
+        @click="toggleAuthMode"
       >
         {{
           isSignUp ? 'Already have an account? Sign In' : 'No account? Sign Up'

--- a/web/app/components/FirebaseAuth.vue
+++ b/web/app/components/FirebaseAuth.vue
@@ -439,7 +439,7 @@ function getGeneralErrorMessage(
         density="comfortable"
         class="mb-2"
         persistent-placeholder
-        placeholder="Enter your full name e.g. John Doe"
+        placeholder="Enter your full name (e.g. John Doe)"
         :error="errorMessages.has('name')"
         :error-messages="errorMessages.get('name')"
       />
@@ -449,7 +449,7 @@ function getGeneralErrorMessage(
         color="primary"
         type="email"
         persistent-placeholder
-        placeholder="Enter your email address e.g john@gmail.com"
+        placeholder="Enter your email address (e.g. john@gmail.com)"
         variant="outlined"
         density="comfortable"
         class="mb-2"
@@ -463,7 +463,7 @@ function getGeneralErrorMessage(
         color="primary"
         variant="outlined"
         density="comfortable"
-        placeholder="Create a password"
+        placeholder="Create a secure /password"
         persistent-placeholder
         class="mb-2"
         :error="errorMessages.has('password')"

--- a/web/app/components/FirebaseAuth.vue
+++ b/web/app/components/FirebaseAuth.vue
@@ -138,7 +138,11 @@ async function submitEmail() {
           displayName: name.value.trim(),
         })
       } catch (error) {
-        await deleteUser(result.user)
+        try {
+          await deleteUser(result.user)
+        } catch (deleteError) {
+          console.error(deleteError)
+        }
         throw error
       }
     } else {
@@ -435,7 +439,7 @@ function getGeneralErrorMessage(
         density="comfortable"
         class="mb-2"
         persistent-placeholder
-        placeholder="e.g John Doe"
+        placeholder="e.g. John Doe"
         :error="errorMessages.has('name')"
         :error-messages="errorMessages.get('name')"
       />

--- a/web/app/components/FirebaseAuth.vue
+++ b/web/app/components/FirebaseAuth.vue
@@ -434,8 +434,8 @@ function getGeneralErrorMessage(
         variant="outlined"
         density="comfortable"
         class="mb-2"
-        persistent-hint
-        hint="e.g John Doe"
+        persistent-placeholder
+        placeholder="e.g John Doe"
         :error="errorMessages.has('name')"
         :error-messages="errorMessages.get('name')"
       />
@@ -444,6 +444,8 @@ function getGeneralErrorMessage(
         label="Email Address"
         color="primary"
         type="email"
+        persistent-placeholder
+        placeholder="e.g john@gmail.com"
         variant="outlined"
         density="comfortable"
         class="mb-2"
@@ -457,6 +459,7 @@ function getGeneralErrorMessage(
         color="primary"
         variant="outlined"
         density="comfortable"
+        persistent-placeholder
         class="mb-2"
         :error="errorMessages.has('password')"
         :error-messages="errorMessages.get('password')"

--- a/web/app/components/FirebaseAuth.vue
+++ b/web/app/components/FirebaseAuth.vue
@@ -439,7 +439,7 @@ function getGeneralErrorMessage(
         density="comfortable"
         class="mb-2"
         persistent-placeholder
-        placeholder="e.g. John Doe"
+        placeholder="Enter your full name e.g. John Doe"
         :error="errorMessages.has('name')"
         :error-messages="errorMessages.get('name')"
       />
@@ -449,7 +449,7 @@ function getGeneralErrorMessage(
         color="primary"
         type="email"
         persistent-placeholder
-        placeholder="e.g john@gmail.com"
+        placeholder="Enter your email address e.g john@gmail.com"
         variant="outlined"
         density="comfortable"
         class="mb-2"
@@ -463,6 +463,7 @@ function getGeneralErrorMessage(
         color="primary"
         variant="outlined"
         density="comfortable"
+        placeholder="Create a password"
         persistent-placeholder
         class="mb-2"
         :error="errorMessages.has('password')"

--- a/web/app/components/MessageThreadHeader.vue
+++ b/web/app/components/MessageThreadHeader.vue
@@ -27,6 +27,7 @@ const phonesStore = usePhonesStore()
 const threadsStore = useThreadsStore()
 const appStore = useAppStore()
 const notificationsStore = useNotificationsStore()
+const redirectPreferenceStore = useRedirectPreferenceStore()
 
 const selectedMenuItem = ref(-1)
 
@@ -71,6 +72,7 @@ async function logout() {
   authStore.resetState()
   phonesStore.resetState()
   threadsStore.resetState()
+  redirectPreferenceStore.resetState()
   notificationsStore.addNotification({
     type: 'info',
     message: 'You have successfully logged out',

--- a/web/app/components/MessageThreadHeader.vue
+++ b/web/app/components/MessageThreadHeader.vue
@@ -27,7 +27,6 @@ const phonesStore = usePhonesStore()
 const threadsStore = useThreadsStore()
 const appStore = useAppStore()
 const notificationsStore = useNotificationsStore()
-const redirectPreferenceStore = useRedirectPreferenceStore()
 
 const selectedMenuItem = ref(-1)
 
@@ -72,7 +71,6 @@ async function logout() {
   authStore.resetState()
   phonesStore.resetState()
   threadsStore.resetState()
-  redirectPreferenceStore.resetState()
   notificationsStore.addNotification({
     type: 'info',
     message: 'You have successfully logged out',


### PR DESCRIPTION
## Summary
- add a required Name field to email/password signup
- persist the trimmed name to the Firebase user profile
- clear stale form errors when switching auth modes
- roll back account creation if profile setup fails

## Validation
- `pnpm test`
- targeted ESLint, Prettier, and Stylelint checks
- `pnpm generate`