### PR TITLE
fix(web): disable absolute_redirect in nginx to avoid leaking internal URL

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -4,6 +4,12 @@ server {
   root /usr/share/nginx/html;
   index index.html index.htm;
 
+  # Caddy terminates TLS and proxies here over plain HTTP, so nginx must not
+  # guess scheme/port for its own directory-redirect (e.g. /blog -> /blog/):
+  # absolute_redirect would otherwise leak this container's internal
+  # http://host:3000 into the Location header sent to real visitors.
+  absolute_redirect off;
+
   location / {
     try_files $uri $uri/ /index.html;
   }


### PR DESCRIPTION
## Summary
- nginx's default `absolute_redirect` guesses scheme/host/port from its own `listen` directive when emitting directory redirects (e.g. `/blog` -> `/blog/`)
- Behind a reverse proxy that terminates TLS and forwards to this container over plain HTTP (Caddy, nginx, Traefik, etc. in front — a common self-host setup), that produces a `Location` header like `http://<container-host>:3000/blog/` sent straight to real visitors instead of the public `https://` URL
- Setting `absolute_redirect off` makes nginx emit a relative redirect instead, which the browser resolves against the actual request URL

## Test plan
- [ ] Deploy behind a reverse proxy that terminates TLS and forwards over HTTP
- [ ] `curl -sI https://<host>/blog` and confirm the `Location` header is relative (`/blog/`), not an internal `http://host:port/blog/` URL
